### PR TITLE
Refactor `oma-history` database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,6 +2907,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,6 +3109,7 @@ dependencies = [
 name = "oma-history"
 version = "0.4.10"
 dependencies = [
+ "num_enum",
  "oma-pm-operation-type",
  "rusqlite",
  "serde",
@@ -3159,6 +3181,7 @@ name = "oma-pm-operation-type"
 version = "0.7.0"
 dependencies = [
  "bon",
+ "num_enum",
  "oma-utils 0.10.4",
  "serde",
 ]

--- a/oma-history/Cargo.toml
+++ b/oma-history/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 thiserror = "2"
+num_enum = "0.7.3"

--- a/oma-history/src/lib.rs
+++ b/oma-history/src/lib.rs
@@ -1,29 +1,34 @@
 use std::{
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
 
-use oma_pm_operation_type::{InstallEntry, OmaOperation, RemoveEntry};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use oma_pm_operation_type::{InstallOperation, OmaOperation, RemoveTag};
 use rusqlite::{Connection, Error, Result};
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::debug;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, IntoPrimitive, TryFromPrimitive)]
+#[repr(i64)]
 pub enum SummaryType {
-    Install(Vec<String>),
-    Upgrade(Vec<String>),
-    Remove(Vec<String>),
-    Changes,
-    FixBroken,
-    TopicsChanged {
-        add: Vec<String>,
-        remove: Vec<String>,
-    },
-    Undo,
+    Install = 1,
+    Upgrade = 2,
+    Remove = 3,
+    FixBroken = 4,
+    Undo = 5,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    pub install: Vec<InstallHistoryEntry>,
+    pub remove: Vec<RemoveHistoryEntry>,
+    pub disk_size: (Box<str>, u64),
+    pub total_download_size: u64,
+    pub is_success: bool,
+}
+
+#[derive(Debug)]
 pub struct SummaryLog {
     pub typ: SummaryType,
     pub op: OmaOperation,
@@ -40,8 +45,6 @@ pub enum HistoryError {
     ConnectError(Error),
     #[error("Failed to execute sqlte stmt, kind: {0}")]
     ExecuteError(Error),
-    #[error("Failed to parser object: {0}")]
-    ParseError(serde_json::Error),
     #[error("Failed to parser object: {0}")]
     ParseDbError(Error),
     #[error("History database is empty")]
@@ -69,17 +72,55 @@ pub fn connect_db<P: AsRef<Path>>(db_path: P, write: bool) -> HistoryResult<Conn
 
     if write {
         conn.execute(
-            "CREATE TABLE IF NOT EXISTS \"history_oma_1.2\" (
+            "CREATE TABLE IF NOT EXISTS \"history_oma_1.14\" (
                 id INTEGER PRIMARY KEY,
-                typ BLOB NOT NULL,
+                install_type INTEGER NOT NULL,
                 time INTEGER NOT NULL,
                 is_success INTEGER NOT NULL,
-                install_packages BLOB,
-                remove_packages BLOB,
                 disk_size INTEGER NOT NULL,
                 total_download_size INTEGER
             )",
             (), // empty list of parameters.
+        )
+        .map_err(HistoryError::ExecuteError)?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS \"history_install_package_oma_1.14\" (
+            history_id INTEGER NOT NULL,
+            package_name TEXT NOT NULL,
+            old_version TEXT,
+            new_version TEXT NOT NULL,
+            old_size INTEGER,
+            new_size INTEGER NOT NULL,
+            download_size INTEGER NOT NULL,
+            arch TEXT NOT NULL,
+            operation INTEGER NOT NULL
+        )",
+            (),
+        )
+        .map_err(HistoryError::ExecuteError)?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS \"history_remove_package_oma_1.14\" (
+            history_id INTEGER NOT NULL,
+            package_name TEXT NOT NULL,
+            version TEXT NOT NULL,
+            size INTEGER NOT NULL,
+            arch TEXT NOT NULL
+        )",
+            (),
+        )
+        .map_err(HistoryError::ExecuteError)?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS \"history_remove_package_detail_oma_1.14\" (
+            history_id INTEGER NOT NULL,
+            package_name TEXT NOT NULL,
+            autoremove INTEGER NOT NULL,
+            purge INTEGER NOT NULL,
+            resolver INTEGER NOT NULL
+        )",
+            (),
         )
         .map_err(HistoryError::ExecuteError)?;
     }
