### PR TITLE
提高第三方源兼容性

### DIFF
--- a/oma-contents/src/lib.rs
+++ b/oma-contents/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fs::DirEntry,
-    io::BufReader,
+    io,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -230,14 +230,14 @@ where
             .as_mut()
             .expect("Unexpected error: can not get stdout, maybe you environment is broken?");
 
-        let stdout_reader = BufReader::new(stdout);
+        let stdout_reader = io::BufReader::new(stdout);
         let stdout_lines = stdout_reader.lines();
 
         let mut count = 0;
 
         let mut has_res = false;
 
-        for i in stdout_lines.flatten() {
+        for i in stdout_lines.map_while(io::Result::ok) {
             if let Some(line) = search_line(&i, matches!(query_mode, QueryMode::ListFiles(_)), kw) {
                 count += 1;
                 callback(ContentsEvent::Progress(count));
@@ -341,14 +341,14 @@ where
     let f = std::fs::File::open(path)
         .map_err(|e| OmaContentsError::FailedToOperateDirOrFile(path.display().to_string(), e))?;
     let contents_entry: Box<dyn Read> = match path.extension().and_then(|x| x.to_str()) {
-        Some("gz") if search_zip => Box::new(GzDecoder::new(BufReader::new(f))),
-        Some("lz4") if search_zip => Box::new(BufReadDecompressor::new(BufReader::new(f))?),
-        Some(_) | None => Box::new(BufReader::new(f)),
+        Some("gz") if search_zip => Box::new(GzDecoder::new(io::BufReader::new(f))),
+        Some("lz4") if search_zip => Box::new(BufReadDecompressor::new(io::BufReader::new(f))?),
+        Some(_) | None => Box::new(io::BufReader::new(f)),
     };
 
     let mut res = vec![];
 
-    let reader = BufReader::new(contents_entry);
+    let reader = io::BufReader::new(contents_entry);
 
     let is_list = matches!(*query_mode, QueryMode::ListFiles(_));
     let is_cnf = matches!(*query_mode, QueryMode::CommandNotFound);

--- a/oma-contents/src/lib.rs
+++ b/oma-contents/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fs::DirEntry,
-    io,
+    io::{self,BufReader},
     path::{Path, PathBuf},
     sync::Arc,
 };

--- a/oma-contents/src/lib.rs
+++ b/oma-contents/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fs::DirEntry,
-    io::{self,BufReader},
+    io::{self, BufReader},
     path::{Path, PathBuf},
     sync::Arc,
 };

--- a/oma-contents/src/lib.rs
+++ b/oma-contents/src/lib.rs
@@ -230,7 +230,7 @@ where
             .as_mut()
             .expect("Unexpected error: can not get stdout, maybe you environment is broken?");
 
-        let stdout_reader = io::BufReader::new(stdout);
+        let stdout_reader = BufReader::new(stdout);
         let stdout_lines = stdout_reader.lines();
 
         let mut count = 0;
@@ -341,14 +341,14 @@ where
     let f = std::fs::File::open(path)
         .map_err(|e| OmaContentsError::FailedToOperateDirOrFile(path.display().to_string(), e))?;
     let contents_entry: Box<dyn Read> = match path.extension().and_then(|x| x.to_str()) {
-        Some("gz") if search_zip => Box::new(GzDecoder::new(io::BufReader::new(f))),
-        Some("lz4") if search_zip => Box::new(BufReadDecompressor::new(io::BufReader::new(f))?),
-        Some(_) | None => Box::new(io::BufReader::new(f)),
+        Some("gz") if search_zip => Box::new(GzDecoder::new(BufReader::new(f))),
+        Some("lz4") if search_zip => Box::new(BufReadDecompressor::new(BufReader::new(f))?),
+        Some(_) | None => Box::new(BufReader::new(f)),
     };
 
     let mut res = vec![];
 
-    let reader = io::BufReader::new(contents_entry);
+    let reader = BufReader::new(contents_entry);
 
     let is_list = matches!(*query_mode, QueryMode::ListFiles(_));
     let is_cnf = matches!(*query_mode, QueryMode::CommandNotFound);

--- a/oma-pm/src/apt.rs
+++ b/oma-pm/src/apt.rs
@@ -518,7 +518,6 @@ impl OmaApt {
         let mut log = std::fs::OpenOptions::new()
             .append(true)
             .create(true)
-            .write(true)
             .open(&history)
             .map_err(|e| OmaAptError::FailedOperateDirOrFile(history.display().to_string(), e))?;
 

--- a/oma-pm/src/unmet.rs
+++ b/oma-pm/src/unmet.rs
@@ -85,7 +85,7 @@ pub(crate) fn find_unmet_deps_with_markinstall(cache: &Cache, ver: &Version) -> 
                             continue;
                         }
                     }
