### PR TITLE
ci(deb_loong64): use Debian container snapshot on 20251209

### DIFF
--- a/.github/workflows/deb_loong64.yml
+++ b/.github/workflows/deb_loong64.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         target:
           [
-            "lcr.loongnix.cn/library/debian",
+            "lcr.loongnix.cn/library/debian:sid-20251209",
             # "linuxdeepin/deepin:beige-loong64-v1.4.0", 编译 cargo-deb 会卡住
           ]
     container:


### PR DESCRIPTION
This is the last known version to have good dependencies. As loong64 is now transitioning as an official port, they have ceased to upload dependencies to keep dependencies consistent with debian-ports updates.