@@ -108,7 +149,7 @@ pub fn create_db_file<P: AsRef<Path>>(sysroot: P) -> HistoryResult<PathBuf> {
 
 pub fn write_history_entry(
     summary: &OmaOperation,
-    typ: SummaryType,
+    install_type: SummaryType,
     conn: Connection,
     dry_run: bool,
     start_time: i64,
@@ -119,36 +160,100 @@ pub fn write_history_entry(
         return Ok(());
     }
 
-    conn.execute(
-        "INSERT INTO \"history_oma_1.2\" (typ, time, is_success, install_packages, remove_packages, disk_size, total_download_size) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-        (serde_json::to_string(&typ).map_err(HistoryError::ParseError)?,
+    let install_type: i64 = install_type.into();
+
+    let id: i64 = conn.query_row(
+        r#"INSERT INTO "history_oma_1.14" (install_type, time, is_success, disk_size, total_download_size)
+                VALUES (?1, ?2, ?3, ?4, ?5)
+                RETURNING id;"#,
+        (install_type,
         start_time,
         if success { 1 } else { 0 },
-        serde_json::to_string(&summary.install).map_err(HistoryError::ParseError)?,
-        serde_json::to_string(&summary.remove).map_err(HistoryError::ParseError)?,
         match (summary.disk_size.0.as_ref(), summary.disk_size.1) {
             ("+", x) => x as i64,
             ("-", x) => 0 - x as i64,
             _ => unreachable!()
         },
         summary.total_download_size),
+        |row| row.get(0)
     )
     .map_err(HistoryError::ExecuteError)?;
+
+    for i in &summary.install {
+        let op: u8 = (*i.op()).into();
+        let op = op as i64;
+        conn.execute(
+            r#"INSERT INTO "history_install_package_oma_1.14" (history_id, package_name, old_version, new_version, old_size, new_size, download_size, arch, operation)
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)"#,
+            (id, i.name(), i.old_version(), i.new_version(), i.old_size(), i.new_size(), i.download_size(), i.arch(), op),
+        ).map_err(HistoryError::ExecuteError)?;
+    }
+
+    for i in &summary.remove {
+        let Some(version) = i.version() else {
+            // 仅为删除配置文件时，版本为空，因此不记录
+            continue;
+        };
+
+        conn.execute(
+            r#"INSERT INTO "history_remove_package_oma_1.14" (history_id, package_name, version, size, arch)
+                    VALUES (?1, ?2, ?3, ?4, ?5)"#,
+            (id, i.name(), version, i.size(), i.arch()),
+        ).map_err(HistoryError::ExecuteError)?;
+
+        conn.execute(
+            r#"INSERT INTO "history_remove_package_detail_oma_1.14" (history_id, package_name, autoremove, purge, resolver)
+                    VALUES (?1, ?2, ?3, ?4, ?5)"#,
+            (id,
+                i.name(),
+                if i.details().contains(&RemoveTag::AutoRemove) { 1 } else { 0 },
+                if i.details().contains(&RemoveTag::Purge) { 1 } else { 0 },
+                if i.details().contains(&RemoveTag::Resolver) { 1 } else { 0 }
+            ),
+        ).map_err(HistoryError::ExecuteError)?;
+    }
 
     Ok(())
 }
 
 pub struct HistoryListEntry {
     pub id: i64,
-    pub t: SummaryType,
+    pub summary_type: SummaryType,
     pub time: i64,
     pub is_success: bool,
 }
 
+pub struct InstallHistoryEntry {
+    pub pkg_name: String,
+    pub old_version: Option<String>,
+    pub new_version: String,
+    pub old_size: Option<i64>,
+    pub new_size: i64,
+    pub download_size: i64,
+    pub arch: String,
+    pub operation: InstallOperation,
+}
+
+pub struct RemoveHistoryEntryTmp {
+    pub pkg_name: String,
+    pub version: String,
+    pub size: i64,
+    pub arch: String,
+}
+
+pub struct RemoveHistoryEntry {
+    pub pkg_name: String,
+    pub version: String,
+    pub size: i64,
+    pub arch: String,
+    pub tags: Vec<RemoveTag>,
+}
+
 pub fn list_history(conn: &Connection) -> HistoryResult<Vec<HistoryListEntry>> {
     let mut res = vec![];
-    let stmt =
-        conn.prepare("SELECT id, typ, time, is_success FROM \"history_oma_1.2\" ORDER BY id DESC");
+    let stmt = conn.prepare(
+        "SELECT id, install_type, time, is_success FROM \"history_oma_1.14\" ORDER BY id DESC",
+    );
 
     let mut stmt = match stmt {
         Ok(stmt) => stmt,
@@ -163,7 +268,7 @@ pub fn list_history(conn: &Connection) -> HistoryResult<Vec<HistoryListEntry>> {
     let res_iter = stmt
         .query_map([], |row| {
             let id: i64 = row.get(0)?;
-            let t: String = row.get(1)?;
+            let t: i64 = row.get(1)?;
             let time: i64 = row.get(2)?;
             let is_success: i64 = row.get(3)?;
 
@@ -173,9 +278,12 @@ pub fn list_history(conn: &Connection) -> HistoryResult<Vec<HistoryListEntry>> {
 
     for i in res_iter {
         let (id, t, time, is_success) = i.map_err(HistoryError::ParseDbError)?;
+
+        let install_type: SummaryType = t.try_into().unwrap();
+
         res.push(HistoryListEntry {
             id,
-            t: serde_json::from_str(&t).map_err(HistoryError::ParseError)?,
+            summary_type: install_type,
             time,
             is_success: is_success == 1,
         });
@@ -188,53 +296,154 @@ pub fn list_history(conn: &Connection) -> HistoryResult<Vec<HistoryListEntry>> {
     Ok(res)
 }
 
-pub fn find_history_by_id(conn: &Connection, id: i64) -> HistoryResult<OmaOperation> {
-    let mut stmt = conn
-        .prepare("SELECT install_packages, remove_packages, disk_size, total_download_size FROM \"history_oma_1.2\" WHERE id = (?1)")
+pub fn find_history_by_id(conn: &Connection, id: i64) -> HistoryResult<HistoryEntry> {
+    let mut query_history_table = conn
+        .prepare("SELECT is_success, disk_size, total_download_size FROM \"history_oma_1.14\" WHERE id = (?1)")
         .map_err(HistoryError::ExecuteError)?;
 
-    let mut res_iter = stmt
+    let mut res_iter = query_history_table
         .query_map([id], |row| {
-            let install_packages: String = row.get(0)?;
-            let remove_packages: String = row.get(1)?;
-            let disk_size: i64 = row.get(2)?;
-            let total_download_size: u64 = row.get(3)?;
+            let is_success: i64 = row.get(0)?;
+            let disk_size: i64 = row.get(1)?;
+            let total_download_size: u64 = row.get(2)?;
 
-            Ok((
-                install_packages,
-                remove_packages,
-                disk_size,
-                total_download_size,
-            ))
+            Ok((is_success, disk_size, total_download_size))
         })
         .map_err(HistoryError::ExecuteError)?;
+
+    let mut query_install_table = conn.prepare(r#"SELECT package_name, old_version, new_version, old_size, new_size, download_size, arch, operation FROM "history_install_package_oma_1.14"
+    WHERE history_id = (?1)"#)
+    .map_err(HistoryError::ExecuteError)?;
+
+    let res_install_iter = query_install_table
+        .query_map([id], |row| {
+            let pkg_name: String = row.get(0)?;
+            let old_version: Option<String> = row.get(1)?;
+            let new_version: String = row.get(2)?;
+            let old_size: Option<i64> = row.get(3)?;
+            let new_size: i64 = row.get(4)?;
+            let download_size: i64 = row.get(5)?;
+            let arch: String = row.get(6)?;
+            let operation: i64 = row.get(7)?;
+            let operation = InstallOperation::from(operation as u8);
+
+            Ok(InstallHistoryEntry {
+                pkg_name,
+                old_version,
+                new_version,
+                old_size,
+                new_size,
+                download_size,
+                arch,
+                operation,
+            })
+        })
+        .map_err(HistoryError::ExecuteError)?;
+
+    let mut query_remove_table = conn
+        .prepare(
+            r#"SELECT package_name, version, size, arch FROM "history_remove_package_oma_1.14"
+    WHERE history_id = (?1)"#,
+        )
+        .map_err(HistoryError::ExecuteError)?;
+
+    let res_remove_iter = query_remove_table
+        .query_map([id], |row| {
+            let pkg_name: String = row.get(0)?;
+            let version: String = row.get(1)?;
+            let size: i64 = row.get(2)?;
+            let arch: String = row.get(3)?;
+
+            Ok(RemoveHistoryEntryTmp {
+                pkg_name,
+                version,
+                size,
+                arch,
+            })
+        })
+        .map_err(HistoryError::ExecuteError)?;
+
+    let mut query_remove_details_table = conn
+        .prepare(
+            r#"SELECT package_name, autoremove, purge, resolver FROM "history_remove_package_detail_oma_1.14"
+    WHERE history_id = (?1)"#,
+        )
+        .map_err(HistoryError::ExecuteError)?;
+
+    let res_remove_details = query_remove_details_table
+        .query_map([id], |row| {
+            let mut remove_tag = vec![];
+            let package_name: String = row.get(0)?;
+            let autoremove: i64 = row.get(1)?;
+            let purge: i64 = row.get(2)?;
+            let resolver: i64 = row.get(3)?;
+
+            if autoremove == 1 {
+                remove_tag.push(RemoveTag::AutoRemove);
+            }
+
+            if purge == 1 {
+                remove_tag.push(RemoveTag::Purge);
+            }
+
+            if resolver == 1 {
+                remove_tag.push(RemoveTag::Resolver);
+            }
+
+            Ok((package_name, remove_tag))
+        })
+        .map_err(HistoryError::ExecuteError)?
+        .collect::<Result<HashMap<_, _>>>()
+        .map_err(HistoryError::ParseDbError)?;
 
     let mut res = None;
 
     if let Some(i) = res_iter.next() {
-        let (install_packages, remove_packages, disk_size, total_download_size) =
-            i.map_err(HistoryError::ParseDbError)?;
+        let (is_success, disk_size, total_download_size) = i.map_err(HistoryError::ParseDbError)?;
 
-        let install_package: Vec<InstallEntry> =
-            serde_json::from_str(&install_packages).map_err(HistoryError::ParseError)?;
-        let remove_package: Vec<RemoveEntry> =
-            serde_json::from_str(&remove_packages).map_err(HistoryError::ParseError)?;
-        let disk_size = if disk_size >= 0 {
+        let is_success = is_success == 1;
+
+        let disk_size: (Box<str>, u64) = if disk_size >= 0 {
             ("+".into(), disk_size as u64)
         } else {
             ("-".into(), (0 - disk_size) as u64)
         };
 
-        res = Some(OmaOperation {
-            install: install_package,
-            remove: remove_package,
+        let mut install = vec![];
+        let mut remove = vec![];
+
+        for i in res_install_iter {
+            let i = i.map_err(HistoryError::ParseDbError)?;
+
+            install.push(i);
+        }
+
+        for i in res_remove_iter {
+            let RemoveHistoryEntryTmp {
+                pkg_name,
+                version,
+                size,
+                arch,
+            } = i.map_err(HistoryError::ParseDbError)?;
+
+            let tags = res_remove_details.get(&pkg_name).unwrap().to_owned();
+
+            remove.push(RemoveHistoryEntry {
+                pkg_name,
+                version,
+                size,
+                arch,
+                tags,
+            });
+        }
+
+        res = Some(HistoryEntry {
+            install,
+            remove,
             disk_size,
             total_download_size,
-            // 不记录 autoremovable
-            autoremovable: (0, 0),
-            suggest: vec![],
-            recommend: vec![],
-        });
+            is_success,
+        })
     }
 
     res.ok_or_else(|| HistoryError::NoResult(id))

--- a/oma-history/src/migrations.rs
+++ b/oma-history/src/migrations.rs
@@ -1,0 +1,355 @@
+use oma_pm_operation_type::{InstallOperation, RemoveTag};
+use rusqlite::Connection;
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use crate::{
+    HistoryEntryInner, HistoryError, HistoryResult, InstallHistoryEntry, RemoveHistoryEntry,
+    INSERT_INSTALL_TABLE, INSERT_NEW_MAIN_TABLE, INSERT_REMOVE_DETAIL_TABLE, INSERT_REMOVE_TABLE,
+};
+
+pub fn create_and_maybe_migration_from_oma_db_v2(conn: &Connection) -> HistoryResult<()> {
+    create_history_table(conn)?;
+
+    let old_db_count: i32 = conn
+        .query_row(
+            "SELECT COUNT(name) FROM sqlite_schema WHERE name = 'history_oma_1.2'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(HistoryError::ExecuteError)?;
+
+    let new_db_count: i32 = conn
+        .query_row("SELECT COUNT(id) FROM 'history_oma_1.14'", [], |row| {
+            row.get(0)
+        })
+        .map_err(HistoryError::ExecuteError)?;
+
+    if old_db_count != 0 && new_db_count == 0 {
+        info!("Migrating oma history database, this may take a few minutes ...");
+        migration_from_oma_db_v2(conn)?;
+    }
+
+    Ok(())
+}
+
+struct OldTableEntry {
+    inner: HistoryEntryInner,
+    _id: i64,
+    time: i64,
+    summary_type: OldSummaryType,
+}
+
+fn handle_packages_items(items: &[String]) -> String {
+    items
+        .iter()
+        .map(|x| {
+            x.split_once(" ")
+                .map(|x| (x.0.to_string(), x.1.to_string()))
+                .unwrap_or_else(|| (x.to_string(), "".to_string()))
+                .0
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn migration_from_oma_db_v2(conn: &Connection) -> HistoryResult<()> {
+    let table = get_old_table(conn)?;
+
+    for entry in table {
+        let command = match &entry.summary_type {
+            OldSummaryType::Install(items) => {
+                format!("oma install {}", handle_packages_items(items))
+            }
+            OldSummaryType::Upgrade(items) => {
+                format!("oma upgrade {}", handle_packages_items(items))
+            }
+            OldSummaryType::Remove(items) => format!("oma remove {}", handle_packages_items(items)),
+            OldSummaryType::Changes => "oma tui".to_string(),
+            OldSummaryType::FixBroken => "oma fix-broken".to_string(),
+            OldSummaryType::TopicsChanged { add, remove } => {
+                let mut s = "oma topics".to_string();
+                if !add.is_empty() {
+                    s.push_str(" --opt-in ");
+                    s.push_str(&add.join(" "));
+                }
+                if !remove.is_empty() {
+                    s.push_str(" --opt-out ");
+                    s.push_str(&remove.join(" "));
+                }
+                s
+            }
+            OldSummaryType::Undo => "oma undo".to_string(),
+        };
+
+        let id: i64 = conn
+            .query_row(
+                INSERT_NEW_MAIN_TABLE,
+                (
+                    command,
+                    entry.time,
+                    entry.inner.is_success,
+                    entry.inner.disk_size,
+                    entry.inner.total_download_size,
+                    entry
+                        .inner
+                        .install
+                        .iter()
+                        .filter(|x| x.operation == InstallOperation::Install)
+                        .count(),
+                    entry.inner.remove.len(),
+                    entry
+                        .inner
+                        .install
+                        .iter()
+                        .filter(|x| x.operation == InstallOperation::Upgrade)
+                        .count(),
+                    entry
+                        .inner
+                        .install
+                        .iter()
+                        .filter(|x| x.operation == InstallOperation::Downgrade)
+                        .count(),
+                    entry
+                        .inner
+                        .install
+                        .iter()
+                        .filter(|x| x.operation == InstallOperation::ReInstall)
+                        .count(),
+                    entry.summary_type == OldSummaryType::FixBroken,
+                    entry.summary_type == OldSummaryType::Undo,
+                ),
+                |row| row.get(0),
+            )
+            .map_err(HistoryError::ExecuteError)?;
+
+        for i in &entry.inner.install {
+            let op: u8 = i.operation.into();
+            let op = op as i64;
+
+            conn.execute(
+                INSERT_INSTALL_TABLE,
+                (
+                    id,
+                    &i.pkg_name,
+                    &i.old_version,
+                    &i.new_version,
+                    i.old_size,
+                    i.new_size,
+                    i.download_size,
+                    &i.arch,
+                    op,
+                ),
+            )
+            .map_err(HistoryError::ExecuteError)?;
+        }
+
+        for j in &entry.inner.remove {
+            conn.execute(
+                INSERT_REMOVE_TABLE,
+                (id, &j.pkg_name, &j.version, j.size, &j.arch),
+            )
+            .map_err(HistoryError::ExecuteError)?;
+
+            conn.execute(
+                INSERT_REMOVE_DETAIL_TABLE,
+                (
+                    id,
+                    &j.pkg_name,
+                    if j.tags.contains(&RemoveTag::AutoRemove) {
+                        1
+                    } else {
+                        0
+                    },
+                    if j.tags.contains(&RemoveTag::Purge) {
+                        1
+                    } else {
+                        0
+                    },
+                    if j.tags.contains(&RemoveTag::Resolver) {
+                        1
+                    } else {
+                        0
+                    },
+                ),
+            )
+            .map_err(HistoryError::ExecuteError)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OldSummaryType {
+    Install(Vec<String>),
+    Upgrade(Vec<String>),
+    Remove(Vec<String>),
+    Changes,
+    FixBroken,
+    TopicsChanged {
+        add: Vec<String>,
+        remove: Vec<String>,
+    },
+    Undo,
+}
+
+fn get_old_table(conn: &Connection) -> Result<Vec<OldTableEntry>, HistoryError> {
+    let mut stmt = conn
+        .prepare("SELECT id, time, install_packages, remove_packages, disk_size, total_download_size, is_success, typ FROM \"history_oma_1.2\" ORDER BY id ASC")
+        .map_err(HistoryError::ExecuteError)?;
+    let res_iter = stmt
+        .query_map([], |row| {
+            let id: i64 = row.get(0)?;
+            let time: i64 = row.get(1)?;
+            let install_packages: String = row.get(2)?;
+            let remove_packages: String = row.get(3)?;
+            let disk_size: i64 = row.get(4)?;
+            let total_download_size: u64 = row.get(5)?;
+            let is_success: i64 = row.get(6)?;
+            let summary_type: String = row.get(7)?;
+
+            Ok((
+                id,
+                time,
+                install_packages,
+                remove_packages,
+                disk_size,
+                total_download_size,
+                is_success,
+                summary_type,
+            ))
+        })
+        .map_err(HistoryError::ExecuteError)?;
+    let mut res = vec![];
+    for i in res_iter {
+        let (
+            id,
+            time,
+            install_packages,
+            remove_packages,
+            disk_size,
+            total_download_size,
+            is_success,
+            summary_type,
+        ) = i.map_err(HistoryError::ExecuteError)?;
+
+        let install_packages =
+            match serde_json::from_str::<Vec<InstallHistoryEntry>>(&install_packages) {
+                Ok(i) => i,
+                Err(e) => {
+                    warn!("Failed to parse item: {e}");
+                    debug!("install packages: {}", install_packages);
+                    continue;
+                }
+            };
+
+        let remove_packages =
+            match serde_json::from_str::<Vec<RemoveHistoryEntry>>(&remove_packages) {
+                Ok(i) => i,
+                Err(e) => {
+                    warn!("Failed to parse item: {e}");
+                    debug!("remove packages: {}", &remove_packages);
+                    continue;
+                }
+            };
+
+        let summary_type = match serde_json::from_str::<OldSummaryType>(&summary_type) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("Failed to parse item: {e}");
+                debug!("summary type: {}", &summary_type);
+                continue;
+            }
+        };
+
+        res.push(OldTableEntry {
+            inner: HistoryEntryInner {
+                install: install_packages,
+                remove: remove_packages,
+                disk_size,
+                total_download_size,
+                is_success: is_success == 1,
+            },
+            _id: id,
+            time,
+            summary_type,
+        })
+    }
+
+    Ok(res)
+}
+
+fn create_history_table(conn: &Connection) -> HistoryResult<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS \"history_oma_1.14\" (
+                id INTEGER PRIMARY KEY,
+                command TEXT,
+                time INTEGER NOT NULL,
+                is_success INTEGER NOT NULL,
+                disk_size INTEGER NOT NULL,
+                total_download_size INTEGER,
+                install_count INTEGER NOT NULL,
+                remove_count INTEGER NOT NULL,
+                upgrade_count INTEGER NOT NULL,
+                downgrade_count INTEGER NOT NULL,
+                reinstall_count INTEGER NOT NULL,
+                is_fixbroken INTEGER NOT NULL,
+                is_undo INTEGER NOT NULL
+            )",
+        (),
+    )
+    .map_err(HistoryError::ExecuteError)?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS \"history_install_package_oma_1.14\" (
+            history_id INTEGER NOT NULL,
+            package_name TEXT NOT NULL,
+            old_version TEXT,
+            new_version TEXT NOT NULL,
+            old_size INTEGER,
+            new_size INTEGER NOT NULL,
+            download_size INTEGER NOT NULL,
+            arch TEXT NOT NULL,
+            operation INTEGER NOT NULL
+        )",
+        (),
+    )
+    .map_err(HistoryError::ExecuteError)?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS \"history_remove_package_oma_1.14\" (
+            history_id INTEGER NOT NULL,
+            package_name TEXT NOT NULL,
+            version TEXT NOT NULL,
+            size INTEGER NOT NULL,
+            arch TEXT NOT NULL
+        )",
+        (),
+    )
+    .map_err(HistoryError::ExecuteError)?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS \"history_remove_package_detail_oma_1.14\" (
+            history_id INTEGER NOT NULL,
+            package_name TEXT NOT NULL,
+            autoremove INTEGER NOT NULL,
+            purge INTEGER NOT NULL,
+            resolver INTEGER NOT NULL
+        )",
+        (),
+    )
+    .map_err(HistoryError::ExecuteError)?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS \"history_topic_oma_1.14\" (
+            history_id INTEGER NOT NULL,
+            topic_name TEXT NOT NULL,
+            enable INTEGER NOT NULL
+        )",
+        (),
+    )
+    .map_err(HistoryError::ExecuteError)?;
+
+    Ok(())
+}

--- a/oma-pm-operation-type/Cargo.toml
+++ b/oma-pm-operation-type/Cargo.toml
@@ -13,3 +13,4 @@ oma-utils = { version = "^0.10.0", path = "../oma-utils", features = [
     "human-bytes",
 ] }
 bon = "3"
+num_enum = "0.7.3"

--- a/oma-pm-operation-type/src/lib.rs
+++ b/oma-pm-operation-type/src/lib.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use bon::{builder, Builder};
+use num_enum::{FromPrimitive, IntoPrimitive};
 use oma_utils::human_bytes::HumanBytes;
 use serde::{Deserialize, Serialize};
 
@@ -145,10 +146,23 @@ pub enum RemoveTag {
     Resolver,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Default, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Default,
+    Serialize,
+    Deserialize,
+    IntoPrimitive,
+    FromPrimitive,
+    Copy,
+)]
+#[repr(u8)]
 pub enum InstallOperation {
     #[default]
-    Default,
+    Default = 0,
     Install,
     ReInstall,
     Upgrade,

--- a/oma-pm-operation-type/src/lib.rs
+++ b/oma-pm-operation-type/src/lib.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 pub struct OmaOperation {
     pub install: Vec<InstallEntry>,
     pub remove: Vec<RemoveEntry>,
-    pub disk_size: (Box<str>, u64),
+    pub disk_size_delta: i64,
     pub autoremovable: (u64, u64),
     pub total_download_size: u64,
     pub suggest: Vec<(String, String)>,
@@ -96,7 +96,12 @@ impl Display for OmaOperation {
             writeln!(f, "Purge: {}", purge.join(", "))?;
         }
 
-        let (symbol, n) = &self.disk_size;
+        let (symbol, n) = if self.disk_size_delta >= 0 {
+            ("+", self.disk_size_delta as u64)
+        } else {
+            ("-", (0 - self.disk_size_delta) as u64)
+        };
+
         writeln!(f, "Size-delta: {symbol}{}", HumanBytes(n.to_owned()))?;
 
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -880,10 +880,6 @@ impl From<HistoryError> for OutputError {
                 description: fl!("failed-to-execute-query-stmt"),
                 source: Some(Box::new(e)),
             },
-            HistoryError::ParseError(e) => Self {
-                description: fl!("failed-to-parse-history-object"),
-                source: Some(Box::new(e)),
-            },
             HistoryError::ParseDbError(e) => Self {
                 description: fl!("failed-to-parse-history-object"),
                 source: Some(Box::new(e)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,9 +55,9 @@ use crate::egg::ailurus;
 use crate::error::Chain;
 use crate::subcommand::*;
 
-static ALLOWCTRLC: AtomicBool = AtomicBool::new(false);
+static NOT_DISPLAY_ABORT: AtomicBool = AtomicBool::new(false);
 static LOCKED: AtomicBool = AtomicBool::new(false);
-static SPAWN_NEW_OMA: AtomicBool = AtomicBool::new(false);
+static NOT_ALLOW_CTRLC: AtomicBool = AtomicBool::new(false);
 static APP_USER_AGENT: &str = concat!("oma/", env!("CARGO_PKG_VERSION"));
 static COLOR_FORMATTER: OnceLock<OmaColorFormat> = OnceLock::new();
 static RT: LazyLock<Runtime> = LazyLock::new(|| {
@@ -444,11 +444,11 @@ async fn find_another_oma_inner() -> Result<(), OutputError> {
 }
 
 fn single_handler() {
-    if SPAWN_NEW_OMA.load(Ordering::Relaxed) {
+    if NOT_ALLOW_CTRLC.load(Ordering::Relaxed) {
         return;
     }
 
-    let allow_ctrlc = ALLOWCTRLC.load(Ordering::Relaxed);
+    let not_display_abort = NOT_DISPLAY_ABORT.load(Ordering::Relaxed);
 
     // Dealing with lock
     if LOCKED.load(Ordering::Relaxed) {
@@ -459,7 +459,7 @@ fn single_handler() {
     // This is not a big deal so we won't panic on this.
     let _ = WRITER.show_cursor();
 
-    if !allow_ctrlc {
+    if !not_display_abort {
         info!("{}", fl!("user-aborted-op"));
     }
 

--- a/src/subcommand/fix_broken.rs
+++ b/src/subcommand/fix_broken.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use oma_history::SummaryType;
 use oma_pm::apt::{AptConfig, OmaApt, OmaAptArgs};
 
 use crate::{
@@ -88,8 +87,8 @@ impl CliExecuter for FixBroken {
         CommitChanges::builder()
             .apt(apt)
             .dry_run(dry_run)
-            .request_type(SummaryType::FixBroken)
             .no_fixbroken(false)
+            .is_fixbroken(true)
             .no_progress(no_progress)
             .sysroot(sysroot.to_string_lossy().to_string())
             .fix_dpkg_status(!no_fix_dpkg_status)

--- a/src/subcommand/history.rs
+++ b/src/subcommand/history.rs
@@ -278,15 +278,18 @@ fn format_summary_log(list: &[HistoryListEntry], undo: bool) -> Vec<(String, usi
         })
         .map(|(index, log)| {
             let date = format_date(log.time);
+            let command = &log.command;
 
             // TODO
-            let s = match &log.summary_type {
-                SummaryType::Install => format!("{}Install pkg", format_success(log.is_success)),
-                SummaryType::Upgrade => format!("{}Upgrade pkg", format_success(log.is_success)),
-                SummaryType::Remove => format!("{}Remove pkg", format_success(log.is_success)),
-                SummaryType::FixBroken => format!("{}Fix broken", format_success(log.is_success)),
-                SummaryType::Undo => format!("{}Undo", format_success(log.is_success)),
-            };
+            // let s = match &log.summary_type {
+            //     SummaryType::Install => format!("{}Install pkg", format_success(log.is_success)),
+            //     SummaryType::Upgrade => format!("{}Upgrade pkg", format_success(log.is_success)),
+            //     SummaryType::Remove => format!("{}Remove pkg", format_success(log.is_success)),
+            //     SummaryType::FixBroken => format!("{}Fix broken", format_success(log.is_success)),
+            //     SummaryType::Undo => format!("{}Undo", format_success(log.is_success)),
+            // };
+
+            let s = format!("{}[{}] {}", format_success(log.is_success), date, command);
 
             let s = select_tui_display_msg(&s, false).to_string();
 

--- a/src/subcommand/history.rs
+++ b/src/subcommand/history.rs
@@ -4,7 +4,7 @@ use chrono::{Local, LocalResult, TimeZone};
 use clap::Args;
 use dialoguer::{theme::ColorfulTheme, Select};
 use oma_history::{
-    connect_db, find_history_by_id, list_history, HistoryListEntry, SummaryType, DATABASE_PATH,
+    connect_db, find_history_by_id, list_history, HistoryListEntry, DATABASE_PATH,
 };
 use oma_pm::apt::{AptConfig, InstallOperation, OmaAptArgs};
 use oma_pm::matches::{GetArchMethod, PackagesMatcher};
@@ -233,7 +233,7 @@ impl CliExecuter for Undo {
         CommitChanges::builder()
             .apt(apt)
             .dry_run(dry_run)
-            .request_type(SummaryType::Undo)
+            .is_undo(true)
             .no_fixbroken(no_fixbroken)
             .no_progress(no_progress)
             .sysroot(sysroot.to_string_lossy().to_string())
@@ -271,7 +271,7 @@ fn format_summary_log(list: &[HistoryListEntry], undo: bool) -> Vec<(String, usi
         .enumerate()
         .filter(|(_, log)| {
             if undo {
-                log.summary_type != SummaryType::FixBroken && log.summary_type != SummaryType::Undo
+                !log.is_fixbroken && !log.is_undo
             } else {
                 true
             }
@@ -279,15 +279,6 @@ fn format_summary_log(list: &[HistoryListEntry], undo: bool) -> Vec<(String, usi
         .map(|(index, log)| {
             let date = format_date(log.time);
             let command = &log.command;
-
-            // TODO
-            // let s = match &log.summary_type {
-            //     SummaryType::Install => format!("{}Install pkg", format_success(log.is_success)),
-            //     SummaryType::Upgrade => format!("{}Upgrade pkg", format_success(log.is_success)),
-            //     SummaryType::Remove => format!("{}Remove pkg", format_success(log.is_success)),
-            //     SummaryType::FixBroken => format!("{}Fix broken", format_success(log.is_success)),
-            //     SummaryType::Undo => format!("{}Undo", format_success(log.is_success)),
-            // };
 
             let s = format!("{}[{}] {}", format_success(log.is_success), date, command);
 

--- a/src/subcommand/history.rs
+++ b/src/subcommand/history.rs
@@ -3,7 +3,7 @@ use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::{Local, LocalResult, TimeZone};
 use clap::Args;
 use dialoguer::{theme::ColorfulTheme, Select};
-use oma_history::{connect_db, find_history_by_id, list_history, HistoryListEntry, DATABASE_PATH};
+use oma_history::{connect_db, find_history_by_id, list_history, HistoryEntry, DATABASE_PATH};
 use oma_pm::apt::{AptConfig, InstallOperation, OmaAptArgs};
 use oma_pm::matches::{GetArchMethod, PackagesMatcher};
 use oma_pm::pkginfo::PtrIsNone;
@@ -61,7 +61,7 @@ impl CliExecuter for History {
             let op = find_history_by_id(&conn, id)?;
             let install = &op.install;
             let remove = &op.remove;
-            let disk_size = &op.disk_size;
+            let disk_size = op.disk_size;
 
             table_for_history_pending(install, remove, disk_size)?;
         }
@@ -263,7 +263,7 @@ fn dialoguer_select_history(
     Ok(selected)
 }
 
-fn format_summary_log(list: &[HistoryListEntry], undo: bool) -> Vec<(String, usize)> {
+fn format_summary_log(list: &[HistoryEntry], undo: bool) -> Vec<(String, usize)> {
     let display_list = list
         .iter()
         .enumerate()

--- a/src/subcommand/history.rs
+++ b/src/subcommand/history.rs
@@ -3,9 +3,7 @@ use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::{Local, LocalResult, TimeZone};
 use clap::Args;
 use dialoguer::{theme::ColorfulTheme, Select};
-use oma_history::{
-    connect_db, find_history_by_id, list_history, HistoryListEntry, DATABASE_PATH,
-};
+use oma_history::{connect_db, find_history_by_id, list_history, HistoryListEntry, DATABASE_PATH};
 use oma_pm::apt::{AptConfig, InstallOperation, OmaAptArgs};
 use oma_pm::matches::{GetArchMethod, PackagesMatcher};
 use oma_pm::pkginfo::PtrIsNone;
@@ -281,7 +279,6 @@ fn format_summary_log(list: &[HistoryListEntry], undo: bool) -> Vec<(String, usi
             let command = &log.command;
 
             let s = format!("{}[{}] {}", format_success(log.is_success), date, command);
-
             let s = select_tui_display_msg(&s, false).to_string();
 
             (s, index)

--- a/src/subcommand/history.rs
+++ b/src/subcommand/history.rs
@@ -20,7 +20,7 @@ use crate::{
     error::OutputError,
     table::table_for_history_pending,
     utils::{dbus_check, root},
-    ALLOWCTRLC,
+    NOT_DISPLAY_ABORT,
 };
 
 use super::utils::{
@@ -47,7 +47,7 @@ impl CliExecuter for History {
             .map(|x| x.0)
             .collect::<Vec<_>>();
 
-        ALLOWCTRLC.store(true, Ordering::Relaxed);
+        NOT_DISPLAY_ABORT.store(true, Ordering::Relaxed);
 
         let mut old_selected = 0;
 

--- a/src/subcommand/install.rs
+++ b/src/subcommand/install.rs
@@ -210,11 +210,7 @@ impl CliExecuter for Install {
         CommitChanges::builder()
             .apt(apt)
             .dry_run(dry_run)
-            .request_type(SummaryType::Install(
-                pkgs.iter()
-                    .map(|x| format!("{} {}", x.raw_pkg.fullname(true), x.version_raw.version()))
-                    .collect::<Vec<_>>(),
-            ))
+            .request_type(SummaryType::Install)
             .no_fixbroken(!fix_broken)
             .no_progress(no_progress)
             .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/subcommand/install.rs
+++ b/src/subcommand/install.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use oma_history::SummaryType;
 use oma_pm::apt::AptConfig;
 use oma_pm::apt::OmaApt;
 use oma_pm::apt::OmaAptArgs;
@@ -210,7 +209,6 @@ impl CliExecuter for Install {
         CommitChanges::builder()
             .apt(apt)
             .dry_run(dry_run)
-            .request_type(SummaryType::Install)
             .no_fixbroken(!fix_broken)
             .no_progress(no_progress)
             .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -9,7 +9,7 @@ use oma_pm::{
 use tracing::info;
 
 use crate::{color_formatter, config::Config, error::OutputError, table::PagerPrinter};
-use crate::{fl, ALLOWCTRLC};
+use crate::{fl, NOT_DISPLAY_ABORT};
 use anyhow::anyhow;
 use smallvec::{smallvec, SmallVec};
 
@@ -108,7 +108,7 @@ impl CliExecuter for List {
         };
 
         let mut printer = PagerPrinter::new(stdout());
-        ALLOWCTRLC.store(true, Ordering::Relaxed);
+        NOT_DISPLAY_ABORT.store(true, Ordering::Relaxed);
 
         let mut display_tips = (false, 0);
 

--- a/src/subcommand/pick.rs
+++ b/src/subcommand/pick.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use clap::Args;
 use dialoguer::{theme::ColorfulTheme, Select};
-use oma_history::SummaryType;
 use oma_pm::{
     apt::{AptConfig, OmaApt, OmaAptArgs},
     pkginfo::OmaPackage,
@@ -204,7 +203,6 @@ impl CliExecuter for Pick {
         CommitChanges::builder()
             .apt(apt)
             .dry_run(dry_run)
-            .request_type(SummaryType::Install)
             .no_fixbroken(fix_broken)
             .no_progress(no_progress)
             .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/subcommand/pick.rs
+++ b/src/subcommand/pick.rs
@@ -204,11 +204,7 @@ impl CliExecuter for Pick {
         CommitChanges::builder()
             .apt(apt)
             .dry_run(dry_run)
-            .request_type(SummaryType::Remove(
-                pkgs.iter()
-                    .map(|x| format!("{} {}", x.raw_pkg.fullname(true), x.version_raw.version()))
-                    .collect::<Vec<_>>(),
-            ))
+            .request_type(SummaryType::Install)
             .no_fixbroken(fix_broken)
             .no_progress(no_progress)
             .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/subcommand/remove.rs
+++ b/src/subcommand/remove.rs
@@ -5,7 +5,6 @@ use clap::Args;
 use dialoguer::console::style;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Input};
-use oma_history::SummaryType;
 use oma_pm::apt::{AptConfig, OmaApt, OmaAptArgs};
 use oma_pm::matches::{GetArchMethod, PackagesMatcher};
 use tracing::{info, warn};
@@ -232,7 +231,6 @@ impl CliExecuter for Remove {
         CommitChanges::builder()
             .apt(apt)
             .dry_run(dry_run)
-            .request_type(SummaryType::Remove)
             .no_fixbroken(!fix_broken)
             .no_progress(no_progress)
             .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/subcommand/remove.rs
+++ b/src/subcommand/remove.rs
@@ -212,20 +212,6 @@ impl CliExecuter for Remove {
 
         let pb = create_progress_spinner(no_progress, fl!("resolving-dependencies"));
 
-        let remove_str = pkgs
-            .iter()
-            .map(|x| {
-                format!(
-                    "{} {}",
-                    x.raw_pkg.fullname(true),
-                    x.package(&apt.cache)
-                        .installed()
-                        .map(|x| x.version().to_string())
-                        .unwrap_or_default(),
-                )
-            })
-            .collect::<Vec<_>>();
-
         let context = apt.remove(pkgs, remove_config, no_autoremove)?;
 
         if let Some(pb) = pb {
@@ -246,7 +232,7 @@ impl CliExecuter for Remove {
         CommitChanges::builder()
             .apt(apt)
             .dry_run(dry_run)
-            .request_type(SummaryType::Remove(remove_str))
+            .request_type(SummaryType::Remove)
             .no_fixbroken(!fix_broken)
             .no_progress(no_progress)
             .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/subcommand/topics.rs
+++ b/src/subcommand/topics.rs
@@ -7,7 +7,6 @@ use inquire::{
     ui::{Color, RenderConfig, StyleSheet, Styled},
     MultiSelect,
 };
-use oma_history::SummaryType;
 use oma_pm::{
     apt::{AptConfig, FilterMode, OmaApt, OmaAptArgs, Upgrade},
     matches::{GetArchMethod, PackagesMatcher},
@@ -229,7 +228,6 @@ impl CliExecuter for Topics {
             let code = CommitChanges::builder()
                 .apt(apt)
                 .dry_run(dry_run)
-                .request_type(SummaryType::Install)
                 .no_fixbroken(!no_fixbroken)
                 .no_progress(no_progress)
                 .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/subcommand/topics.rs
+++ b/src/subcommand/topics.rs
@@ -229,10 +229,7 @@ impl CliExecuter for Topics {
             let code = CommitChanges::builder()
                 .apt(apt)
                 .dry_run(dry_run)
-                .request_type(SummaryType::TopicsChanged {
-                    add: opt_in,
-                    remove: opt_out,
-                })
+                .request_type(SummaryType::Install)
                 .no_fixbroken(!no_fixbroken)
                 .no_progress(no_progress)
                 .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/subcommand/topics.rs
+++ b/src/subcommand/topics.rs
@@ -239,6 +239,8 @@ impl CliExecuter for Topics {
                 .network_thread(config.network_thread())
                 .maybe_auth_config(auth_config)
                 .check_update(true)
+                .topics_enabled(opt_in)
+                .topics_disabled(opt_out)
                 .build()
                 .run()?;
 

--- a/src/subcommand/upgrade.rs
+++ b/src/subcommand/upgrade.rs
@@ -26,7 +26,6 @@ use oma_console::pager::PagerExit;
 use oma_history::connect_db;
 use oma_history::create_db_file;
 use oma_history::write_history_entry;
-use oma_history::SummaryType;
 use oma_pm::apt::AptConfig;
 use oma_pm::apt::OmaApt;
 use oma_pm::apt::OmaAptArgs;
@@ -350,7 +349,6 @@ impl CliExecuter for Upgrade {
 
                     write_history_entry(
                         &op,
-                        SummaryType::Upgrade,
                         {
                             let db = create_db_file(sysroot)?;
                             connect_db(db, true)?
@@ -358,6 +356,8 @@ impl CliExecuter for Upgrade {
                         dry_run,
                         start_time,
                         true,
+                        false,
+                        false,
                     )?;
 
                     history_success_tips(dry_run);
@@ -373,13 +373,14 @@ impl CliExecuter for Upgrade {
                         if retry_times == 3 {
                             write_history_entry(
                                 &op,
-                                SummaryType::Upgrade,
                                 {
                                     let db = create_db_file(sysroot)?;
                                     connect_db(db, true)?
                                 },
                                 dry_run,
                                 start_time,
+                                false,
+                                false,
                                 false,
                             )?;
                             undo_tips();

--- a/src/subcommand/upgrade.rs
+++ b/src/subcommand/upgrade.rs
@@ -12,6 +12,7 @@ use crate::subcommand::utils::write_oma_installed_status;
 use ahash::HashMap;
 use ahash::HashSet;
 use flume::unbounded;
+use oma_history::HistoryInfo;
 use oma_pm::apt::OmaOperation;
 use oma_pm::CommitNetworkConfig;
 use serde::Deserialize;
@@ -348,16 +349,20 @@ impl CliExecuter for Upgrade {
                     autoremovable_tips(ar_count, ar_size)?;
 
                     write_history_entry(
-                        &op,
                         {
                             let db = create_db_file(sysroot)?;
                             connect_db(db, true)?
                         },
                         dry_run,
-                        start_time,
-                        true,
-                        false,
-                        false,
+                        HistoryInfo {
+                            summary: &op,
+                            start_time,
+                            success: true,
+                            is_fix_broken: false,
+                            is_undo: false,
+                            topics_enabled: vec![],
+                            topics_disabled: vec![],
+                        },
                     )?;
 
                     history_success_tips(dry_run);
@@ -372,16 +377,20 @@ impl CliExecuter for Upgrade {
                     | OmaAptError::AptCxxException(_) => {
                         if retry_times == 3 {
                             write_history_entry(
-                                &op,
                                 {
                                     let db = create_db_file(sysroot)?;
                                     connect_db(db, true)?
                                 },
                                 dry_run,
-                                start_time,
-                                false,
-                                false,
-                                false,
+                                HistoryInfo {
+                                    summary: &op,
+                                    start_time,
+                                    success: false,
+                                    is_fix_broken: false,
+                                    is_undo: false,
+                                    topics_enabled: vec![],
+                                    topics_disabled: vec![],
+                                },
                             )?;
                             undo_tips();
 

--- a/src/subcommand/upgrade.rs
+++ b/src/subcommand/upgrade.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::fs::read_dir;
 use std::path::Path;
+use std::sync::atomic::Ordering;
 use std::thread;
 
 use crate::pb::RenderDownloadProgress;
@@ -9,6 +10,7 @@ use crate::subcommand::utils::display_suggest_tips;
 use crate::subcommand::utils::history_success_tips;
 use crate::subcommand::utils::undo_tips;
 use crate::subcommand::utils::write_oma_installed_status;
+use crate::NOT_ALLOW_CTRLC;
 use ahash::HashMap;
 use ahash::HashSet;
 use flume::unbounded;
@@ -345,6 +347,8 @@ impl CliExecuter for Upgrade {
                 },
             ) {
                 Ok(()) => {
+                    NOT_ALLOW_CTRLC.store(true, Ordering::Relaxed);
+
                     write_oma_installed_status()?;
                     autoremovable_tips(ar_count, ar_size)?;
 
@@ -376,6 +380,8 @@ impl CliExecuter for Upgrade {
                     | OmaAptError::AptError(_)
                     | OmaAptError::AptCxxException(_) => {
                         if retry_times == 3 {
+                            NOT_ALLOW_CTRLC.store(true, Ordering::Relaxed);
+
                             write_history_entry(
                                 {
                                     let db = create_db_file(sysroot)?;

--- a/src/subcommand/upgrade.rs
+++ b/src/subcommand/upgrade.rs
@@ -297,7 +297,7 @@ impl CliExecuter for Upgrade {
 
             let install = &op.install;
             let remove = &op.remove;
-            let disk_size = &op.disk_size;
+            let disk_size = &op.disk_size_delta;
             let (ar_count, ar_size) = op.autoremovable;
             let (suggest, recommend) = (&op.suggest, &op.recommend);
 
@@ -313,7 +313,7 @@ impl CliExecuter for Upgrade {
                 match table_for_install_pending(
                     install,
                     remove,
-                    disk_size,
+                    *disk_size,
                     Some(matches_tum),
                     !yes,
                     dry_run,

--- a/src/subcommand/upgrade.rs
+++ b/src/subcommand/upgrade.rs
@@ -324,12 +324,6 @@ impl CliExecuter for Upgrade {
                 }
             }
 
-            let typ = SummaryType::Upgrade(
-                pkgs.iter()
-                    .map(|x| format!("{} {}", x.raw_pkg.fullname(true), x.version_raw.version()))
-                    .collect::<Vec<_>>(),
-            );
-
             let start_time = Local::now().timestamp();
 
             match apt.commit(
@@ -356,7 +350,7 @@ impl CliExecuter for Upgrade {
 
                     write_history_entry(
                         &op,
-                        typ,
+                        SummaryType::Upgrade,
                         {
                             let db = create_db_file(sysroot)?;
                             connect_db(db, true)?
@@ -379,17 +373,7 @@ impl CliExecuter for Upgrade {
                         if retry_times == 3 {
                             write_history_entry(
                                 &op,
-                                SummaryType::Upgrade(
-                                    pkgs.iter()
-                                        .map(|x| {
-                                            format!(
-                                                "{} {}",
-                                                x.raw_pkg.fullname(true),
-                                                x.version_raw.version()
-                                            )
-                                        })
-                                        .collect::<Vec<_>>(),
-                                ),
+                                SummaryType::Upgrade,
                                 {
                                     let db = create_db_file(sysroot)?;
                                     connect_db(db, true)?

--- a/src/subcommand/utils.rs
+++ b/src/subcommand/utils.rs
@@ -385,7 +385,7 @@ impl CommitChanges<'_> {
 
         let install = &op.install;
         let remove = &op.remove;
-        let disk_size = &op.disk_size;
+        let disk_size = &op.disk_size_delta;
         let (ar_count, ar_size) = op.autoremovable;
         let (suggest, recommend) = (&op.suggest, &op.recommend);
 
@@ -401,7 +401,7 @@ impl CommitChanges<'_> {
             match table_for_install_pending(
                 install,
                 remove,
-                disk_size,
+                *disk_size,
                 Some(matches_tum),
                 !yes,
                 dry_run,
@@ -411,7 +411,7 @@ impl CommitChanges<'_> {
                 x @ PagerExit::DryRun => return Ok(x.into()),
             }
         } else {
-            match table_for_install_pending(install, remove, disk_size, None, !yes, dry_run)? {
+            match table_for_install_pending(install, remove, *disk_size, None, !yes, dry_run)? {
                 PagerExit::NormalExit => {}
                 x @ PagerExit::Sigint => return Ok(x.into()),
                 x @ PagerExit::DryRun => return Ok(x.into()),

--- a/src/subcommand/utils.rs
+++ b/src/subcommand/utils.rs
@@ -53,7 +53,6 @@ use oma_contents::searcher::Mode;
 use oma_history::connect_db;
 use oma_history::create_db_file;
 use oma_history::write_history_entry;
-use oma_history::SummaryType;
 use oma_pm::apt::AptConfig;
 use oma_pm::apt::FilterMode;
 use oma_pm::apt::OmaApt;
@@ -281,7 +280,10 @@ pub(crate) struct CommitChanges<'a> {
     apt: OmaApt,
     #[builder(default = true)]
     dry_run: bool,
-    request_type: SummaryType,
+    #[builder(default)]
+    is_fixbroken: bool,
+    #[builder(default)]
+    is_undo: bool,
     #[builder(default = true)]
     no_fixbroken: bool,
     #[builder(default)]
@@ -309,7 +311,8 @@ impl CommitChanges<'_> {
         let CommitChanges {
             mut apt,
             dry_run,
-            request_type: typ,
+            is_fixbroken,
+            is_undo,
             no_fixbroken,
             no_progress,
             sysroot,
@@ -447,7 +450,6 @@ impl CommitChanges<'_> {
 
                 write_history_entry(
                     &op,
-                    typ,
                     {
                         let db = create_db_file(sysroot)?;
                         connect_db(db, true)?
@@ -455,6 +457,8 @@ impl CommitChanges<'_> {
                     dry_run,
                     start_time,
                     true,
+                    is_fixbroken,
+                    is_undo
                 )?;
 
                 history_success_tips(dry_run);
@@ -466,7 +470,6 @@ impl CommitChanges<'_> {
                 undo_tips();
                 write_history_entry(
                     &op,
-                    typ,
                     {
                         let db = create_db_file(sysroot)?;
                         connect_db(db, true)?
@@ -474,6 +477,8 @@ impl CommitChanges<'_> {
                     dry_run,
                     start_time,
                     false,
+                    is_fixbroken,
+                    is_undo,
                 )?;
                 Err(e.into())
             }

--- a/src/subcommand/utils.rs
+++ b/src/subcommand/utils.rs
@@ -31,6 +31,7 @@ use crate::upgrade::get_matches_tum;
 use crate::upgrade::get_tum;
 use crate::HTTP_CLIENT;
 use crate::LOCKED;
+use crate::NOT_ALLOW_CTRLC;
 use crate::RT;
 use crate::WRITER;
 use ahash::HashSet;
@@ -452,6 +453,7 @@ impl CommitChanges<'_> {
 
         match res {
             Ok(_) => {
+                NOT_ALLOW_CTRLC.store(true, Ordering::Relaxed);
                 write_oma_installed_status()?;
                 autoremovable_tips(ar_count, ar_size)?;
 
@@ -478,6 +480,7 @@ impl CommitChanges<'_> {
                 Ok(0)
             }
             Err(e) => {
+                NOT_ALLOW_CTRLC.store(true, Ordering::Relaxed);
                 undo_tips();
                 write_history_entry(
                     {

--- a/src/table.rs
+++ b/src/table.rs
@@ -8,7 +8,7 @@ use std::sync::LazyLock;
 use crate::console::style;
 use crate::error::OutputError;
 use crate::upgrade::TopicUpdateEntryRef;
-use crate::{color_formatter, fl, ALLOWCTRLC, WRITER};
+use crate::{color_formatter, fl, NOT_DISPLAY_ABORT, WRITER};
 use ahash::HashMap;
 use ahash::HashSet;
 use oma_console::indicatif::HumanBytes;
@@ -204,7 +204,7 @@ pub fn oma_display_with_normal_output(
     len: usize,
 ) -> Result<Pager<'static>, OutputError> {
     if !is_question {
-        ALLOWCTRLC.store(true, Ordering::Relaxed);
+        NOT_DISPLAY_ABORT.store(true, Ordering::Relaxed);
     }
 
     let pager = if len < WRITER.get_height().into() {

--- a/src/table.rs
+++ b/src/table.rs
@@ -311,7 +311,7 @@ impl<W: Write> PagerPrinter<W> {
 pub fn table_for_install_pending(
     install: &[InstallEntry],
     remove: &[RemoveEntry],
-    disk_size: &(Box<str>, u64),
+    disk_size: i64,
     tum: Option<HashMap<&str, TopicUpdateEntryRef<'_>>>,
     is_pager: bool,
     dry_run: bool,
@@ -392,7 +392,7 @@ pub fn table_for_install_pending(
 pub fn table_for_history_pending(
     install: &[InstallHistoryEntry],
     remove: &[RemoveHistoryEntry],
-    disk_size: &(Box<str>, u64),
+    disk_size: i64,
 ) -> Result<(), OutputError> {
     let mut pager = Pager::external(
         &OmaPagerUIText { is_question: false },
@@ -451,7 +451,7 @@ fn print_pending_inner<W: Write>(
     mut printer: PagerPrinter<W>,
     remove: &[RemoveEntryDisplay],
     install: &[InstallEntryDisplay],
-    disk_size: &(Box<str>, u64),
+    disk_size: i64,
     total_download_size: u64,
     tum: &Option<HashMap<&str, TopicUpdateEntryRef<'_>>>,
 ) {
@@ -602,14 +602,18 @@ fn print_pending_inner<W: Write>(
         ))
         .ok();
 
-    let (symbol, abs_install_size_change) = disk_size;
+    let (symbol, abs_install_size_change) = if disk_size >= 0 {
+        ("+", disk_size as u64)
+    } else {
+        ("-", (0 - disk_size) as u64)
+    };
 
     printer
         .println(format!(
             "{}{}{}",
             style(fl!("change-storage-usage")).bold(),
             symbol,
-            HumanBytes(*abs_install_size_change)
+            HumanBytes(abs_install_size_change)
         ))
         .ok();
     printer.println("").ok();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,8 +4,11 @@ use std::{
 };
 
 use clap::Args;
-use oma_console::pager::{exit_tui, prepare_create_tui};
-use oma_history::SummaryType;
+use oma_console::{
+    indicatif::ProgressBar,
+    pager::{exit_tui, prepare_create_tui},
+    pb::spinner_style,
+};
 use oma_pm::{
     apt::{AptConfig, OmaApt, OmaAptArgs, Upgrade},
     search::IndiciumSearch,
@@ -245,7 +248,6 @@ impl CliExecuter for Tui {
             code = CommitChanges::builder()
                 .apt(apt)
                 .dry_run(dry_run)
-                .request_type(SummaryType::Install)
                 .no_fixbroken(!fix_broken)
                 .no_progress(no_progress)
                 .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -245,7 +245,7 @@ impl CliExecuter for Tui {
             code = CommitChanges::builder()
                 .apt(apt)
                 .dry_run(dry_run)
-                .request_type(SummaryType::Changes)
+                .request_type(SummaryType::Install)
                 .no_fixbroken(!fix_broken)
                 .no_progress(no_progress)
                 .sysroot(sysroot.to_string_lossy().to_string())

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,11 +4,7 @@ use std::{
 };
 
 use clap::Args;
-use oma_console::{
-    indicatif::ProgressBar,
-    pager::{exit_tui, prepare_create_tui},
-    pb::spinner_style,
-};
+use oma_console::pager::{exit_tui, prepare_create_tui};
 use oma_pm::{
     apt::{AptConfig, OmaApt, OmaAptArgs, Upgrade},
     search::IndiciumSearch,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{color_formatter, fl, RT, WRITER};
-use crate::{error::OutputError, SPAWN_NEW_OMA};
+use crate::{error::OutputError, NOT_ALLOW_CTRLC};
 use anyhow::anyhow;
 use dialoguer::{console::style, theme::ColorfulTheme, Confirm};
 use oma_console::{
@@ -41,7 +41,7 @@ pub fn root() -> Result<()> {
         info!("{}", fl!("pkexec-tips-1"));
         info!("{}", fl!("pkexec-tips-2"));
 
-        SPAWN_NEW_OMA.store(true, Ordering::Relaxed);
+        NOT_ALLOW_CTRLC.store(true, Ordering::Relaxed);
 
         let out = Command::new("pkexec")
             .args(args)


### PR DESCRIPTION
## TODO

- [x] re-design table, remove `serde-json` dependency
- [x] re-design `SummaryType`
- [x] Migration, from the old table

## Research

The old `oma history` output had titles that didn't necessarily describe what they did, e.g. changes made via `oma tui` were attributed to “Changes”, how should we redesign the titles in the menu? This will also affect how some fields are stored in the database

The new `oma history` will be more flexible and have more possible ways of querying the data the user wants, do we need to categorize some of the common queries into subcommands in `oma history`?

How should I migrate from the old table to the new one?