### PR TITLE
feat(oma-pm)!: add `oma upgrade` option for non-AOSC OS targets

### DIFF
--- a/oma-pm/src/apt.rs
+++ b/oma-pm/src/apt.rs
@@ -9,8 +9,10 @@ use ahash::HashSet;
 use bon::{builder, Builder};
 use chrono::Local;
 
+pub use oma_apt::cache::Upgrade;
+
 use oma_apt::{
-    cache::{Cache, PackageSort, Upgrade},
+    cache::{Cache, PackageSort},
     error::{AptError, AptErrors},
     new_cache,
     progress::{AcquireProgress, InstallProgress},
@@ -333,8 +335,8 @@ impl OmaApt {
     }
 
     /// Set apt manager status as upgrade
-    pub fn upgrade(&self) -> OmaAptResult<()> {
-        self.cache.upgrade(Upgrade::FullUpgrade)?;
+    pub fn upgrade(&self, mode: Upgrade) -> OmaAptResult<()> {
+        self.cache.upgrade(mode)?;
 
         Ok(())
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -200,6 +200,15 @@ pub fn command_builder() -> Command {
                 cmd = cmd.arg(&no_refresh_topics);
             }
 
+            if !cfg!(feature = "aosc") {
+                cmd = cmd.arg(
+                    Arg::new("no_remove")
+                    .long("no-remove")
+                    .help("Do not allow removal of packages during upgrade (like `apt upgrade')")
+                    .action(ArgAction::SetTrue)
+                )
+            }
+
             cmd
         }
         )

--- a/src/subcommand/topics.rs
+++ b/src/subcommand/topics.rs
@@ -9,7 +9,7 @@ use inquire::{
 use oma_console::writer::Writeln;
 use oma_history::SummaryType;
 use oma_pm::{
-    apt::{AptConfig, FilterMode, OmaApt, OmaAptArgs},
+    apt::{AptConfig, FilterMode, OmaApt, OmaAptArgs, Upgrade},
     query::OmaDatabase,
 };
 use oma_utils::dpkg::dpkg_arch;
@@ -133,7 +133,7 @@ pub fn execute(args: TopicArgs, client: Client, oma_args: OmaArgs) -> Result<i32
     }
 
     apt.install(&pkgs, false)?;
-    apt.upgrade()?;
+    apt.upgrade(Upgrade::FullUpgrade)?;
 
     let request = CommitRequest {
         apt,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,7 +7,7 @@ use oma_console::{
 };
 use oma_history::SummaryType;
 use oma_pm::{
-    apt::{AptConfig, OmaApt, OmaAptArgs},
+    apt::{AptConfig, OmaApt, OmaAptArgs, Upgrade},
     search::IndiciumSearch,
 };
 use oma_utils::dbus::{create_dbus_connection, take_wake_lock};
@@ -108,7 +108,7 @@ pub fn execute(tui: TuiArgs) -> Result<i32, OutputError> {
         };
 
         lock_oma()?;
-        apt.upgrade()?;
+        apt.upgrade(Upgrade::FullUpgrade)?;
         apt.install(&install, false)?;
         apt.remove(&remove, false, false)?;
 


### PR DESCRIPTION
`--no-remove` like `apt upgrade`