### PR TITLE
fix(policykit): add allow_gui annotation

### DIFF
--- a/data/policykit/io.aosc.oma.apply.policy
+++ b/data/policykit/io.aosc.oma.apply.policy
@@ -18,6 +18,7 @@
       <allow_active>auth_admin</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/oma</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
 
 </policyconfig>


### PR DESCRIPTION
Previously, when invoking oma via polkit, oma loses detection for the $DISPLAY variable, user prompts would then assume that oma was ran in non-graphical environments.

Add this notation for "legacy applications" to fix this issue.