### PR TITLE
Move log error handler from `AsyncPoolSink` to `Logger`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -365,14 +365,6 @@ fn init_logger(oma: &OhManagerAilurus) -> anyhow::Result<PathBuf> {
         Ok(file_sink) => Some(
             AsyncPoolSink::builder()
                 .sink(Arc::new(file_sink))
-                .error_handler(|err| {
-                    match err {
-                        spdlog::Error::SendToChannel(SendToChannelError::Full, _) => {
-                            // Ignore, the async pool sink is dropping logs
-                        }
-                        err => spdlog::ErrorHandler::default().call(err),
-                    }
-                })
                 .overflow_policy(spdlog::sink::OverflowPolicy::DropIncoming)
                 .build()
                 .unwrap(),
@@ -395,6 +387,14 @@ fn init_logger(oma: &OhManagerAilurus) -> anyhow::Result<PathBuf> {
     logger_builder
         .level_filter(LevelFilter::All)
         .flush_level_filter(LevelFilter::All)
+        .error_handler(|err| {
+            match err {
+                spdlog::Error::SendToChannel(SendToChannelError::Full, _) => {
+                    // Ignore, the async pool sink is dropping logs
+                }
+                err => spdlog::ErrorHandler::default().call(err),
+            }
+        })
         .sink(Arc::new(stream_sink));
 
     if let Some(file_sink) = file_sink {


### PR DESCRIPTION
Follow-up #676.

Because the error `SendToChannel` is returned directly to logger, so the error handler of the sink will not be called for it.

This is somewhat of a pitfall. I'll consider later whether I should redesign the error handling mechanism in spdlog-rs upstream.