### PR TITLE
fix(oma-pm,oma-pm-operate-type)!: fix calculate need disk size

### DIFF
--- a/oma-pm-operation-type/src/lib.rs
+++ b/oma-pm-operation-type/src/lib.rs
@@ -14,6 +14,7 @@ pub struct OmaOperation {
     pub total_download_size: u64,
     pub suggest: Vec<(String, String)>,
     pub recommend: Vec<(String, String)>,
+    pub max_old_installed_size: u64,
 }
 
 impl Display for OmaOperation {


### PR DESCRIPTION
dpkg unpacks the new version of the file before deleting the original, so we need to add the installed size of the largest of the packages being changed