### PR TITLE
ci: temporary not publish debian11 package

### DIFF
--- a/.github/workflows/deb_amd64.yml
+++ b/.github/workflows/deb_amd64.yml
@@ -14,7 +14,7 @@ jobs:
             "ubuntu:20.04",
             "ubuntu:22.04",
             "ubuntu:24.04",
-            "debian:11",
+            # "debian:11",
             "debian:12",
             "debian:trixie",
             "linuxdeepin/deepin",

--- a/.github/workflows/deb_arm64.yml
+++ b/.github/workflows/deb_arm64.yml
@@ -14,7 +14,7 @@ jobs:
             "arm64v8/ubuntu:20.04",
             "arm64v8/ubuntu:22.04",
             "arm64v8/ubuntu:24.04",
-            "arm64v8/debian:11",
+            # "arm64v8/debian:11",
             "arm64v8/debian:12",
             "arm64v8/debian:trixie",
             "linuxdeepin/deepin:beige-arm64-v1.4.0",


### PR DESCRIPTION
```
   Compiling oma v1.21.0-rc.1 (/oma)
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/rustcfbIfcK/symbols.o" "<359 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/tmp/rustcfbIfcK/{liboma_apt-b2e6e1fb7ca27be7.rlib,libcxx-bf91f6f2fd4e9cac.rlib,liblink_cplusplus-1de963ed9e61a14e.rlib,liblibsqlite3_sys-3c26806c9b57f725.rlib,libring-d159ed07f1c3fa49.rlib,libzstd_sys-6693a21698c7deac.rlib,liblzzzz-4c1698d662505cbd.rlib}.rlib" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lnettle" "-lhogweed" "-lgmp" "-lapt-pkg" "-lstdc++" "-llzma" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcfbIfcK/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/oma/target/release/build/lzzzz-3dead1a5b8b43eb3/out" "-L" "/oma/target/release/build/zstd-sys-be4ca9ffe64edceb/out" "-L" "/oma/target/release/build/ring-1abd5da64f40ba6e/out" "-L" "/oma/target/release/build/libsqlite3-sys-0a0bc5f20bd026d7/out" "-L" "/oma/target/release/build/cxx-8a9fe54c7c8f47f5/out" "-L" "/oma/target/release/build/link-cplusplus-72c886bee2bd8e21/out" "-L" "/oma/target/release/build/oma-apt-f92b48358ba4456a/out" "-L" "/usr/lib/x86_64-linux-gnu" "-L" "/usr/lib/x86_64-linux-gnu" "-L" "/usr/lib/x86_64-linux-gnu" "-L" "/usr/lib/x86_64-linux-gnu" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/oma/target/release/deps/oma-139ca5f9180b1411" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-Wl,--strip-debug" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld: /oma/target/release/deps/oma-139ca5f9180b1411.compression_codecs-c117f42bf0f141e5.compression_codecs.ad496668f5050982-cgu.0.rcgu.o.rcgu.o: in function `compression_codecs::lzma::params::<impl core::convert::TryFrom<&compression_codecs::lzma::params::LzmaDecoderParams> for liblzma::stream::Stream>::try_from':
          compression_codecs.ad496668f5050982-cgu.0:(.text._ZN18compression_codecs4lzma6params139_$LT$impl$u20$core..convert..TryFrom$LT$$RF$compression_codecs..lzma..params..LzmaDecoderParams$GT$$u20$for$u20$liblzma..stream..Stream$GT$8try_from17h4d6d030d33c79391E+0x253): undefined reference to `lzma_lzip_decoder'
          collect2: error: ld returned 1 exit status

  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)

error: could not compile `oma` (bin "oma") due to 1 previous error
error: Recipe `deb` failed on line 2 with exit code 101
```