### PR TITLE
get-oma.sh: add more distributions

### DIFF
--- a/data/installer/get-oma.sh
+++ b/data/installer/get-oma.sh
@@ -86,6 +86,28 @@ _parse_os_release() {
 You are using a non-LTS Ubuntu release, which is not officially supported!
 '
 		fi
+	# deepin switched their ID half way through the V23 cycle.
+	elif [ "${ID}" = 'Deepin' -o \
+	       "${ID}" = 'deepin' ]; then
+		if [ "$VERSION_ID" = '23' ]; then
+			_oma_codename='beige'
+		else
+			echo "
+>>> oma 暂不支持 deepin ${VERSION_ID}，抱歉！
+>>> oma does not yet support deepin ${VERSION_ID}, sorry!
+"
+			exit 1
+		fi
+	elif [ "${ID}" = 'openkylin' ]; then
+		if [ "$VERSION_ID" = '2.0' ]; then
+			_oma_codename='nile'
+		else
+			echo "
+>>> oma 暂不支持 openKylin ${VERSION_ID}，抱歉！
+>>> oma does not yet support openKylin ${VERSION_ID}, sorry!
+"
+			exit 1
+		fi
 	elif [ "${ID}" = "aosc" -o \
 	       "${ID}" = "afterglow" ]; then
 		echo '

--- a/data/installer/get-oma.sh
+++ b/data/installer/get-oma.sh
@@ -65,15 +65,10 @@ _parse_os_release() {
 		elif [ "$VERSION_ID" = '24.04' ]; then
 			_oma_codename='noble'
 			_non_lts='0'
-# FIXME: Ubuntu 24.10 ships with APT 2.9, which is no longer compatible with
-# our current GPG signing key's encryption algorithm (nistp521).
-#
-# Re-enable Ubuntu 24.10 when we refresh that key.
-#
-#		elif [ "$VERSION_ID" = '24.10' ]; then
-#			# Match 24.04 (Noble Numbat).
-#			_oma_codename='noble'
-#			_non_lts='1'
+		elif [ "$VERSION_ID" = '24.10' ]; then
+			# Match 24.04 (Noble Numbat).
+			_oma_codename='noble'
+			_non_lts='1'
 		else
 			echo "
 >>> oma 暂不支持 Ubuntu ${VERSION_ID}，抱歉！

--- a/data/installer/get-oma.sh
+++ b/data/installer/get-oma.sh
@@ -136,7 +136,7 @@ You are using a non-LTS Ubuntu release, which is not officially supported!
 
 _install_keyring() {
 	# Install repository GPG key.
-	curl -sSf https://repo.aosc.io/pubkeys/repo/aosc.gpg | \
+	curl -sSf https://repo.aosc.io/pubkeys/repo/oma.gpg | \
 		gpg --dearmor --yes -o /usr/share/keyrings/oma.gpg
 
 	if [ "$?" != '0' ]; then

--- a/data/installer/get-oma.sh
+++ b/data/installer/get-oma.sh
@@ -98,6 +98,10 @@ You are using a non-LTS Ubuntu release, which is not officially supported!
 "
 			exit 1
 		fi
+		echo "
+>>> 探测到 deepin ${VERSION_ID} ...
+>>> Detected deepin ${VERSION_ID} ...
+"
 	elif [ "${ID}" = 'openkylin' ]; then
 		if [ "$VERSION_ID" = '2.0' ]; then
 			_oma_codename='nile'
@@ -108,6 +112,10 @@ You are using a non-LTS Ubuntu release, which is not officially supported!
 "
 			exit 1
 		fi
+		echo "
+>>> 探测到 openKylin ${VERSION_ID} ...
+>>> Detected openKylin ${VERSION_ID} ...
+"
 	elif [ "${ID}" = "aosc" -o \
 	       "${ID}" = "afterglow" ]; then
 		echo '


### PR DESCRIPTION
Enable Ubuntu 24.10, add deepin V23 and openKylin 2.0 as we deploy the new repo signing key on October 7, 2024.