### PR TITLE
fix(oma-console): fix termbg timeout will blocking stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,21 +209,10 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
 ]
 
 [[package]]
@@ -280,21 +269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,7 +293,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -330,14 +304,14 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.1",
+ "event-listener",
  "futures-lite",
  "rustix",
  "tracing",
@@ -370,32 +344,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -635,7 +583,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1353,12 +1301,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -1374,7 +1316,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1709,18 +1651,6 @@ name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "h2"
@@ -2442,15 +2372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lalrpop"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,9 +2522,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "logind-zbus"
@@ -3047,7 +2965,7 @@ dependencies = [
  "icu_segmenter",
  "indicatif",
  "ratatui",
- "termbg",
+ "termbg-with-async-stdin",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4569,14 +4487,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "termbg"
-version = "0.5.1"
+name = "termbg-with-async-stdin"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc77395d133abffe2ff55fc005178ae410973936f706833b8f75272154887f2"
+checksum = "0bf0563075b61919f8290ea8f035221a0319b7cab2ce699cb73e5c6757c8affd"
 dependencies = [
- "async-std",
  "crossterm 0.28.1",
+ "futures",
+ "libc",
  "thiserror",
+ "tokio",
  "winapi",
 ]
 
@@ -5092,12 +5012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5589,7 +5503,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.3.1",
+ "event-listener",
  "futures-core",
  "futures-sink",
  "futures-util",

--- a/oma-console/Cargo.toml
+++ b/oma-console/Cargo.toml
@@ -13,7 +13,9 @@ indicatif = { version = "0.17", optional = true }
 icu_segmenter = { version = "1.3", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber =  { version = "0.3", optional = true }
-termbg = { version = "0.5", optional = true }
+# https://github.com/async-rs/async-std/issues/1055
+# https://github.com/tokio-rs/tokio/issues/5535
+termbg = { version = "0.1", package = "termbg-with-async-stdin", optional = true }
 ratatui = { version = "0.28", optional = true }
 crossterm = {version = "0.28", optional = true}
 ansi-to-tui = { version = "6.0", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,8 +318,6 @@ fn run_subcmd(matches: ArgMatches, dry_run: bool, no_progress: bool) -> Result<i
         // Ref: https://github.com/dalance/procs/commit/83305be6fb431695a070524328b66c7107ce98f3
         let timeout = Duration::from_millis(100);
 
-        let term = env::var("TERM");
-
         if !stdout().is_terminal() || !stderr().is_terminal() || !stdin().is_terminal() || no_color
         {
             follow_term_color = true;
@@ -328,7 +326,7 @@ fn run_subcmd(matches: ArgMatches, dry_run: bool, no_progress: bool) -> Result<i
                 "You are running oma in an SSH session, using default terminal colors to avoid latency."
             );
             follow_term_color = true;
-        } else if term.is_err() || term.is_ok_and(|x| x == "linux") {
+        } else if env::var("TERM").is_err() {
             // Workaround for raw tty:
             // termbg will get stdin
             // pager requires two key presses to respond to time


### PR DESCRIPTION
`async-std` and `tokio` stdin use `spawn_blocking` to handle `stdin`, That is, `stdin` task does not end after the timeout, so no input can be processed after opening the TUI.

This fix came from upstream: https://github.com/dalance/termbg/tree/non_blocking_stdin, but it was not adopted by upstream because it doesn't compile under Windows, but fortunately oma has no plans to support Windows for the time being.

ref:

- https://github.com/tokio-rs/tokio/issues/5535
- https://github.com/async-rs/async-std/issues/1055
- https://github.com/zellij-org/zellij/issues/538
- https://github.com/zellij-org/zellij/blob/3569daf7c9cacc1dbbec6a3813079130b4c0683c/zellij-client/src/os_input_output.rs#L270