### PR TITLE
fix(oma-pm)!: try to fix install after oma will return `LZMA: write failed`

### DIFF
--- a/oma-history/src/lib.rs
+++ b/oma-history/src/lib.rs
@@ -126,7 +126,7 @@ pub fn write_history_entry(
         if success { 1 } else { 0 },
         serde_json::to_string(&summary.install).map_err(HistoryError::ParseError)?,
         serde_json::to_string(&summary.remove).map_err(HistoryError::ParseError)?,
-        match (summary.disk_size.0.as_str(), summary.disk_size.1) {
+        match (summary.disk_size.0.as_ref(), summary.disk_size.1) {
             ("+", x) => x as i64,
             ("-", x) => 0 - x as i64,
             _ => unreachable!()
@@ -220,9 +220,9 @@ pub fn find_history_by_id(conn: &Connection, id: i64) -> HistoryResult<OmaOperat
         let remove_package: Vec<RemoveEntry> =
             serde_json::from_str(&remove_packages).map_err(HistoryError::ParseError)?;
         let disk_size = if disk_size >= 0 {
-            ("+".to_string(), disk_size as u64)
+            ("+".into(), disk_size as u64)
         } else {
-            ("-".to_string(), (0 - disk_size) as u64)
+            ("-".into(), (0 - disk_size) as u64)
         };
 
         res = Some(OmaOperation {
@@ -230,6 +230,8 @@ pub fn find_history_by_id(conn: &Connection, id: i64) -> HistoryResult<OmaOperat
             remove: remove_package,
             disk_size,
             total_download_size,
+            // 不记录 autoremovable
+            autoremovable: (0, 0),
         });
     }
 

--- a/oma-pm-operation-type/src/lib.rs
+++ b/oma-pm-operation-type/src/lib.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 pub struct OmaOperation {
     pub install: Vec<InstallEntry>,
     pub remove: Vec<RemoveEntry>,
-    pub disk_size: (String, u64),
+    pub disk_size: (Box<str>, u64),
+    pub autoremovable: (u64, u64),
     pub total_download_size: u64,
 }
 

--- a/src/subcommand/upgrade.rs
+++ b/src/subcommand/upgrade.rs
@@ -144,9 +144,10 @@ pub fn execute(
         let install = &op.install;
         let remove = &op.remove;
         let disk_size = &op.disk_size;
+        let (ar_count, ar_size) = op.autoremovable;
 
         if is_nothing_to_do(install, remove) {
-            autoremovable_tips(&apt)?;
+            autoremovable_tips(ar_count, ar_size)?;
             return Ok(0);
         }
 
@@ -190,14 +191,7 @@ pub fn execute(
                 success!("{}", fl!("history-tips-1"));
                 info!("{}", fl!("history-tips-2", cmd = cmd.to_string()));
 
-                let apt = OmaApt::new(
-                    vec![],
-                    OmaAptArgs::builder().build(),
-                    false,
-                    AptConfig::new(),
-                )?;
-
-                autoremovable_tips(&apt)?;
+                autoremovable_tips(ar_count, ar_size)?;
 
                 drop(fds);
                 return Ok(0);

--- a/src/table.rs
+++ b/src/table.rs
@@ -206,7 +206,7 @@ impl<W: Write> PagerPrinter<W> {
 pub fn table_for_install_pending(
     install: &[InstallEntry],
     remove: &[RemoveEntry],
-    disk_size: &(String, u64),
+    disk_size: &(Box<str>, u64),
     is_pager: bool,
     dry_run: bool,
 ) -> Result<PagerExit, OutputError> {
@@ -263,7 +263,7 @@ pub fn table_for_install_pending(
 pub fn table_for_history_pending(
     install: &[InstallEntry],
     remove: &[RemoveEntry],
-    disk_size: &(String, u64),
+    disk_size: &(Box<str>, u64),
 ) -> Result<(), OutputError> {
     let mut pager = Pager::external(
         &OmaPagerUIText { is_question: false },
@@ -296,7 +296,7 @@ fn print_pending_inner<W: Write>(
     mut printer: PagerPrinter<W>,
     remove: &[RemoveEntry],
     install: &[InstallEntry],
-    disk_size: &(String, u64),
+    disk_size: &(Box<str>, u64),
 ) {
     if !remove.is_empty() {
         printer


### PR DESCRIPTION
... It seems that executing `new_cache!()` immediately after the commit completes triggers a race condition, so I've changed the logic for getting autoremovable, which may also be faster since it doesn't need to reload the cache.