### PR TITLE
chore: split `oma mirror` from aosc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,8 @@ unic-langid = "0.9.5"
 sys-locale = "0.3"
 
 [features]
-aosc = ["dep:oma-topics", "dep:oma-mirror", "oma-refresh/aosc", "oma-pm/aosc", "oma-contents/aosc", "reqwest/blocking"]
+aosc = ["dep:oma-topics", "oma-refresh/aosc", "oma-pm/aosc", "oma-contents/aosc", "dep:oma-mirror", "reqwest/blocking"]
+mirror = []
 sequoia-openssl-backend = ["oma-refresh/sequoia-openssl-backend"]
 sequoia-nettle-backend = ["oma-refresh/sequoia-nettle-backend"]
 egg = ["dep:colored", "dep:image"]
@@ -82,7 +83,7 @@ rustls = ["reqwest/rustls-tls", "oma-fetch/rustls", "oma-refresh/rustls", "oma-t
 openssl = ["reqwest/native-tls", "oma-fetch/native-tls", "oma-refresh/native-tls", "oma-topics/native-tls"]
 nice-setup = ["sequoia-nettle-backend", "rustls", "oma-refresh/apt"]
 openssl-setup = ["sequoia-openssl-backend", "openssl", "oma-refresh/apt"]
-default = ["aosc", "nice-setup"]
+default = ["aosc", "nice-setup", "mirror"]
 
 [workspace]
 members = ["oma-contents", "oma-console", "oma-topics", "oma-fetch", "oma-refresh", "oma-utils", "oma-pm", "oma-history", "oma-pm-operation-type", "oma-repo-verify", "oma-mirror", "apt-auth-config"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -33,9 +33,6 @@ use crate::{
 };
 
 #[cfg(feature = "aosc")]
-use crate::mirror::CliMirror;
-
-#[cfg(feature = "aosc")]
 use crate::topics::Topics;
 
 #[enum_dispatch]
@@ -110,10 +107,10 @@ pub enum SubCmd {
     /// Manage testing topics enrollment
     #[command(visible_alias = "topic")]
     Topics(Topics),
-    #[cfg(feature = "aosc")]
+    #[cfg(feature = "mirror")]
     /// Manage Mirrors enrollment
     #[command(visible_alias = "mirrors")]
-    Mirror(CliMirror),
+    Mirror(crate::mirror::CliMirror),
     /// purge (like apt purge) the specified package(s)
     #[command(hide = true)]
     Purge(Purge),

--- a/src/subcommand/mod.rs
+++ b/src/subcommand/mod.rs
@@ -9,7 +9,7 @@ pub mod history;
 pub mod install;
 pub mod list;
 pub mod mark;
-#[cfg(feature = "aosc")]
+#[cfg(feature = "mirror")]
 pub mod mirror;
 pub mod pick;
 pub mod rdepends;


### PR DESCRIPTION
In environments such as 2k0300, `oma mirror` will not be available, so for the convenience of users for this purpose, `oma mirror` is listed as a separate `mirror` feature.