### PR TITLE
change: polkit rules to fix remote access

### DIFF
--- a/data/policykit/io.aosc.oma.apply.policy
+++ b/data/policykit/io.aosc.oma.apply.policy
@@ -13,8 +13,8 @@
     <message xml:lang="zh_CN">应用系统软件包修改需要授权</message>
     <icon_name>preferences-system</icon_name>
     <defaults>
-      <allow_any>no</allow_any>
-      <allow_inactive>no</allow_inactive>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
       <allow_active>auth_admin</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/oma</annotate>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,6 +29,8 @@ pub fn root() -> Result<()> {
 
     let mut args = std::env::args().collect::<Vec<_>>();
 
+    // 检测是否有 DISPLAY，如果有，则在提权时使用 pkexec
+    // 通常情况下 SSH 连接不会有 DISPLAY 环境变量，除非开启 X11 Forwarding
     if (env::var("DISPLAY").is_ok() || env::var("WAYLAND_DISPLAY").is_ok()) && !is_wsl() {
         // Workaround: 使用 pkexec 执行其它程序时，若你指定了相对路径
         // pkexec 并不会以当前路径作为起点寻求这个位置


### PR DESCRIPTION
This commit allows remote session like RDP or X11 Forwarding to use Polkit or Polkit-Agent.