-    
+
                     v.push(UnmetDep {
                         package: d.name.to_string(),
                         unmet_dependency: WhyUnmet::DepNotExist {
@@ -144,7 +144,7 @@ pub(crate) fn find_unmet_deps_with_markinstall(cache: &Cache, ver: &Version) -> 
                             continue;
                         }
                     }
-    
+
                     v.push(UnmetDep {
                         package: d.name.to_string(),
                         unmet_dependency: WhyUnmet::DepNotExist {

--- a/oma-refresh/src/inrelease.rs
+++ b/oma-refresh/src/inrelease.rs
@@ -86,7 +86,7 @@ impl InReleaseParser {
             let date = &date.replace("UTC", "+0000");
             let date = DateTime::parse_from_rfc2822(date)
                 .map_err(|_| InReleaseParserError::BadInReleaseData)?;
-	
+
             let now = Utc::now();
 
             // Make `Valid-Until` field optional.

--- a/oma-refresh/src/inrelease.rs
+++ b/oma-refresh/src/inrelease.rs
@@ -97,7 +97,7 @@ impl InReleaseParser {
 
             // Check if the `Valid-Until` field is valid only when it is defined.
             if let Some(valid_until_data) = valid_until {
-                let valid_until = DateTime::parse_from_rfc2822(valid_until_data)
+                let valid_until = DateTime::parse_from_rfc2822(&utc_tzname_quirk(valid_until_data))
                     .map_err(|_| InReleaseParserError::BadInReleaseData)?;
                 if now > valid_until {
                     return Err(InReleaseParserError::ExpiredSignature(

--- a/oma-refresh/src/verify.rs
+++ b/oma-refresh/src/verify.rs
@@ -122,12 +122,11 @@ pub fn verify<P: AsRef<Path>>(
     // SHA-1 to sign their repository metadata (such as InRelease).
     p.accept_hash(HashAlgorithm::SHA1);
 
-    let mut v: sequoia_openpgp::parse::stream::Verifier<'_, InReleaseVerifier> =
-        VerifierBuilder::from_bytes(s.as_bytes())?.with_policy(
-            &p,
-            None,
-            InReleaseVerifier::new(&cert_files, mirror)?,
-        )?;
+    let mut v = VerifierBuilder::from_bytes(s.as_bytes())?.with_policy(
+        &p,
+        None,
+        InReleaseVerifier::new(&cert_files, mirror)?,
+    )?;
 
     let mut res = String::new();
     v.read_to_string(&mut res)

--- a/oma-refresh/src/verify.rs
+++ b/oma-refresh/src/verify.rs
@@ -116,7 +116,7 @@ pub fn verify<P: AsRef<Path>>(
     }
 
     // Derive p to allow configuring sequoia_openpgp's StandardPolicy.
-    let mut p: StandardPolicy<'_> = StandardPolicy::new();
+    let mut p = StandardPolicy::new();
     // Allow SHA-1 (considering it safe, whereas sequoia_openpgp's standard
     // policy forbids it), as many third party APT repositories still uses
     // SHA-1 to sign their repository metadata (such as InRelease).


### PR DESCRIPTION
本 PR 修改如下内容：

1. 调整 Sequoia 的默认安全策略 (StandardPolicy)，允许 SHA-1 校验签名的 PGP 签名；Sequoia 上游以 SHA-1 不够安全为由，默认不允许使用该算法校验的签名和信息，但这与许多第三方源不兼容，因为 Aptly 工具生成的源数据均使用 SHA-1（Aptly 在商用软件的分发中十分常见）
2. 将 `Valid-Util` 改为可选字段，许多仓库似乎都不带这个字段，亦确实是非必须的
3. 将某些源 InRelease 文件中的 `Date` 字段中 `UTC` 改写为  `+0000`，Debian 规范 InRelease 必须使用 UTC 时间，但允许多种表达（如 `UTC`, `+0000`, `GMT`, `Z`），其中 Aptly（上述常用工具）使用的是 `UTC`；另外一方面，我们使用 `chrono` 的 RFC 2822 转写功能恰好不支持 UTC，因此导致 `Date` 字段解析出错