### PR TITLE
refactor `apt-auth-config`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,10 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 name = "apt-auth-config"
 version = "0.2.0"
 dependencies = [
- "rustix",
+ "rust-netrc",
  "thiserror 2.0.9",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -482,7 +483,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -616,6 +617,17 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.92",
+]
+
+[[package]]
+name = "bstr"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.9",
+ "serde",
 ]
 
 [[package]]
@@ -760,7 +772,7 @@ dependencies = [
  "num-traits",
  "pure-rust-locales",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1227,6 +1239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1255,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2490,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3269,6 +3302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,6 +3324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3332,7 +3380,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3985,6 +4033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-netrc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e98097f62769f92dbf95fb51f71c0a68ec18a4ee2e70e0d3e4f47ac005d63e9"
+dependencies = [
+ "shellexpand",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4337,17 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "bstr",
+ "dirs",
+ "os_str_bytes",
+]
 
 [[package]]
 name = "shlex"
@@ -5381,7 +5450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5390,7 +5459,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5402,7 +5471,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result 0.1.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5435,7 +5504,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result 0.2.0",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5444,7 +5513,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5453,7 +5522,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5463,7 +5532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5472,7 +5550,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5481,7 +5559,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5490,15 +5583,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5508,9 +5607,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5526,9 +5637,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5538,9 +5661,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/apt-auth-config/Cargo.toml
+++ b/apt-auth-config/Cargo.toml
@@ -8,4 +8,5 @@ license = "MIT"
 [dependencies]
 thiserror = "2"
 tracing = "0.1"
-rustix = { version = "0.38", features = ["process"] }
+rust-netrc = "0.1"
+url = "2.5"

--- a/apt-auth-config/src/lib.rs
+++ b/apt-auth-config/src/lib.rs
@@ -112,7 +112,7 @@ impl AuthConfig {
         let auth_conf_d = p.as_ref().join("auth.conf.d");
 
         if auth_conf_d.exists() {
-            for i in read_dir(p.as_ref()).map_err(|e| AuthConfigError::ReadDir {
+            for i in read_dir(auth_conf_d).map_err(|e| AuthConfigError::ReadDir {
                 path: p.as_ref().to_path_buf(),
                 err: e,
             })? {

--- a/apt-auth-config/src/lib.rs
+++ b/apt-auth-config/src/lib.rs
@@ -95,8 +95,8 @@ pub struct AuthConfig(pub Vec<(AuthUrl, Authenticator)>);
 
 impl AuthConfig {
     /// Read system auth.conf.d config (/etc/apt/auth.conf.d)
-    pub fn system(etc_apt_dir: impl AsRef<Path>) -> Result<Self, AuthConfigError> {
-        Self::from_path(etc_apt_dir)
+    pub fn system(sysroot: impl AsRef<Path>) -> Result<Self, AuthConfigError> {
+        Self::from_path(sysroot.as_ref().join("etc/apt"))
     }
 
     pub fn from_path(p: impl AsRef<Path>) -> Result<Self, AuthConfigError> {

--- a/apt-auth-config/src/lib.rs
+++ b/apt-auth-config/src/lib.rs
@@ -1,13 +1,13 @@
 use std::{
-    fs::{self, read_dir},
+    fs::read_dir,
     io::{self},
     path::{Path, PathBuf},
-    str::FromStr,
 };
 
-use rustix::process;
+pub use netrc::Authenticator;
+use netrc::Netrc;
 use thiserror::Error;
-use tracing::debug;
+use url::Url;
 
 #[derive(Debug, Error)]
 pub enum AuthConfigError {
@@ -17,199 +17,129 @@ pub enum AuthConfigError {
     DirEntry(std::io::Error),
     #[error("Failed to open file: {path}")]
     OpenFile { path: PathBuf, err: io::Error },
-    #[error("Auth config file missing entry: {0}")]
-    MissingEntry(&'static str),
+    #[error(transparent)]
+    ParseError(#[from] netrc::Error),
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct AuthConfig {
-    pub inner: Vec<AuthConfigEntry>,
+#[derive(Debug, Eq)]
+pub struct AuthUrl {
+    schema: Option<String>,
+    host_and_path: String,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct AuthConfigEntry {
-    pub host: Box<str>,
-    pub user: Box<str>,
-    pub password: Box<str>,
-}
+impl AuthUrl {
+    fn drop_suffix(&self) -> &str {
+        let mut res = self.host_and_path.as_str();
 
-impl FromStr for AuthConfigEntry {
-    type Err = AuthConfigError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let entry = s
-            .split_ascii_whitespace()
-            .filter(|x| !x.starts_with("#"))
-            .collect::<Vec<_>>();
-
-        let mut host = None;
-        let mut login = None;
-        let mut password = None;
-
-        for (i, c) in entry.iter().enumerate() {
-            if *c == "machine" {
-                let Some(h) = entry.get(i + 1) else {
-                    return Err(AuthConfigError::MissingEntry("machine"));
-                };
-
-                host = Some(h);
-                continue;
-            }
-
-            if *c == "login" {
-                let Some(l) = entry.get(i + 1) else {
-                    return Err(AuthConfigError::MissingEntry("login"));
-                };
-
-                login = Some(l);
-                continue;
-            }
-
-            if *c == "password" {
-                let Some(p) = entry.get(i + 1) else {
-                    return Err(AuthConfigError::MissingEntry("password"));
-                };
-
-                password = Some(p);
-                continue;
-            }
+        while let Some(x) = res.strip_suffix('/') {
+            res = x;
         }
 
-        let Some(host) = host else {
-            return Err(AuthConfigError::MissingEntry("machine"));
-        };
-
-        let Some(login) = login else {
-            return Err(AuthConfigError::MissingEntry("login"));
-        };
-
-        let Some(password) = password else {
-            return Err(AuthConfigError::MissingEntry("password"));
-        };
-
-        Ok(Self {
-            host: (*host).into(),
-            user: (*login).into(),
-            password: (*password).into(),
-        })
+        res
     }
 }
 
-impl AuthConfig {
-    /// Read system auth.conf.d config (/etc/apt/auth.conf.d)
-    ///
-    /// Note that this function returns empty vector if run as a non-root user.
-    pub fn system(sysroot: impl AsRef<Path>) -> Result<Self, AuthConfigError> {
-        // 在 auth.conf.d 的使用惯例中
-        // 配置文件的权限一般为 600，并且所有者为 root
-        // 以普通用户身份下载文件时，会没有权限读取 auth 配置
-        // 因此，在以普通用户访问时，不读取 auth 配置
-        if !process::geteuid().is_root() {
-            return Ok(Self { inner: vec![] });
+impl From<&str> for AuthUrl {
+    fn from(value: &str) -> Self {
+        if let Ok(url) = Url::parse(value) {
+            AuthUrl {
+                schema: Some(url.scheme().to_string()),
+                host_and_path: {
+                    let mut s = String::new();
+                    if let Some(host) = url.host_str() {
+                        s.push_str(host);
+                    }
+                    s.push_str(url.path());
+                    s
+                },
+            }
+        } else {
+            AuthUrl {
+                schema: None,
+                host_and_path: value.to_string(),
+            }
+        }
+    }
+}
+
+impl From<&Url> for AuthUrl {
+    fn from(value: &Url) -> Self {
+        let mut host_and_path = String::new();
+        let schema = value.scheme().to_string();
+
+        if let Some(host) = value.host_str() {
+            host_and_path.push_str(host);
         }
 
-        let p = sysroot.as_ref().join("etc/apt/auth.conf.d");
-        Self::from_path(p)
+        host_and_path.push_str(value.path());
+
+        AuthUrl {
+            schema: Some(schema),
+            host_and_path,
+        }
+    }
+}
+
+impl PartialEq for AuthUrl {
+    fn eq(&self, other: &Self) -> bool {
+        if let Some((a, b)) = self.schema.as_ref().zip(other.schema.as_ref()) {
+            return a == b && self.drop_suffix() == other.drop_suffix();
+        }
+
+        self.drop_suffix() == other.drop_suffix()
+    }
+}
+
+#[derive(Debug)]
+pub struct AuthConfig(pub Vec<(AuthUrl, Authenticator)>);
+
+impl AuthConfig {
+    /// Read system auth.conf.d config (/etc/apt/auth.conf.d)
+    pub fn system(etc_apt_dir: impl AsRef<Path>) -> Result<Self, AuthConfigError> {
+        Self::from_path(etc_apt_dir)
     }
 
     pub fn from_path(p: impl AsRef<Path>) -> Result<Self, AuthConfigError> {
         let mut v = vec![];
 
-        for i in read_dir(p.as_ref()).map_err(|e| AuthConfigError::ReadDir {
-            path: p.as_ref().to_path_buf(),
-            err: e,
-        })? {
-            let i = i.map_err(AuthConfigError::DirEntry)?;
+        let auth_conf = p.as_ref().join("auth.conf");
 
-            if !i.path().is_file() {
-                continue;
-            }
+        if auth_conf.exists() {
+            let config = Netrc::from_file(&auth_conf)?;
+            v.push(config);
+        }
 
-            let s = fs::read_to_string(i.path()).map_err(|e| AuthConfigError::OpenFile {
-                path: i.path().to_path_buf(),
+        let auth_conf_d = p.as_ref().join("auth.conf.d");
+
+        if auth_conf_d.exists() {
+            for i in read_dir(p.as_ref()).map_err(|e| AuthConfigError::ReadDir {
+                path: p.as_ref().to_path_buf(),
                 err: e,
-            })?;
+            })? {
+                let i = i.map_err(AuthConfigError::DirEntry)?;
 
-            let config = AuthConfig::from_str(&s)?;
-            v.extend(config.inner);
-        }
+                if !i.path().is_file() {
+                    continue;
+                }
 
-        Ok(Self { inner: v })
-    }
-
-    pub fn find(&self, url: &str) -> Option<&AuthConfigEntry> {
-        let url = url
-            .strip_prefix("http://")
-            .or_else(|| url.strip_prefix("https://"))
-            .unwrap_or(url);
-
-        debug!("auth find url is: {}", url);
-
-        self.inner.iter().find(|x| {
-            let mut host = x.host.to_string();
-            while host.ends_with('/') {
-                host.pop();
+                let config = Netrc::from_file(&i.path())?;
+                v.push(config);
             }
-
-            let mut url = url.to_string();
-            while url.ends_with('/') {
-                url.pop();
-            }
-
-            host == url
-        })
-    }
-
-    pub fn find_package_url(&self, url: &str) -> Option<&AuthConfigEntry> {
-        let url = url
-            .strip_prefix("http://")
-            .or_else(|| url.strip_prefix("https://"))
-            .unwrap_or(url);
-
-        debug!("auth find package url is: {}", url);
-
-        self.inner.iter().find(|x| url.starts_with(x.host.as_ref()))
-    }
-}
-
-impl FromStr for AuthConfig {
-    type Err = AuthConfigError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut v = vec![];
-
-        for i in s.lines().filter(|x| !x.starts_with('#')) {
-            let entry = AuthConfigEntry::from_str(i)?;
-            v.push(entry);
         }
 
-        Ok(Self { inner: v })
+        let v = v
+            .into_iter()
+            .flat_map(|x| x.hosts)
+            .map(|x| (AuthUrl::from(x.0.as_str()), x.1))
+            .collect::<Vec<_>>();
+
+        Ok(Self(v))
     }
-}
 
-#[test]
-fn test_config_parser() {
-    let config = r#"machine esm.ubuntu.com/apps/ubuntu/ login bearer password qaq  # ubuntu-pro-client
-machine esm.ubuntu.com/infra/ubuntu/ login bearer password qaq  # ubuntu-pro-client
-"#;
-
-    let config = AuthConfig::from_str(config).unwrap();
-
-    assert_eq!(
-        config,
-        AuthConfig {
-            inner: vec![
-                AuthConfigEntry {
-                    host: "esm.ubuntu.com/apps/ubuntu/".into(),
-                    user: "bearer".into(),
-                    password: "qaq".into(),
-                },
-                AuthConfigEntry {
-                    host: "esm.ubuntu.com/infra/ubuntu/".into(),
-                    user: "bearer".into(),
-                    password: "qaq".into(),
-                },
-            ]
-        }
-    );
+    pub fn find(&self, url: &str) -> Option<&Authenticator> {
+        self.0
+            .iter()
+            .find(|x| AuthUrl::from(url) == x.0)
+            .map(|x| &x.1)
+    }
 }

--- a/oma-fetch/src/download.rs
+++ b/oma-fetch/src/download.rs
@@ -101,7 +101,7 @@ impl<'a> SingleDownloader<'a> {
         &self,
         global_progress: &AtomicU64,
         source: &DownloadSource,
-        auth: &Option<(Box<str>, Box<str>)>,
+        auth: &Option<(String, String)>,
         callback: &F,
     ) -> DownloadResult<Summary>
     where
@@ -149,7 +149,7 @@ impl<'a> SingleDownloader<'a> {
         global_progress: &AtomicU64,
         allow_resume: bool,
         source: &DownloadSource,
-        auth: &Option<(Box<str>, Box<str>)>,
+        auth: &Option<(String, String)>,
         callback: &F,
     ) -> DownloadResult<Summary>
     where
@@ -556,7 +556,7 @@ impl<'a> SingleDownloader<'a> {
         &self,
         url: &str,
         method: Method,
-        auth: &Option<(Box<str>, Box<str>)>,
+        auth: &Option<(String, String)>,
     ) -> RequestBuilder {
         let mut req = self.client.request(method, url);
 

--- a/oma-fetch/src/lib.rs
+++ b/oma-fetch/src/lib.rs
@@ -123,7 +123,7 @@ pub struct DownloadSource {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum DownloadSourceType {
-    Http { auth: Option<(Box<str>, Box<str>)> },
+    Http { auth: Option<(String, String)> },
     Local(bool),
 }
 

--- a/oma-pm-operation-type/src/lib.rs
+++ b/oma-pm-operation-type/src/lib.rs
@@ -108,7 +108,7 @@ pub struct InstallEntry {
     new_version: String,
     old_size: Option<u64>,
     new_size: u64,
-    pkg_urls: Vec<String>,
+    pkg_urls: Vec<PackageUrl>,
     sha256: Option<String>,
     md5: Option<String>,
     sha512: Option<String>,
@@ -118,6 +118,12 @@ pub struct InstallEntry {
     #[builder(default)]
     automatic: bool,
     index: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Default, Serialize, Deserialize, Builder)]
+pub struct PackageUrl {
+    pub download_url: String,
+    pub index_url: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -173,7 +179,7 @@ impl InstallEntry {
         &self.new_version
     }
 
-    pub fn pkg_urls(&self) -> &[String] {
+    pub fn pkg_urls(&self) -> &[PackageUrl] {
         &self.pkg_urls
     }
 

--- a/oma-pm/examples/download_pkgs.rs
+++ b/oma-pm/examples/download_pkgs.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), OmaAptError> {
         DownloadConfig {
             network_thread: None,
             download_dir: Some(Path::new("test")),
-            auth: &AuthConfig::system("/").unwrap(),
+            auth: Some(&AuthConfig::system("/").unwrap()),
         },
         false,
         |event| async {

--- a/oma-pm/examples/install_fish.rs
+++ b/oma-pm/examples/install_fish.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), OmaAptError> {
         &client,
         CommitNetworkConfig {
             network_thread: None,
-            auth_config: &AuthConfig::system("/").unwrap(),
+            auth_config: Some(&AuthConfig::system("/").unwrap()),
         },
         |event| async {
             if let Err(e) = tx.send_async(event).await {

--- a/oma-pm/src/apt.rs
+++ b/oma-pm/src/apt.rs
@@ -165,7 +165,7 @@ pub enum SummarySort {
 pub struct DownloadConfig<'a> {
     pub network_thread: Option<usize>,
     pub download_dir: Option<&'a Path>,
-    pub auth: &'a AuthConfig,
+    pub auth: Option<&'a AuthConfig>,
 }
 
 impl OmaApt {

--- a/oma-pm/src/apt.rs
+++ b/oma-pm/src/apt.rs
@@ -440,7 +440,7 @@ impl OmaApt {
                 .name_without_arch(pkg.raw_pkg.name().to_string())
                 .new_version(ver.version().to_string())
                 .new_size(install_size)
-                .pkg_urls(ver.uris().collect::<Vec<_>>())
+                .pkg_urls(get_package_url(&ver))
                 .arch(ver.arch().to_string())
                 .download_size(ver.size())
                 .op(InstallOperation::Download)
@@ -836,8 +836,9 @@ impl OmaApt {
                     .take()
                     .ok_or_else(|| OmaAptError::PkgNoCandidate(pkg.fullname(true)))?;
 
-                let uri = cand.uris().collect::<Vec<_>>();
-                let not_local_source = uri.iter().all(|x| !x.starts_with("file:"));
+                let uri = get_package_url(&cand);
+
+                let not_local_source = uri.iter().all(|x| !x.index_url.starts_with("file:"));
                 let version = cand.version();
                 let size = cand.installed_size();
 
@@ -976,7 +977,7 @@ impl OmaApt {
                     .new_version(version.version().to_string())
                     .old_size(version.installed_size())
                     .new_size(version.installed_size())
-                    .pkg_urls(uri)
+                    .pkg_urls(get_package_url(&version))
                     .arch(version.arch().to_string())
                     .download_size(version.size())
                     .op(InstallOperation::ReInstall)
@@ -1108,6 +1109,24 @@ impl OmaApt {
     }
 }
 
+fn get_package_url(cand: &Version<'_>) -> Vec<PackageUrl> {
+    let uri = cand
+        .version_files()
+        .filter_map(|v| {
+            let pkg_file = v.package_file();
+            if !pkg_file.is_downloadable() {
+                return None;
+            }
+
+            Some(PackageUrl {
+                download_url: pkg_file.index_file().archive_uri(&v.lookup().filename()),
+                index_url: pkg_file.index_file().archive_uri(""),
+            })
+        })
+        .collect::<Vec<_>>();
+    uri
+}
+
 /// Mark package as delete.
 fn mark_delete(pkg: &Package, purge: bool) -> OmaAptResult<bool> {
     if pkg.marked_delete() {
@@ -1173,7 +1192,7 @@ fn pkg_delta(new_pkg: &Package, op: InstallOperation) -> OmaAptResult<InstallEnt
         .new_version(new_version.to_owned())
         .old_size(installed.installed_size())
         .new_size(cand.installed_size())
-        .pkg_urls(cand.uris().collect::<Vec<_>>())
+        .pkg_urls(get_package_url(&cand))
         .arch(cand.arch().to_string())
         .download_size(cand.size())
         .op(op)

--- a/oma-pm/src/commit.rs
+++ b/oma-pm/src/commit.rs
@@ -22,7 +22,7 @@ const TIME_FORMAT: &str = "%H:%M:%S on %Y-%m-%d";
 
 pub struct CommitNetworkConfig<'a> {
     pub network_thread: Option<usize>,
-    pub auth_config: &'a AuthConfig,
+    pub auth_config: Option<&'a AuthConfig>,
 }
 
 pub struct DoInstall<'a> {

--- a/oma-pm/src/download.rs
+++ b/oma-pm/src/download.rs
@@ -47,7 +47,7 @@ where
                 let source_type = if x.index_url.starts_with("file:") {
                     DownloadSourceType::Local(false)
                 } else {
-                    let auth = auth.find(&x.index_url);
+                    let auth = auth.and_then(|auth| auth.find(&x.index_url));
 
                     DownloadSourceType::Http {
                         auth: auth.map(|x| (x.login.to_owned(), x.password.to_owned())),

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -122,7 +122,7 @@ pub struct OmaRefresh<'a> {
     refresh_topics: bool,
     apt_config: &'a Config,
     topic_msg: &'a str,
-    auth_config: &'a AuthConfig,
+    auth_config: Option<&'a AuthConfig>,
 }
 
 /// Create `apt update` file lock

--- a/oma-refresh/src/sourceslist.rs
+++ b/oma-refresh/src/sourceslist.rs
@@ -267,7 +267,7 @@ impl<'a, 'b> MirrorSources<'a, 'b> {
     pub(crate) fn from_sourcelist(
         sourcelist: &'a [OmaSourceEntry<'a>],
         replacer: &DatabaseFilenameReplacer,
-        auth_config: &'b AuthConfig,
+        auth_config: Option<&'b AuthConfig>,
     ) -> Result<Self, RefreshError> {
         let mut map: HashMap<String, Vec<&OmaSourceEntry>> =
             HashMap::with_hasher(ahash::RandomState::new());
@@ -287,7 +287,7 @@ impl<'a, 'b> MirrorSources<'a, 'b> {
 
         for (_, v) in map {
             let url = v[0].url();
-            let auth = auth_config.find(url);
+            let auth = auth_config.and_then(|auth| auth.find(url));
 
             res.push(MirrorSource {
                 sources: v,

--- a/src/error.rs
+++ b/src/error.rs
@@ -449,9 +449,9 @@ impl From<AuthConfigError> for OutputError {
                 description: format!("Failed to open file: {}", path.display()),
                 source: Some(Box::new(err)),
             },
-            AuthConfigError::MissingEntry(field) => Self {
-                description: format!("Missing field: {field}"),
-                source: None,
+            AuthConfigError::ParseError(error) => Self {
+                description: "Parse auth file got error".to_string(),
+                source: Some(Box::new(error)),
             },
         }
     }

--- a/src/subcommand/download.rs
+++ b/src/subcommand/download.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 use std::thread;
 
-use apt_auth_config::AuthConfig;
 use clap::Args;
 use flume::unbounded;
 use oma_pm::apt::{AptConfig, DownloadConfig, OmaApt, OmaAptArgs};
@@ -17,7 +16,7 @@ use crate::{error::OutputError, subcommand::utils::handle_no_result};
 
 use crate::args::CliExecuter;
 
-use super::utils::is_terminal;
+use super::utils::{auth_config, is_terminal};
 
 #[derive(Debug, Args)]
 pub struct Download {
@@ -76,7 +75,7 @@ impl CliExecuter for Download {
             DownloadConfig {
                 network_thread: Some(config.network_thread()),
                 download_dir: Some(&path),
-                auth: &AuthConfig::system("/")?,
+                auth: auth_config("/").as_ref(),
             },
             dry_run,
             |event| async {

--- a/src/subcommand/fix_broken.rs
+++ b/src/subcommand/fix_broken.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use apt_auth_config::AuthConfig;
 use clap::Args;
 use oma_history::SummaryType;
 use oma_pm::apt::{AptConfig, OmaApt, OmaAptArgs};
@@ -11,7 +10,7 @@ use crate::{
     utils::{dbus_check, root},
 };
 
-use super::utils::{lock_oma, no_check_dbus_warn, CommitChanges};
+use super::utils::{auth_config, lock_oma, no_check_dbus_warn, CommitChanges};
 use crate::args::CliExecuter;
 
 #[derive(Debug, Args)]
@@ -74,7 +73,8 @@ impl CliExecuter for FixBroken {
             no_check_dbus_warn();
         }
 
-        let auth_config = AuthConfig::system(&sysroot)?;
+        let auth_config = auth_config(&sysroot);
+        let auth_config = auth_config.as_ref();
 
         let oma_apt_args = OmaAptArgs::builder()
             .sysroot(sysroot.to_string_lossy().to_string())
@@ -97,7 +97,7 @@ impl CliExecuter for FixBroken {
             .yes(false)
             .autoremove(autoremove)
             .remove_config(remove_config)
-            .auth_config(&auth_config)
+            .maybe_auth_config(auth_config)
             .network_thread(config.network_thread())
             .build()
             .run()

--- a/src/subcommand/history.rs
+++ b/src/subcommand/history.rs
@@ -1,5 +1,4 @@
 use anyhow::anyhow;
-use apt_auth_config::AuthConfig;
 use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::{Local, LocalResult, TimeZone};
 use clap::Args;
@@ -27,8 +26,7 @@ use crate::{
 };
 
 use super::utils::{
-    handle_no_result, lock_oma, no_check_dbus_warn, select_tui_display_msg, tui_select_list_size,
-    CommitChanges,
+    auth_config, handle_no_result, lock_oma, no_check_dbus_warn, select_tui_display_msg, tui_select_list_size, CommitChanges
 };
 use crate::args::CliExecuter;
 
@@ -228,7 +226,8 @@ impl CliExecuter for Undo {
 
         apt.install(&install, false)?;
 
-        let auth_config = AuthConfig::system(&sysroot)?;
+        let auth_config = auth_config(&sysroot);
+        let auth_config = auth_config.as_ref();
 
         CommitChanges::builder()
             .apt(apt)
@@ -243,7 +242,7 @@ impl CliExecuter for Undo {
             .remove_config(remove_config)
             .autoremove(autoremove)
             .network_thread(config.network_thread())
-            .auth_config(&auth_config)
+            .maybe_auth_config(auth_config)
             .build()
             .run()
     }

--- a/src/subcommand/history.rs
+++ b/src/subcommand/history.rs
@@ -26,7 +26,8 @@ use crate::{
 };
 
 use super::utils::{
-    auth_config, handle_no_result, lock_oma, no_check_dbus_warn, select_tui_display_msg, tui_select_list_size, CommitChanges
+    auth_config, handle_no_result, lock_oma, no_check_dbus_warn, select_tui_display_msg,
+    tui_select_list_size, CommitChanges,
 };
 use crate::args::CliExecuter;
 

--- a/src/subcommand/install.rs
+++ b/src/subcommand/install.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use apt_auth_config::AuthConfig;
 use clap::Args;
 use oma_history::SummaryType;
 use oma_pm::apt::AptConfig;
@@ -18,6 +17,7 @@ use crate::utils::dbus_check;
 use crate::utils::root;
 use crate::HTTP_CLIENT;
 
+use super::utils::auth_config;
 use super::utils::handle_no_result;
 use super::utils::lock_oma;
 use super::utils::no_check_dbus_warn;
@@ -133,7 +133,8 @@ impl CliExecuter for Install {
 
         let apt_config = AptConfig::new();
 
-        let auth_config = AuthConfig::system(&sysroot)?;
+        let auth_config = auth_config(&sysroot);
+        let auth_config = auth_config.as_ref();
 
         if !no_refresh {
             let sysroot = sysroot.to_string_lossy();
@@ -144,7 +145,7 @@ impl CliExecuter for Install {
                 .network_thread(config.network_thread())
                 .sysroot(&sysroot)
                 .config(&apt_config)
-                .auth_config(&auth_config);
+                .maybe_auth_config(auth_config);
 
             #[cfg(feature = "aosc")]
             let refresh = builder
@@ -222,7 +223,7 @@ impl CliExecuter for Install {
             .remove_config(remove_config)
             .autoremove(autoremove)
             .network_thread(config.network_thread())
-            .auth_config(&auth_config)
+            .maybe_auth_config(auth_config)
             .fix_dpkg_status(!no_fix_dpkg_status)
             .build()
             .run()

--- a/src/subcommand/mirror.rs
+++ b/src/subcommand/mirror.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use std::time::Instant;
 
 use anyhow::anyhow;
-use apt_auth_config::AuthConfig;
 use clap::Args;
 use clap::Subcommand;
 use dialoguer::console::style;
@@ -46,6 +45,7 @@ use crate::APP_USER_AGENT;
 use crate::HTTP_CLIENT;
 use crate::RT;
 
+use super::utils::auth_config;
 use super::utils::tui_select_list_size;
 use super::utils::Refresh;
 use crate::args::CliExecuter;
@@ -529,7 +529,8 @@ fn refresh(
     network_threads: usize,
     refresh_topic: bool,
 ) -> Result<(), OutputError> {
-    let auth_config = AuthConfig::system("/")?;
+    let auth_config = auth_config("/");
+    let auth_config = auth_config.as_ref();
 
     Refresh::builder()
         .client(&HTTP_CLIENT)
@@ -538,7 +539,7 @@ fn refresh(
         .network_thread(network_threads)
         .refresh_topics(refresh_topic)
         .config(&AptConfig::new())
-        .auth_config(&auth_config)
+        .maybe_auth_config(auth_config)
         .build()
         .run()?;
 

--- a/src/subcommand/refresh.rs
+++ b/src/subcommand/refresh.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use apt_auth_config::AuthConfig;
 use clap::Args;
 use oma_console::indicatif::ProgressBar;
 use oma_console::pb::spinner_style;
@@ -11,7 +10,7 @@ use crate::config::Config;
 use crate::{error::OutputError, utils::root};
 use crate::{fl, success, HTTP_CLIENT};
 
-use super::utils::Refresh as RefreshInner;
+use super::utils::{auth_config, Refresh as RefreshInner};
 use crate::args::CliExecuter;
 
 #[derive(Debug, Args)]
@@ -45,7 +44,8 @@ impl CliExecuter for Refresh {
         root()?;
 
         let apt_config = AptConfig::new();
-        let auth_config = AuthConfig::system(&sysroot)?;
+        let auth_config = auth_config(&sysroot);
+        let auth_config = auth_config.as_ref();
 
         let sysroot_str = sysroot.to_string_lossy();
         let builder = RefreshInner::builder()
@@ -55,7 +55,7 @@ impl CliExecuter for Refresh {
             .network_thread(config.network_thread())
             .sysroot(&sysroot_str)
             .config(&apt_config)
-            .auth_config(&auth_config);
+            .maybe_auth_config(auth_config);
 
         #[cfg(feature = "aosc")]
         let refresh = builder

--- a/src/subcommand/remove.rs
+++ b/src/subcommand/remove.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use anyhow::anyhow;
-use apt_auth_config::AuthConfig;
 use clap::Args;
 use dialoguer::console::style;
 use dialoguer::theme::ColorfulTheme;
@@ -19,7 +18,7 @@ use crate::{
     utils::{dbus_check, root},
 };
 
-use super::utils::{handle_no_result, lock_oma, no_check_dbus_warn, CommitChanges};
+use super::utils::{auth_config, handle_no_result, lock_oma, no_check_dbus_warn, CommitChanges};
 use crate::args::CliExecuter;
 
 #[derive(Debug, Args)]
@@ -243,7 +242,8 @@ impl CliExecuter for Remove {
 
         handle_no_result(&sysroot, no_result, no_progress)?;
 
-        let auth = AuthConfig::system(&sysroot)?;
+        let auth_config = auth_config(&sysroot);
+        let auth_config = auth_config.as_ref();
 
         CommitChanges::builder()
             .apt(apt)
@@ -257,7 +257,7 @@ impl CliExecuter for Remove {
             .remove_config(remove_config)
             .autoremove(!no_autoremove)
             .network_thread(config.network_thread())
-            .auth_config(&auth)
+            .maybe_auth_config(auth_config)
             .fix_dpkg_status(!no_fix_dpkg_status)
             .build()
             .run()

--- a/src/subcommand/topics.rs
+++ b/src/subcommand/topics.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Display, path::PathBuf};
 
-use apt_auth_config::AuthConfig;
 use clap::{ArgAction, Args};
 use dialoguer::console::style;
 use inquire::{
@@ -26,8 +25,8 @@ use crate::{
 };
 
 use super::utils::{
-    lock_oma, no_check_dbus_warn, select_tui_display_msg, tui_select_list_size, CommitChanges,
-    Refresh,
+    auth_config, lock_oma, no_check_dbus_warn, select_tui_display_msg, tui_select_list_size,
+    CommitChanges, Refresh,
 };
 
 use crate::args::CliExecuter;
@@ -175,7 +174,8 @@ impl CliExecuter for Topics {
 
         let code = Ok(()).and_then(|_| -> Result<i32, OutputError> {
             let apt_config = AptConfig::new();
-            let auth_config = AuthConfig::system(&sysroot)?;
+            let auth_config = auth_config(&sysroot);
+            let auth_config = auth_config.as_ref();
 
             Refresh::builder()
                 .client(&HTTP_CLIENT)
@@ -185,7 +185,7 @@ impl CliExecuter for Topics {
                 .sysroot(&sysroot.to_string_lossy())
                 .refresh_topics(true)
                 .config(&apt_config)
-                .auth_config(&auth_config)
+                .maybe_auth_config(auth_config)
                 .build()
                 .run()?;
 
@@ -243,7 +243,7 @@ impl CliExecuter for Topics {
                 .remove_config(remove_config)
                 .autoremove(autoremove)
                 .network_thread(config.network_thread())
-                .auth_config(&auth_config)
+                .maybe_auth_config(auth_config)
                 .check_update(true)
                 .build()
                 .run()?;

--- a/src/subcommand/upgrade.rs
+++ b/src/subcommand/upgrade.rs
@@ -346,7 +346,7 @@ impl CliExecuter for Upgrade {
                 &HTTP_CLIENT,
                 CommitNetworkConfig {
                     network_thread: Some(config.network_thread()),
-                    auth_config: &auth_config,
+                    auth_config: Some(&auth_config),
                 },
                 |event| async {
                     if let Err(e) = tx.send_async(event).await {

--- a/src/subcommand/utils.rs
+++ b/src/subcommand/utils.rs
@@ -275,6 +275,7 @@ impl Refresh<'_> {
 
 pub fn auth_config(sysroot: impl AsRef<Path>) -> Option<AuthConfig> {
     AuthConfig::system(sysroot.as_ref().join("etc/apt"))
+        .inspect(|res| debug!("Auth config: {res:#?}"))
         .inspect_err(|e| debug!("Couldn't read auth config: {e}"))
         .ok()
 }

--- a/src/subcommand/utils.rs
+++ b/src/subcommand/utils.rs
@@ -274,7 +274,7 @@ impl Refresh<'_> {
 }
 
 pub fn auth_config(sysroot: impl AsRef<Path>) -> Option<AuthConfig> {
-    AuthConfig::system(sysroot.as_ref().join("etc/apt"))
+    AuthConfig::system(sysroot)
         .inspect(|res| debug!("Auth config: {res:#?}"))
         .inspect_err(|e| debug!("Couldn't read auth config: {e}"))
         .ok()

--- a/src/subcommand/utils.rs
+++ b/src/subcommand/utils.rs
@@ -201,7 +201,7 @@ pub struct Refresh<'a> {
     #[builder(default = true)]
     refresh_topics: bool,
     config: &'a AptConfig,
-    auth_config: &'a AuthConfig,
+    auth_config: Option<&'a AuthConfig>,
 }
 
 impl Refresh<'_> {
@@ -239,7 +239,7 @@ impl Refresh<'_> {
             .arch(arch)
             .apt_config(config)
             .client(client)
-            .auth_config(auth_config)
+            .maybe_auth_config(auth_config)
             .topic_msg(&msg);
 
         #[cfg(feature = "aosc")]
@@ -273,6 +273,12 @@ impl Refresh<'_> {
     }
 }
 
+pub fn auth_config(sysroot: impl AsRef<Path>) -> Option<AuthConfig> {
+    AuthConfig::system(sysroot.as_ref().join("etc/apt"))
+        .inspect_err(|e| debug!("Couldn't read auth config: {e}"))
+        .ok()
+}
+
 #[derive(Builder)]
 pub(crate) struct CommitChanges<'a> {
     apt: OmaApt,
@@ -295,7 +301,7 @@ pub(crate) struct CommitChanges<'a> {
     remove_config: bool,
     #[builder(default)]
     autoremove: bool,
-    auth_config: &'a AuthConfig,
+    auth_config: Option<&'a AuthConfig>,
     network_thread: usize,
     #[builder(default)]
     check_update: bool,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,7 +3,6 @@ use std::{
     time::Duration,
 };
 
-use apt_auth_config::AuthConfig;
 use clap::Args;
 use oma_console::{
     indicatif::ProgressBar,
@@ -19,7 +18,7 @@ use oma_utils::dbus::{create_dbus_connection, take_wake_lock};
 use tracing::info;
 use tui_inner::{Task, Tui as TuiInner};
 
-use crate::{args::CliExecuter, GlobalOptions};
+use crate::{args::CliExecuter, subcommand::utils::auth_config, GlobalOptions};
 use crate::{
     config::Config,
     error::OutputError,
@@ -141,7 +140,8 @@ impl CliExecuter for Tui {
         };
 
         let apt_config = AptConfig::new();
-        let auth_config = AuthConfig::system(&sysroot)?;
+        let auth_config = auth_config(&sysroot);
+        let auth_config = auth_config.as_ref();
 
         if !no_refresh {
             let sysroot = sysroot.to_string_lossy();
@@ -152,7 +152,7 @@ impl CliExecuter for Tui {
                 .network_thread(config.network_thread())
                 .sysroot(&sysroot)
                 .config(&apt_config)
-                .auth_config(&auth_config);
+                .maybe_auth_config(auth_config);
 
             #[cfg(feature = "aosc")]
             let refresh = builder
@@ -261,7 +261,7 @@ impl CliExecuter for Tui {
                 .yes(false)
                 .remove_config(remove_config)
                 .autoremove(autoremove)
-                .auth_config(&auth_config)
+                .maybe_auth_config(auth_config)
                 .network_thread(config.network_thread())
                 .check_update(upgrade)
                 .build()


### PR DESCRIPTION
TODO list:

- [x] Refactor `apt-auth-config` use `netrc` crate; and passed smoke test
- [x] Handle call `apt-auth-config` but has no permission to get `/etc/apt/auth.conf.d`