### PR TITLE
ci: fix check for oma-preview branch existence, rebase-push logic

### DIFF
--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -38,7 +38,7 @@ jobs:
           git config user.name "eatradish"
           git config user.email "sakiiily@aosc.io"
           # Check if the `oma-preview' branch exists, create if not.
-          if ! git rev-parse --verify oma-preview > /dev/null; then
+          if ! git rev-parse --verify origin/oma-preview > /dev/null; then
               git checkout -b oma-preview
           else
               # Checkout the existing branch.
@@ -54,7 +54,7 @@ jobs:
           git add .
           git commit -m "oma: update to ${DPKG_VER}"
           # Note: Git not allow tilde (~) in branch names, so use dash here.
-          git push --set-upstream origin oma-preview
+          git push --set-upstream --force origin oma-preview
           uri=$(echo -e "Topic Description\n-----------------\n\n- oma: update to ${DPKG_VER}\n\nPackage(s) Affected\n-------------------\n\n- oma: ${DPKG_VER}\n\nSecurity Update?\n----------------\n\nNo\n\nBuild Order\n-----------\n\n\`\`\`\n#buildit oma\n\`\`\`\n\nTest Build(s) Done\n------------------\n\n**Primary Architectures**\n\n- [ ] AMD64 \`amd64\`\n- [ ] AArch64 \`arm64\`\n- [ ] LoongArch 64-bit \`loongarch64\`\n\n**Secondary Architectures**\n\n- [ ] Loongson 3 \`loongson3\`\n- [ ] PowerPC 64-bit (Little Endian) \`ppc64el\`\n- [ ] RISC-V 64-bit \`riscv64\`\n\n\n" | \
                 gh pr create -d --title "oma: update to ${DPKG_VER}" -l "upgrade,preview" -F -)
           num=$(basename ${uri})


### PR DESCRIPTION
The last implementation checked for a local `oma-preview' branch with `git rev-parse', this is not correct as that branch was never checked out. This caused the workflow to create a new `oma-preview' branch unconditionally, destroying previous history in that process.

Also, rebased branches must be pushed forcefully, so specify `--force' with the push command.