### PR TITLE
chore: refine descriptions for each crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma"
 version = "1.4.1"
 edition = "2021"
-description = "Package management interface for AOSC OS"
+description = "User-friendly and performant package manager for APT repositories"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/oma-console/Cargo.toml
+++ b/oma-console/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma-console"
 version = "0.11.0"
 edition = "2021"
-description = "A library to help oma handle terminal"
+description = "Console and terminal emulator handling library used by oma"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oma-contents/Cargo.toml
+++ b/oma-contents/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma-contents"
 version = "0.7.4"
 edition = "2021"
-description = "A library to help oma handle apt database Contents"
+description = "APT Contents metadata handling library"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oma-fetch/Cargo.toml
+++ b/oma-fetch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma-fetch"
 version = "0.12.0"
 edition = "2021"
-description = "A downloader to help oma download something"
+description = "APT repository download routines library"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oma-history/Cargo.toml
+++ b/oma-history/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma-history"
 version = "0.4.3"
 edition = "2021"
-description = "A crate to help oma operate history database"
+description = "Package manager operations history database management library"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oma-pm-operation-type/Cargo.toml
+++ b/oma-pm-operation-type/Cargo.toml
@@ -3,7 +3,7 @@ name = "oma-pm-operation-type"
 version = "0.2.0"
 edition = "2021"
 license = "MIT"
-description = "some type abstract from oma-pm crate"
+description = "APT package management operation abstraction library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/oma-pm/Cargo.toml
+++ b/oma-pm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma-pm"
 version = "0.26.0"
 edition = "2021"
-description = "A crate to help oma handle package manager operation"
+description = "APT package manager API abstraction library"
 license = "GPL-3.0-or-later"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oma-refresh/Cargo.toml
+++ b/oma-refresh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma-refresh"
 version = "0.22.1"
 edition = "2021"
-description = "A crate to help oma refresh apt repo database"
+description = "APT repository refresh handler library"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oma-topics/Cargo.toml
+++ b/oma-topics/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma-topics"
 version = "0.12.0"
 edition = "2021"
-description = "A crate to handle AOSC OS topics."
+description = "AOSC OS topic (testing) repository manager used by oma"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/oma-utils/Cargo.toml
+++ b/oma-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oma-utils"
 version = "0.8.0"
 edition = "2021"
-description = "Some small-tools to help oma handle something"
+description = "General system API and utilities used by oma"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Unless a module is mostly useful for oma, I have described them as general- purpose crates; otherwise, I have marked them as "used by oma," to avoid potential confusion whilst suggesting that the crate can still be useful for other projects.