### PR TITLE
chore(.github): use tilde to replace dash-suffix in DPKG_VER

### DIFF
--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -35,7 +35,8 @@ jobs:
         run: |
           cd ./aosc-os-abbs/app-admin/oma
           source ./spec
-          export DPKG_VER=$(echo ${RELEASE_VERSION} | sed -e "s|v||g")
+          # Note: Use tilde (~) to denote pre-release, allowing users to upgrade to a final release later.
+          export DPKG_VER=$(echo ${RELEASE_VERSION} | sed -e 's|v||g' | sed -e 's|-|~|g')
           sed -e "s|VER=$VER|VER=${DPKG_VER}|g" -i spec
           sed -e "s|REL=$REL||g" -i spec
           sed -e '/^$/d' -i spec
@@ -44,7 +45,8 @@ jobs:
           git checkout -b oma-${DPKG_VER}
           git add .
           git commit -m "oma: update to ${DPKG_VER}"
-          git push --set-upstream origin oma-${DPKG_VER}
+          # Note: BuildIt! may not allow tilde (~) in branch names, so use dash here.
+          git push --set-upstream origin oma-${DPKG_VER/\~/-}
           uri=$(echo -e "Topic Description\n-----------------\n\n- oma: update to ${DPKG_VER}\n\nPackage(s) Affected\n-------------------\n\n- oma: ${DPKG_VER}\n\nSecurity Update?\n----------------\n\nNo\n\nBuild Order\n-----------\n\n\`\`\`\n#buildit oma\n\`\`\`\n\nTest Build(s) Done\n------------------\n\n**Primary Architectures**\n\n- [ ] AMD64 \`amd64\`\n- [ ] AArch64 \`arm64\`\n- [ ] LoongArch 64-bit \`loongarch64\`\n\n**Secondary Architectures**\n\n- [ ] Loongson 3 \`loongson3\`\n- [ ] PowerPC 64-bit (Little Endian) \`ppc64el\`\n- [ ] RISC-V 64-bit \`riscv64\`\n\n\n" | gh pr create -d --title "oma: update to ${DPKG_VER}" -l "upgrade" -F -)
           num=$(basename ${uri})
           curl --header "Content-Type: application/json" \


### PR DESCRIPTION
Use tilde (~) to denote pre-release, allowing users to upgrade to a final release later.