### PR TITLE
fix(oma-contents): fix `/var/lib/apt/lists` contents does not exist ...

### DIFF
--- a/oma-contents/src/searcher.rs
+++ b/oma-contents/src/searcher.rs
@@ -62,6 +62,10 @@ impl Mode {
             }
         }
 
+        if paths.is_empty() {
+            return Err(OmaContentsError::ContentsNotExist);
+        }
+
         Ok(paths)
     }
 }


### PR DESCRIPTION
... will give `ripgrep` empty argument, and ripgrep will find all file from this directory