### PR TITLE
fix: make entries in TopicUpdateManifest pub

### DIFF
--- a/oma-tum/src/lib.rs
+++ b/oma-tum/src/lib.rs
@@ -13,7 +13,7 @@ use tracing::warn;
 #[derive(Deserialize, Debug)]
 pub struct TopicUpdateManifest {
     #[serde(flatten)]
-    entries: HashMap<String, TopicUpdateEntry>,
+    pub entries: HashMap<String, TopicUpdateEntry>,
 }
 
 #[inline]


### PR DESCRIPTION
Made a small change to the `oma-tum/src/lib.rs` file.
Making entries in TopicUpdateManifest pub for aoska to parse the entries.