### PR TITLE
refactor(subcmd/command-not-found): if strsin number < `FILTER_JARO_N…

### DIFF
--- a/src/subcommand/command_not_found.rs
+++ b/src/subcommand/command_not_found.rs
@@ -57,7 +57,7 @@ pub fn execute(query: &str) -> Result<i32, OutputError> {
 
             for (pkg, file, jaro) in jaro {
                 if jaro < FILTER_JARO_NUM {
-                    continue;
+                    break;
                 }
 
                 if let Some(pkg) = apt.cache.get(&pkg) {


### PR DESCRIPTION
…UM` should break

Because the list has already been sorted once.