### PR TITLE
chore(oma-mirror): switch `serde_yaml` to `serde_yaml_ng`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,7 +3215,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "snafu",
  "tracing",
 ]
@@ -4432,10 +4432,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.9.0",
  "itoa",

--- a/oma-mirror/Cargo.toml
+++ b/oma-mirror/Cargo.toml
@@ -6,7 +6,7 @@ description = "Library to handle AOSC OS APT configuration (sources.list)"
 license = "MIT"
 
 [dependencies]
-serde_yaml = "0.9"
+serde_yaml = { version = "0.10", package = "serde_yaml_ng" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.8.5"


### PR DESCRIPTION
`serde_yaml` is unmaintained