### PR TITLE
chore: make `apt update` download `BinContents`

### DIFF
--- a/data/apt.conf.d/50oma.conf
+++ b/data/apt.conf.d/50oma.conf
@@ -1,0 +1,15 @@
+# apt update deletes BinContents created by oma refresh
+# so let apt update download it and it won't be deleted.
+
+Acquire::IndexTargets {
+    deb::BinContents-deb  {
+        MetaKey "$(COMPONENT)/BinContents-$(ARCHITECTURE)";
+        ShortDescription "BinContents-$(ARCHITECTURE)";
+        Description "$(RELEASE)/$(COMPONENT) $(ARCHITECTURE) BinContents (deb)";
+
+        flatMetaKey "BinContents-$(ARCHITECTURE)";
+        flatDescription "$(RELEASE) BinContents (deb)";
+        PDiffs "true";
+        KeepCompressed "false";
+    };
+}


### PR DESCRIPTION
`apt update` deletes BinContents created by `oma refresh`, so let `apt update` download it and it won't be deleted.