### PR TITLE
fix(oma-console): use `console::measure_text_width` to calculate termininal width on pager

### DIFF
--- a/oma-console/Cargo.toml
+++ b/oma-console/Cargo.toml
@@ -20,6 +20,6 @@ ansi-to-tui = { version = "6.0", optional = true }
 
 [features]
 print = ["dep:tracing", "dep:tracing-subscriber", "dep:icu_segmenter", "dep:console", "dep:termbg"]
-pager = ["dep:ratatui", "dep:crossterm", "dep:ansi-to-tui"]
+pager = ["dep:ratatui", "dep:crossterm", "dep:ansi-to-tui", "dep:console"]
 progress_bar_style = ["dep:indicatif"]
 default = ["print", "pager", "progress_bar_style"]

--- a/oma-console/src/pager.rs
+++ b/oma-console/src/pager.rs
@@ -168,7 +168,12 @@ impl<'a> OmaPager<'a> {
             unreachable!()
         };
 
-        let width = text.iter().map(|x| x.chars().count()).max().unwrap_or(1);
+        let width = text
+            .iter()
+            .map(|x| console::measure_text_width(x))
+            .max()
+            .unwrap_or(1);
+
         self.max_width = width as u16;
         self.inner_len = text.len();
 
@@ -244,6 +249,7 @@ impl<'a> OmaPager<'a> {
 
     fn right(&mut self) -> ControlFlow<()> {
         let width = WRITER.get_length();
+
         if self.max_width <= self.horizontal_scroll as u16 + width {
             return ControlFlow::Break(());
         }


### PR DESCRIPTION
`console::measure_text_width` will strip ansi escape code