### PR TITLE
chore(data): split Debian (non-AOSC) 50oma.conf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ assets = [
     ["target/release/oma", "usr/bin/", "755"],
     ["README.md", "usr/share/doc/oma/README", "644"],
     ["data/config/oma-debian.toml", "etc/oma.toml", "644"],
-    ["data/apt.conf.d/50oma.conf", "etc/apt/apt.conf.d/50oma.conf", "644"],
+    ["data/apt.conf.d/50oma-debian.conf", "etc/apt/apt.conf.d/50oma.conf", "644"],
     ["data/dbus/oma-dbus.conf", "usr/share/dbus-1/system.d/oma-dbus.conf", "644"],
     ["data/policykit/io.aosc.oma.apply.policy", "usr/share/polkit-1/actions/io.aosc.oma.apply.policy", "644" ],
     ["completions/oma.bash", "usr/share/bash-completion/completions/oma.bash", "644"],

--- a/data/apt.conf.d/50oma-debian.conf
+++ b/data/apt.conf.d/50oma-debian.conf
@@ -1,0 +1,66 @@
+## To make sure that apt update doesn't delete the contents downloaded by oma refresh
+## let apt download Contents and BinContents as well.
+
+Acquire::IndexTargets {
+    deb::Contents-deb  {
+        MetaKey "$(COMPONENT)/Contents-$(ARCHITECTURE)";
+        ShortDescription "Contents-$(ARCHITECTURE)";
+        Description "$(RELEASE)/$(COMPONENT) $(ARCHITECTURE) Contents (deb)";
+
+        flatMetaKey "Contents-$(ARCHITECTURE)";
+        flatDescription "$(RELEASE) Contents (deb)";
+        PDiffs "true";
+        KeepCompressed "true";
+    };
+
+    deb::BinContents-deb  {
+        MetaKey "$(COMPONENT)/BinContents-$(ARCHITECTURE)";
+        ShortDescription "BinContents-$(ARCHITECTURE)";
+        Description "$(RELEASE)/$(COMPONENT) $(ARCHITECTURE) BinContents (deb)";
+
+        flatMetaKey "BinContents-$(ARCHITECTURE)";
+        flatDescription "$(RELEASE) BinContents (deb)";
+        PDiffs "true";
+        KeepCompressed "false";
+    };
+
+    # Download Contents for source files if there is a deb-src
+    # line
+    deb-src::Contents-dsc  {
+        MetaKey "$(COMPONENT)/Contents-source";
+        ShortDescription "Contents-source";
+        Description "$(RELEASE)/$(COMPONENT) source Contents (dsc)";
+
+        flatMetaKey "Contents-source";
+        flatDescription "$(RELEASE) Contents (dsc)";
+        PDiffs "true";
+        KeepCompressed "true";
+        DefaultEnabled "false";
+    };
+
+    # Configuration for downloading Contents files for
+    # debian-installer packages (udebs).
+    deb::Contents-udeb  {
+        MetaKey "$(COMPONENT)/Contents-udeb-$(ARCHITECTURE)";
+        ShortDescription "Contents-udeb-$(ARCHITECTURE)";
+        Description "$(RELEASE)/$(COMPONENT) $(ARCHITECTURE) Contents (udeb)";
+
+        flatMetaKey "Contents-udeb-$(ARCHITECTURE)";
+        flatDescription "$(RELEASE) Contents (udeb)";
+        KeepCompressed "true";
+        PDiffs "true";
+        DefaultEnabled "false";
+    };
+
+    ### FALLBACKS
+    deb::Contents-deb-legacy {
+        MetaKey "Contents-$(ARCHITECTURE)";
+        ShortDescription "Contents-$(ARCHITECTURE)";
+        Description "$(RELEASE) $(ARCHITECTURE) Contents (deb)";
+
+        PDiffs "true";
+        KeepCompressed "true";
+        Fallback-Of "Contents-deb";
+        Identifier "Contents-deb";
+    }
+}


### PR DESCRIPTION
Split 50oma-debian.conf from 50oma.conf so that TUM is not fetched. This was not supposed to be an issue but with the following snippet of APT configuration from Ubuntu 22.04:

  deb http://security.ubuntu.com/ubuntu/ jammy-security main restricted
  deb http://security.ubuntu.com/ubuntu/ jammy-security universe
  deb http://security.ubuntu.com/ubuntu/ jammy-security multiverse

When 50oma.conf is configured to fetch TUM data (updates.json), `apt update' would throw the following warnings:

  W: Target TUM (updates.json) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:2
  W: Target TUM (updates.json) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list:3

We will have to investigate this further but for now, split out the configuration as a workaround.