### PR TITLE
chore!: use `std::sync::LazyLock` to replace `once_cell::sync::Lazy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,7 +2948,6 @@ dependencies = [
  "oma-refresh",
  "oma-topics",
  "oma-utils 0.8.0",
- "once_cell",
  "ratatui",
  "reqwest",
  "rust-embed",
@@ -2993,7 +2992,6 @@ dependencies = [
  "console",
  "icu_segmenter",
  "indicatif",
- "once_cell",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3153,7 +3151,6 @@ dependencies = [
  "logind-zbus",
  "number_prefix",
  "oma-console",
- "once_cell",
  "os-release",
  "thiserror",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ description = "Package management interface for AOSC OS"
 [dependencies]
 # Cli
 clap = { version = "4.2.4", features = ["cargo", "wrap_help", "color", "string"] }
-once_cell = "1.18"
 anyhow = "1.0"
 ctrlc = "3.4"
 tabled = { version = "0.15", features = ["ansi"] }

--- a/oma-console/Cargo.toml
+++ b/oma-console/Cargo.toml
@@ -10,13 +10,12 @@ license = "MIT"
 [dependencies]
 console = { version = "0.15", optional = true }
 indicatif = { version = "0.17", optional = true }
-once_cell = { version = "1.18", optional = true }
 icu_segmenter = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber =  { version = "0.3", optional = true }
 
 [features]
-print = ["dep:tracing", "dep:tracing-subscriber", "dep:icu_segmenter", "dep:console", "dep:once_cell"]
+print = ["dep:tracing", "dep:tracing-subscriber", "dep:icu_segmenter", "dep:console"]
 pager = []
 progress_bar_style = ["dep:indicatif"]
 default = ["print", "pager", "progress_bar_style"]

--- a/oma-console/src/lib.rs
+++ b/oma-console/src/lib.rs
@@ -23,10 +23,7 @@ pub use indicatif;
 use writer::Writer;
 
 #[cfg(feature = "print")]
-use once_cell::sync::Lazy;
-
-#[cfg(feature = "print")]
-pub static WRITER: Lazy<Writer> = Lazy::new(writer::Writer::default);
+pub static WRITER: std::sync::LazyLock<Writer> = std::sync::LazyLock::new(writer::Writer::default);
 
 #[cfg(feature = "print")]
 pub fn is_terminal() -> bool {

--- a/oma-utils/Cargo.toml
+++ b/oma-utils/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 [dependencies]
 thiserror = "1.0"
 number_prefix = { version = "0.4", optional = true }
-once_cell = "1.18"
 os-release = "0.1"
 oma-console = { version = "^0.11", path = "../oma-console", optional = true, default-features = false, features = [
     "print",

--- a/oma-utils/src/oma/mod.rs
+++ b/oma-utils/src/oma/mod.rs
@@ -1,12 +1,12 @@
 use oma_console::is_terminal;
-use once_cell::sync::Lazy;
 use std::{
     io::{Error, ErrorKind},
     path::PathBuf,
+    sync::LazyLock,
 };
 
 type IOResult<T> = std::io::Result<T>;
-static LOCK: Lazy<PathBuf> = Lazy::new(|| PathBuf::from("/run/lock/oma.lock"));
+static LOCK: LazyLock<PathBuf> = LazyLock::new(|| PathBuf::from("/run/lock/oma.lock"));
 
 /// lock oma
 pub fn lock_oma_inner() -> IOResult<()> {

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,16 +1,17 @@
+use std::sync::LazyLock;
+
 use i18n_embed::{
     fluent::{fluent_language_loader, FluentLanguageLoader},
     unic_langid::LanguageIdentifier,
     DesktopLanguageRequester, LanguageLoader,
 };
-use once_cell::sync::Lazy;
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
 #[folder = "./i18n/"]
 struct Localizations;
 
-pub static LANGUAGE_LOADER: Lazy<FluentLanguageLoader> = Lazy::new(|| {
+pub static LANGUAGE_LOADER: LazyLock<FluentLanguageLoader> = LazyLock::new(|| {
     let language_loader: FluentLanguageLoader = fluent_language_loader!();
     let requested_languages = DesktopLanguageRequester::requested_languages();
     let fallback_language: &[LanguageIdentifier] = &["en-US".parse().unwrap()];


### PR DESCRIPTION
This change breaks rustc < 1.80.0 compilation