### PR TITLE
refactor(oma-fetch): rewrite HTTP download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,6 +3145,7 @@ dependencies = [
  "faster-hex",
  "flume",
  "futures",
+ "headers",
  "liblzma",
  "md-5",
  "reqwest",
@@ -4366,6 +4391,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/oma-fetch/Cargo.toml
+++ b/oma-fetch/Cargo.toml
@@ -39,6 +39,7 @@ tokio-util = { version = "0.7", features = ["compat"] }
 md-5 = "0.10.6"
 bon = "3"
 snafu = "0.9"
+headers = "0.4.1"
 
 [dev-dependencies]
 tokio = { version = "1.42", features = ["macros", "rt-multi-thread"] }

--- a/oma-fetch/src/checksum.rs
+++ b/oma-fetch/src/checksum.rs
@@ -14,6 +14,7 @@ pub enum Checksum {
 
 #[derive(Clone, Debug)]
 pub enum ChecksumValidator {
+    None,
     Sha256((Vec<u8>, Sha256)),
     Sha512((Vec<u8>, Sha512)),
     Md5((Vec<u8>, Md5)),
@@ -22,14 +23,25 @@ pub enum ChecksumValidator {
 impl ChecksumValidator {
     pub fn update(&mut self, data: impl AsRef<[u8]>) {
         match self {
+            ChecksumValidator::None => {}
             ChecksumValidator::Sha256((_, v)) => v.update(data),
             ChecksumValidator::Sha512((_, v)) => v.update(data),
             ChecksumValidator::Md5((_, v)) => v.update(data),
         }
     }
 
+    pub fn reset(&mut self) {
+        match self {
+            ChecksumValidator::None => {}
+            ChecksumValidator::Sha256((_, v)) => v.reset(),
+            ChecksumValidator::Sha512((_, v)) => v.reset(),
+            ChecksumValidator::Md5((_, v)) => v.reset(),
+        }
+    }
+
     pub fn finish(&self) -> bool {
         match self {
+            ChecksumValidator::None => true,
             ChecksumValidator::Sha256((c, v)) => c == &v.clone().finalize().to_vec(),
             ChecksumValidator::Sha512((c, v)) => c == &v.clone().finalize().to_vec(),
             ChecksumValidator::Md5((c, v)) => c == &v.clone().finalize().to_vec(),

--- a/oma-fetch/src/download.rs
+++ b/oma-fetch/src/download.rs
@@ -1,8 +1,11 @@
-use crate::{CompressFile, DownloadSource, Event, checksum::ChecksumValidator, send_request};
+use crate::{CompressType, DownloadSource, Event, checksum::ChecksumValidator, send_request};
 use std::{
     borrow::Cow,
     io::{self, SeekFrom},
     path::Path,
+    pin::Pin,
+    sync::atomic::{AtomicUsize, Ordering},
+    task::{Context, Poll},
     time::Duration,
 };
 
@@ -10,11 +13,9 @@ use async_compression::futures::bufread::{
     BzDecoder, GzipDecoder, Lz4Decoder, LzmaDecoder, XzDecoder, ZstdDecoder,
 };
 use bon::bon;
-use futures::{AsyncRead, TryStreamExt, io::BufReader};
-use reqwest::{
-    Client, Method, RequestBuilder,
-    header::{ACCEPT_RANGES, CONTENT_LENGTH, HeaderValue, RANGE},
-};
+use futures::{AsyncBufRead, AsyncRead, TryStreamExt, io::BufReader};
+use headers::{ContentLength, ContentRange, HeaderMapExt};
+use reqwest::{Client, Method, RequestBuilder, StatusCode, header::RANGE};
 use snafu::{ResultExt, Snafu};
 use tokio::{
     fs::{self, File},
@@ -45,7 +46,7 @@ pub(crate) struct SingleDownloader<'a> {
     retry_times: usize,
     msg: Option<Cow<'static, str>>,
     download_list_index: usize,
-    file_type: CompressFile,
+    file_type: CompressType,
     timeout: Duration,
 }
 
@@ -78,7 +79,7 @@ pub enum SingleDownloadError {
     Write { source: io::Error },
     #[snafu(display("Failed to flush file"))]
     Flush { source: io::Error },
-    #[snafu(display("Failed to Remove file"))]
+    #[snafu(display("Failed to remove file"))]
     Remove { source: io::Error },
     #[snafu(display("Failed to create symlink"))]
     CreateSymlink { source: io::Error },
@@ -104,7 +105,7 @@ impl<'a> SingleDownloader<'a> {
         retry_times: usize,
         msg: Option<Cow<'static, str>>,
         download_list_index: usize,
-        file_type: CompressFile,
+        file_type: CompressType,
         timeout: Duration,
     ) -> Result<SingleDownloader<'a>, BuilderError> {
         if entry.source.is_empty() {
@@ -251,12 +252,10 @@ impl<'a> SingleDownloader<'a> {
     ) -> Result<bool, SingleDownloadError> {
         let file = self.entry.dir.join(&*self.entry.filename);
         let file_exist = file.exists();
-        let mut file_size = file.metadata().ok().map(|x| x.len()).unwrap_or(0);
+        let file_size = file.metadata().ok().map(|x| x.len()).unwrap_or(0);
 
         trace!("{} Exist file size is: {file_size}", file.display());
         trace!("{} download url is: {}", file.display(), source.url);
-        let mut dest = None;
-        let mut validator = None;
         let is_symlink = file.is_symlink();
 
         debug!("file {} is symlink = {}", file.display(), is_symlink);
@@ -265,51 +264,50 @@ impl<'a> SingleDownloader<'a> {
             tokio::fs::remove_file(&file).await.context(RemoveSnafu)?;
         }
 
-        // 如果要下载的文件已经存在，则验证 Checksum 是否正确，若正确则添加总进度条的进度，并返回
-        // 如果不存在，则继续往下走
+        // downloaded HTTP content representation size
+        let mut downloaded_size: u64 = 0;
+        let mut old_downloaded_size: u64 = 0;
+
+        let mut validator = self
+            .entry
+            .hash
+            .as_ref()
+            .map(|hash| hash.get_validator())
+            .unwrap_or(ChecksumValidator::None);
+
         if file_exist && !is_symlink {
             trace!(
                 "File {} already exists, verifying checksum ...",
                 self.entry.filename
             );
+            downloaded_size = file_size;
 
             if let Some(hash) = &self.entry.hash {
                 trace!("Hash {} exists for the existing file.", hash);
 
                 let mut f = tokio::fs::OpenOptions::new()
-                    .write(true)
                     .read(true)
                     .open(&file)
                     .await
-                    .context(OpenAsWriteModeSnafu)?;
+                    .context(OpenSnafu)?;
 
-                trace!("oma opened file {} read/write.", self.entry.filename);
-
-                let mut v = hash.get_validator();
-
-                trace!("Validator created.");
-
-                let (read, finish) = checksum(callback, &mut f, &mut v).await;
+                let (read, finish) = checksum(callback, &mut f, &mut validator).await;
 
                 if finish {
-                    trace!("Checksum {} matches, cache hit!", self.entry.filename);
-
+                    trace!("checksum of {} matches, cache hit!", self.entry.filename);
                     callback(Event::ProgressDone(self.download_list_index)).await;
-
                     return Ok(false);
                 }
 
                 debug!(
-                    "Checksum mismatch, initiating re-download for file {} ...",
+                    "checksum mismatch, initiating re-download for file {} ...",
                     self.entry.filename
                 );
+                old_downloaded_size = read;
+            }
 
-                if !allow_resume {
-                    callback(Event::GlobalProgressSub(read)).await;
-                } else {
-                    dest = Some(f);
-                    validator = Some(v);
-                }
+            if self.entry.file_type != CompressType::None {
+                downloaded_size = 0;
             }
         }
 
@@ -320,253 +318,309 @@ impl<'a> SingleDownloader<'a> {
         })
         .await;
 
-        let req = self.build_request_with_basic_auth(&source.url, Method::HEAD, auth);
-        let resp_head = timeout(self.timeout, send_request(&source.url, req)).await;
-
-        callback(Event::ProgressDone(self.download_list_index)).await;
-
-        let resp_head = match resp_head {
-            Ok(Ok(resp)) => resp,
-            Ok(Err(e)) => {
-                return Err(SingleDownloadError::ReqwestError { source: e });
-            }
-            Err(_) => {
-                return Err(SingleDownloadError::SendRequestTimeout);
-            }
-        };
-
-        let head = resp_head.headers();
-
-        // 看看头是否有 ACCEPT_RANGES 这个变量
-        // 如果有，而且值不为 none，则可以断点续传
-        // 反之，则不能断点续传
-        let server_can_resume = match head.get(ACCEPT_RANGES) {
-            Some(x) if x == "none" => false,
-            Some(_) => true,
-            None => false,
-        };
-
-        // 从服务器获取文件的总大小
-        let total_size = {
-            let total_size = head
-                .get(CONTENT_LENGTH)
-                .map(|x| x.to_owned())
-                .unwrap_or(HeaderValue::from(0));
-
-            total_size
-                .to_str()
-                .ok()
-                .and_then(|x| x.parse::<u64>().ok())
-                .unwrap_or_default()
-        };
-
-        trace!("File total size is: {total_size}");
-
-        let mut req = self.build_request_with_basic_auth(&source.url, Method::GET, auth);
-
-        let mut resume = server_can_resume;
-
-        if !allow_resume {
-            resume = false;
-        }
-
-        if server_can_resume && allow_resume {
-            // 如果已存在的文件大小大于或等于要下载的文件，则重置文件大小，重新下载
-            // 因为已经走过一次 chekcusm 了，函数走到这里，则说明肯定文件完整性不对
-            if total_size <= file_size {
-                trace!(
-                    "Resetting size indicator for file to 0, as the file to download is larger that the one that already exists."
-                );
-                callback(Event::GlobalProgressSub(file_size)).await;
-                file_size = 0;
-                resume = false;
-            }
-
-            // 发送 RANGE 的头，传入的是已经下载的文件的大小
-            trace!("oma will set header range as bytes={file_size}-");
-            req = req.header(RANGE, format!("bytes={file_size}-"));
-        }
-
-        debug!("Can resume = {server_can_resume}, will resume = {resume}",);
-
-        let resp = timeout(self.timeout, req.send()).await;
-
-        callback(Event::ProgressDone(self.download_list_index)).await;
-
-        let resp = match resp {
-            Ok(resp) => resp
-                .and_then(|resp| resp.error_for_status())
-                .context(ReqwestSnafu)?,
-            Err(_) => return Err(SingleDownloadError::SendRequestTimeout),
-        };
-
-        callback(Event::NewProgressBar {
-            index: self.download_list_index,
-            msg: self.download_message(),
-            total: self.total,
-            size: total_size,
-        })
-        .await;
-
-        let source = resp;
-
-        let hash = &self.entry.hash;
-
-        let mut self_progress = 0;
-        let (mut dest, mut validator) = if !resume {
-            // 如果不能 resume，则使用创建模式
-            trace!(
-                "oma will open file {} in creation mode.",
-                self.entry.filename
-            );
-
-            let f = match File::create(&file).await {
-                Ok(f) => f,
-                Err(e) => {
-                    callback(Event::ProgressDone(self.download_list_index)).await;
-                    return Err(SingleDownloadError::Create { source: e });
-                }
-            };
-
-            if file_size > 0 {
-                callback(Event::GlobalProgressSub(file_size)).await;
-            }
-
-            if let Err(e) = f.set_len(0).await {
+        // open destination file
+        let mut dest = match tokio::fs::OpenOptions::new()
+            .write(true)
+            .read(true)
+            .create(true)
+            .truncate(false)
+            .open(&file)
+            .await
+        {
+            Ok(f) => f,
+            Err(e) => {
                 callback(Event::ProgressDone(self.download_list_index)).await;
                 return Err(SingleDownloadError::Create { source: e });
             }
+        };
 
-            (f, hash.as_ref().map(|hash| hash.get_validator()))
-        } else if let Some((dest, validator)) = dest.zip(validator) {
-            callback(Event::ProgressInc {
-                index: self.download_list_index,
-                size: file_size,
-            })
-            .await;
-
-            trace!(
-                "oma will re-use opened destination file for {}",
-                self.entry.filename
-            );
-            self_progress += file_size;
-
-            (dest, Some(validator))
+        let mut buf = Vec::with_capacity(DOWNLOAD_BUFSIZE);
+        #[allow(clippy::uninit_vec)]
+        unsafe {
+            buf.set_len(DOWNLOAD_BUFSIZE)
+        };
+        let mut total_size: Option<u64> = None;
+        let mut first_request = true;
+        'download: while if let Some(total_size) = total_size {
+            downloaded_size < total_size
         } else {
-            trace!(
-                "oma will open file {} in creation mode.",
-                self.entry.filename
-            );
-
-            let f = match File::create(&file).await {
-                Ok(f) => f,
-                Err(e) => {
-                    callback(Event::ProgressDone(self.download_list_index)).await;
-                    return Err(SingleDownloadError::Create { source: e });
-                }
-            };
-
-            if let Err(e) = f.set_len(0).await {
-                callback(Event::ProgressDone(self.download_list_index)).await;
-                return Err(SingleDownloadError::Create { source: e });
+            true
+        } {
+            if !allow_resume || self.entry.file_type != CompressType::None {
+                // restart download if resume is disallowed
+                downloaded_size = 0;
             }
 
-            (f, hash.as_ref().map(|hash| hash.get_validator()))
-        };
+            let old_total_size = total_size;
 
-        if server_can_resume && allow_resume {
-            // 把文件指针移动到末尾
-            trace!("oma will seek to end-of-file for {}", self.entry.filename);
-            if let Err(e) = dest.seek(SeekFrom::End(0)).await {
-                callback(Event::ProgressDone(self.download_list_index)).await;
-                return Err(SingleDownloadError::Seek { source: e });
+            // send request
+            let mut req = self.build_request_with_basic_auth(&source.url, Method::GET, auth);
+            if downloaded_size != 0 {
+                // request for resume
+                // assume reqwest's automatical decompression is disabled
+                debug!("sending partial request ...");
+                req = req.header(RANGE, format!("bytes={downloaded_size}-"));
+            } else {
+                debug!("sending complete request ...");
             }
-        }
-        // 下载！
-        trace!("Starting download!");
-
-        let bytes_stream = source
-            .bytes_stream()
-            .map_err(io::Error::other)
-            .into_async_read();
-
-        let reader: &mut (dyn AsyncRead + Unpin + Send) = match self.file_type {
-            CompressFile::Xz => &mut XzDecoder::new(BufReader::new(bytes_stream)),
-            CompressFile::Gzip => &mut GzipDecoder::new(BufReader::new(bytes_stream)),
-            CompressFile::Bz2 => &mut BzDecoder::new(BufReader::new(bytes_stream)),
-            CompressFile::Zstd => &mut ZstdDecoder::new(BufReader::new(bytes_stream)),
-            CompressFile::Lzma => &mut LzmaDecoder::new(BufReader::new(bytes_stream)),
-            CompressFile::Lz4 => &mut Lz4Decoder::new(BufReader::new(bytes_stream)),
-            CompressFile::Nothing => &mut BufReader::new(bytes_stream),
-        };
-
-        let mut reader = reader.compat();
-
-        let mut buf = vec![0u8; DOWNLOAD_BUFSIZE];
-
-        loop {
-            let size = match timeout(self.timeout, reader.read(&mut buf[..])).await {
-                Ok(Ok(size)) => size,
-                Ok(Err(e)) => {
-                    callback(Event::ProgressDone(self.download_list_index)).await;
-                    return Err(SingleDownloadError::BrokenPipe { source: e });
-                }
+            let resp = timeout(self.timeout, send_request(&source.url, req)).await;
+            let resp = match resp {
+                Ok(Ok(resp)) => resp,
+                Ok(Err(e)) => match e.status() {
+                    Some(StatusCode::RANGE_NOT_SATISFIABLE) => {
+                        debug!("range not satisfiable from server, restarting ...");
+                        downloaded_size = 0;
+                        continue 'download;
+                    }
+                    Some(StatusCode::BAD_REQUEST) => {
+                        // some servers reply with Bad Request when Range is invalid
+                        // so retry once
+                        if downloaded_size == 0 {
+                            return Err(SingleDownloadError::ReqwestError { source: e });
+                        } else {
+                            debug!("HTTP Bad Request from server, restarting ...");
+                            downloaded_size = 0;
+                            continue 'download;
+                        }
+                    }
+                    _ => return Err(SingleDownloadError::ReqwestError { source: e }),
+                },
                 Err(_) => {
-                    callback(Event::ProgressDone(self.download_list_index)).await;
-                    return Err(SingleDownloadError::DownloadTimeout);
+                    return Err(SingleDownloadError::SendRequestTimeout);
                 }
             };
 
-            if size == 0 {
-                break;
+            // check resume
+            let resp_headers = resp.headers();
+            'resume: {
+                if resp.status() == StatusCode::PARTIAL_CONTENT {
+                    match resp_headers.typed_get::<ContentRange>() {
+                        Some(range) => {
+                            // update total size if possible
+                            if let Some(new_total_size) = range.bytes_len() {
+                                debug!(
+                                    "extracted complete length from Content-Range: {new_total_size}"
+                                );
+                                total_size = Some(new_total_size);
+                            }
+
+                            // check returned range is the expected
+                            if let Some((returned_start, _)) = range.bytes_range() {
+                                if returned_start != downloaded_size {
+                                    // The server didn't send us the request range
+                                    // Implementing part combination is too complex, just restart it
+                                    debug!("incomplete Content-Range, restarting ...");
+                                    downloaded_size = 0;
+                                    continue 'download;
+                                }
+                                debug!("partial request succeeded");
+                                break 'resume;
+                            } else {
+                                // Unsatisfiable Content-Range should never appear in HTTP 206
+                                // per RFC 9110. The server implementation is violating RFC.
+                                debug!("unsatisfiable Content-Range in HTTP 206, restarting ...");
+                                downloaded_size = 0;
+                                continue 'download;
+                            }
+                        }
+                        None => {
+                            debug!("multi-parts are not supported, restarting ...");
+                            downloaded_size = 0;
+                            continue 'download;
+                        }
+                    }
+                }
+                if resp.status() == StatusCode::OK {
+                    // update total size if possible.
+                    // Content-Length is the complete length for OK but it may not be the case for other statuses
+                    if let Some(length) = resp_headers.typed_get::<ContentLength>() {
+                        let length = length.0;
+                        debug!("extracted complete length from Content-Length: {length}");
+                        total_size = Some(length);
+                    }
+                }
+                if downloaded_size != 0 {
+                    // requested partial response, but not getting expected response
+                    debug!("range request failed");
+                    downloaded_size = 0;
+                    // no need to re-send request in this case, the body is already complete
+                }
+            }
+            debug!("response body is at {downloaded_size}/{total_size:?}");
+            let is_complete = resp.status() == StatusCode::OK;
+
+            // seek to expected location
+            if downloaded_size != old_downloaded_size {
+                assert!(downloaded_size == 0 || self.entry.file_type == CompressType::None);
+                debug!("moving writer from {old_downloaded_size} to {downloaded_size}");
+                if let Err(e) = dest.seek(SeekFrom::Start(0)).await {
+                    callback(Event::ProgressDone(self.download_list_index)).await;
+                    return Err(SingleDownloadError::Seek { source: e });
+                }
+
+                if downloaded_size == 0 {
+                    validator.reset();
+                } else {
+                    {
+                        // refresh hasher state
+                        let mut dest_buf = Vec::with_capacity(downloaded_size.try_into().unwrap());
+                        if let Err(e) = dest.read_to_end(&mut dest_buf).await {
+                            callback(Event::ProgressDone(self.download_list_index)).await;
+                            return Err(SingleDownloadError::Seek { source: e });
+                        }
+                        validator.reset();
+                        validator.update(dest_buf);
+                    }
+
+                    if let Err(e) = dest.seek(SeekFrom::Start(downloaded_size)).await {
+                        callback(Event::ProgressDone(self.download_list_index)).await;
+                        return Err(SingleDownloadError::Seek { source: e });
+                    }
+                }
+
+                // truncate file
+                if let Err(e) = dest.set_len(downloaded_size).await {
+                    callback(Event::ProgressDone(self.download_list_index)).await;
+                    return Err(SingleDownloadError::Write { source: e });
+                }
             }
 
-            if let Err(e) = dest.write_all(&buf[..size]).await {
+            // update progress
+            if old_total_size != total_size
+                || old_downloaded_size > downloaded_size
+                || first_request
+            {
+                // recreate the progress bar if:
+                // 1. total size updated
+                // 2. offset moved backwards
+                // 3. is the first request (the previous bar is a spinner)
+                first_request = false;
+                callback(Event::ProgressDone(self.download_list_index)).await;
+                callback(Event::NewProgressBar {
+                    index: self.download_list_index,
+                    msg: self.download_message(),
+                    total: self.total,
+                    size: total_size.unwrap_or(0),
+                })
+                .await;
+                callback(Event::ProgressInc {
+                    index: self.download_list_index,
+                    size: downloaded_size,
+                })
+                .await;
+                if old_downloaded_size != downloaded_size {
+                    callback(Event::GlobalProgressSub(old_downloaded_size)).await;
+                    callback(Event::GlobalProgressAdd(downloaded_size)).await;
+                }
+            } else if old_downloaded_size < downloaded_size {
+                let new_offset = downloaded_size - old_downloaded_size;
+                callback(Event::ProgressInc {
+                    index: self.download_list_index,
+                    size: new_offset,
+                })
+                .await;
+                callback(Event::GlobalProgressAdd(new_offset)).await;
+            }
+
+            old_downloaded_size = downloaded_size;
+
+            let stream = resp
+                .bytes_stream()
+                .map_err(io::Error::other)
+                .into_async_read();
+            let stream = BufReader::new(stream);
+            let stream_counter = AtomicUsize::new(0);
+            let mut stream = Counter::new(stream, &stream_counter);
+
+            // initialize decompressor
+            let reader: &mut (dyn AsyncRead + Unpin + Send) = match self.file_type {
+                CompressType::Xz => &mut XzDecoder::new(&mut stream),
+                CompressType::Gzip => &mut GzipDecoder::new(&mut stream),
+                CompressType::Bz2 => &mut BzDecoder::new(&mut stream),
+                CompressType::Zstd => &mut ZstdDecoder::new(&mut stream),
+                CompressType::Lzma => &mut LzmaDecoder::new(&mut stream),
+                CompressType::Lz4 => &mut Lz4Decoder::new(&mut stream),
+                CompressType::None => &mut stream,
+            };
+            let mut reader = reader.compat();
+
+            // copy data
+            loop {
+                let buf_size = match timeout(self.timeout, reader.read(&mut buf[..])).await {
+                    Ok(Ok(size)) => size,
+                    Ok(Err(e)) => {
+                        callback(Event::ProgressDone(self.download_list_index)).await;
+                        return Err(SingleDownloadError::BrokenPipe { source: e });
+                    }
+                    Err(_) => {
+                        callback(Event::ProgressDone(self.download_list_index)).await;
+                        return Err(SingleDownloadError::DownloadTimeout);
+                    }
+                };
+                if buf_size == 0 {
+                    break; // EOF
+                }
+                if let Err(e) = dest.write_all(&buf[..buf_size]).await {
+                    callback(Event::ProgressDone(self.download_list_index)).await;
+                    return Err(SingleDownloadError::Write { source: e });
+                }
+                validator.update(&buf[..buf_size]);
+
+                let http_size = stream_counter.swap(0, Ordering::AcqRel);
+                let http_size: u64 = http_size.try_into().unwrap();
+                downloaded_size += http_size;
+                callback(Event::ProgressInc {
+                    index: self.download_list_index,
+                    size: http_size,
+                })
+                .await;
+                callback(Event::GlobalProgressAdd(http_size)).await;
+            }
+
+            debug!("downloaded {} bytes", downloaded_size - old_downloaded_size);
+            if downloaded_size == old_downloaded_size {
+                // this should not happen ...
+                break 'download;
+            }
+
+            if is_complete || total_size.is_none() {
+                // total size is unknown, we have to assume that the body is complete
+                break 'download;
+            }
+
+            old_downloaded_size = downloaded_size;
+        }
+        debug!("download end, {downloaded_size} bytes");
+        callback(Event::ProgressDone(self.download_list_index)).await;
+
+        // verify checksum
+        if !validator.finish() {
+            debug!("checksum mismatch for {}", self.entry.filename);
+            callback(Event::GlobalProgressSub(downloaded_size)).await;
+            callback(Event::ProgressDone(self.download_list_index)).await;
+
+            // truncate file, avoid attempts to reuse it in retries
+            if let Err(e) = dest.set_len(0).await {
                 callback(Event::ProgressDone(self.download_list_index)).await;
                 return Err(SingleDownloadError::Write { source: e });
             }
 
-            callback(Event::ProgressInc {
-                index: self.download_list_index,
-                size: size as u64,
-            })
-            .await;
-
-            self_progress += size as u64;
-
-            callback(Event::GlobalProgressAdd(size as u64)).await;
-
-            if let Some(ref mut v) = validator {
-                v.update(&buf[..size]);
-            }
+            return Err(SingleDownloadError::ChecksumMismatch);
+        }
+        if matches!(validator, ChecksumValidator::None) {
+            trace!(
+                "checksum verification succeeded for {}",
+                self.entry.filename
+            );
         }
 
-        // 下载完成，告诉运行时不再写这个文件了
-        trace!("Download complete! Shutting down destination file stream ...");
+        // flush
         if let Err(e) = dest.shutdown().await {
             callback(Event::ProgressDone(self.download_list_index)).await;
             return Err(SingleDownloadError::Flush { source: e });
         }
 
-        // 最后看看 checksum 验证是否通过
-        if let Some(v) = validator {
-            if !v.finish() {
-                debug!("Checksum mismatch for file {}", self.entry.filename);
-                trace!("{self_progress}");
-
-                callback(Event::GlobalProgressSub(self_progress)).await;
-                callback(Event::ProgressDone(self.download_list_index)).await;
-                return Err(SingleDownloadError::ChecksumMismatch);
-            }
-
-            trace!(
-                "Checksum verification successful for file {}",
-                self.entry.filename
-            );
-        }
-
         callback(Event::ProgressDone(self.download_list_index)).await;
-
         Ok(true)
     }
 
@@ -641,13 +695,13 @@ impl<'a> SingleDownloader<'a> {
             .context(CreateSnafu)?;
 
         let reader: &mut (dyn AsyncRead + Unpin + Send) = match self.file_type {
-            CompressFile::Xz => &mut XzDecoder::new(BufReader::new(from)),
-            CompressFile::Gzip => &mut GzipDecoder::new(BufReader::new(from)),
-            CompressFile::Bz2 => &mut BzDecoder::new(BufReader::new(from)),
-            CompressFile::Zstd => &mut ZstdDecoder::new(BufReader::new(from)),
-            CompressFile::Lzma => &mut LzmaDecoder::new(BufReader::new(from)),
-            CompressFile::Lz4 => &mut Lz4Decoder::new(BufReader::new(from)),
-            CompressFile::Nothing => &mut BufReader::new(from),
+            CompressType::Xz => &mut XzDecoder::new(BufReader::new(from)),
+            CompressType::Gzip => &mut GzipDecoder::new(BufReader::new(from)),
+            CompressType::Bz2 => &mut BzDecoder::new(BufReader::new(from)),
+            CompressType::Zstd => &mut ZstdDecoder::new(BufReader::new(from)),
+            CompressType::Lzma => &mut LzmaDecoder::new(BufReader::new(from)),
+            CompressType::Lz4 => &mut Lz4Decoder::new(BufReader::new(from)),
+            CompressType::None => &mut BufReader::new(from),
         };
 
         let mut reader = reader.compat();
@@ -751,4 +805,54 @@ async fn checksum(
     }
 
     (read, v.finish())
+}
+
+pub struct Counter<'a, D> {
+    inner: D,
+    bytes: &'a AtomicUsize,
+}
+
+impl<'a, D> Counter<'a, D> {
+    #[inline]
+    pub const fn new(inner: D, bytes: &'a AtomicUsize) -> Self {
+        Self { inner, bytes }
+    }
+
+    #[inline]
+    pub fn take_read_bytes(&self) -> usize {
+        self.bytes.swap(0, Ordering::AcqRel)
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for Counter<'_, R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let counter = self.get_mut();
+        let pin = Pin::new(&mut counter.inner);
+
+        let poll = pin.poll_read(ctx, buf);
+        if let Poll::Ready(Ok(bytes)) = poll {
+            counter.bytes.fetch_add(bytes, Ordering::AcqRel);
+        }
+
+        poll
+    }
+}
+
+impl<R: AsyncBufRead + Unpin> AsyncBufRead for Counter<'_, R> {
+    fn poll_fill_buf(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<std::io::Result<&[u8]>> {
+        let counter = self.get_mut();
+        let pin = Pin::new(&mut counter.inner);
+        pin.poll_fill_buf(ctx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let counter = self.get_mut();
+        counter.bytes.fetch_add(amt, Ordering::AcqRel);
+        let pin = Pin::new(&mut counter.inner);
+        pin.consume(amt);
+    }
 }

--- a/oma-fetch/src/lib.rs
+++ b/oma-fetch/src/lib.rs
@@ -23,7 +23,7 @@ pub struct DownloadEntry {
     allow_resume: bool,
     msg: Option<Cow<'static, str>>,
     #[builder(default)]
-    file_type: CompressFile,
+    file_type: CompressType,
 }
 
 impl Debug for DownloadEntry {
@@ -41,7 +41,7 @@ impl Debug for DownloadEntry {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Copy)]
-pub enum CompressFile {
+pub enum CompressType {
     Bz2,
     Gzip,
     Xz,
@@ -49,17 +49,17 @@ pub enum CompressFile {
     Lzma,
     Lz4,
     #[default]
-    Nothing,
+    None,
 }
 
-impl From<&str> for CompressFile {
+impl From<&str> for CompressType {
     fn from(s: &str) -> Self {
         match s {
-            "xz" => CompressFile::Xz,
-            "gz" => CompressFile::Gzip,
-            "bz2" => CompressFile::Bz2,
-            "zst" => CompressFile::Zstd,
-            _ => CompressFile::Nothing,
+            "xz" => CompressType::Xz,
+            "gz" => CompressType::Gzip,
+            "bz2" => CompressType::Bz2,
+            "zst" => CompressType::Zstd,
+            _ => CompressType::None,
         }
     }
 }

--- a/oma-refresh/src/config.rs
+++ b/oma-refresh/src/config.rs
@@ -9,7 +9,7 @@ use ahash::AHashMap;
 use aho_corasick::AhoCorasick;
 #[cfg(feature = "apt")]
 use oma_apt::config::{Config, ConfigTree};
-use oma_fetch::CompressFile;
+use oma_fetch::CompressType;
 use once_cell::sync::OnceCell;
 use spdlog::debug;
 
@@ -19,29 +19,29 @@ static COMPRESSION_ORDER: OnceCell<Vec<CompressFileWrapper>> = OnceCell::new();
 
 #[derive(Debug, Eq, PartialEq)]
 struct CompressFileWrapper {
-    compress_file: CompressFile,
+    compress_file: CompressType,
 }
 
 impl From<&str> for CompressFileWrapper {
     fn from(value: &str) -> Self {
         match value {
             "xz" => CompressFileWrapper {
-                compress_file: CompressFile::Xz,
+                compress_file: CompressType::Xz,
             },
             "bz2" => CompressFileWrapper {
-                compress_file: CompressFile::Bz2,
+                compress_file: CompressType::Bz2,
             },
             "lzma" => CompressFileWrapper {
-                compress_file: CompressFile::Lzma,
+                compress_file: CompressType::Lzma,
             },
             "gz" => CompressFileWrapper {
-                compress_file: CompressFile::Gzip,
+                compress_file: CompressType::Gzip,
             },
             "lz4" => CompressFileWrapper {
-                compress_file: CompressFile::Lz4,
+                compress_file: CompressType::Lz4,
             },
             "zst" => CompressFileWrapper {
-                compress_file: CompressFile::Zstd,
+                compress_file: CompressType::Zstd,
             },
             x => {
                 if !x.is_ascii() {
@@ -49,7 +49,7 @@ impl From<&str> for CompressFileWrapper {
                 }
 
                 CompressFileWrapper {
-                    compress_file: CompressFile::Nothing,
+                    compress_file: CompressType::None,
                 }
             }
         }
@@ -98,8 +98,8 @@ impl Ord for CompressFileWrapper {
     }
 }
 
-impl From<CompressFile> for CompressFileWrapper {
-    fn from(value: CompressFile) -> Self {
+impl From<CompressType> for CompressFileWrapper {
+    fn from(value: CompressType) -> Self {
         Self {
             compress_file: value,
         }
@@ -386,7 +386,7 @@ fn to_download_entry(
 }
 
 fn uncompress_file_name(target: &str) -> Cow<'_, str> {
-    if compress_file(target) == CompressFile::Nothing.into() {
+    if compress_file(target) == CompressType::None.into() {
         Cow::Borrowed(target)
     } else {
         let compress_target_without_ext = Path::new(target).with_extension("");
@@ -445,7 +445,7 @@ fn get_matches_language(locales: impl IntoIterator<Item = String>) -> Vec<String
 
 fn compress_file(name: &str) -> CompressFileWrapper {
     CompressFileWrapper {
-        compress_file: CompressFile::from(
+        compress_file: CompressType::from(
             Path::new(name)
                 .extension()
                 .map(|x| x.to_string_lossy())
@@ -481,13 +481,13 @@ fn test_compression_order() {
     assert_eq!(
         types,
         vec![
-            CompressFile::Zstd,
-            CompressFile::Xz,
-            CompressFile::Bz2,
-            CompressFile::Lzma,
-            CompressFile::Gzip,
-            CompressFile::Lz4,
-            CompressFile::Nothing
+            CompressType::Zstd,
+            CompressType::Xz,
+            CompressType::Bz2,
+            CompressType::Lzma,
+            CompressType::Gzip,
+            CompressType::Lz4,
+            CompressType::None
         ]
         .into_iter()
         .map(|x| x.into())

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -13,7 +13,7 @@ use chrono::Utc;
 use oma_apt::config::Config;
 use oma_apt_sources_lists::SourcesListError;
 use oma_fetch::{
-    CompressFile, DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType,
+    CompressType, DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType,
     checksum::{Checksum, ChecksumError},
     download::{BuilderError, SuccessSummary},
     reqwest::{
@@ -776,7 +776,7 @@ fn collect_flat_repo_no_release(
         .dir(download_dir.to_path_buf())
         .allow_resume(false)
         .msg(msg.into())
-        .file_type(CompressFile::Nothing)
+        .file_type(CompressType::None)
         .build();
 
     tasks.push(task);
@@ -868,16 +868,16 @@ fn collect_download_task(
         .msg(msg.into())
         .file_type({
             if c.keep_compress {
-                CompressFile::Nothing
+                CompressType::None
             } else {
                 match Path::new(&c.item.name).extension().and_then(|x| x.to_str()) {
-                    Some("gz") => CompressFile::Gzip,
-                    Some("xz") => CompressFile::Xz,
-                    Some("bz2") => CompressFile::Bz2,
-                    Some("zst") => CompressFile::Zstd,
-                    Some("lzma") => CompressFile::Lzma,
-                    Some("lz4") => CompressFile::Lz4,
-                    _ => CompressFile::Nothing,
+                    Some("gz") => CompressType::Gzip,
+                    Some("xz") => CompressType::Xz,
+                    Some("bz2") => CompressType::Bz2,
+                    Some("zst") => CompressType::Zstd,
+                    Some("lzma") => CompressType::Lzma,
+                    Some("lz4") => CompressType::Lz4,
+                    _ => CompressType::None,
                 }
             }
         })


### PR DESCRIPTION
refactor(oma-fetch): rewrite HTTP download

- Remove a HEAD request, reduce download startup time
- Remove the false assumption that if a server sends
  Accept-Ranges, Range must be supported and accepted.
  Per RFC 9110, a server may ignore the range.
- Remove the false assumption that if a server sends
  a partial response, the range must be the requested one.
  Per RFC 9110, the server may return another range or
  multiple ranges.
  For the sake of simplicity, oma-fetch now only implements
  single-part cases where start offset is the same as requested.
- Truncate file on checksum mismatch.
  So downloader won't try to resume download in the next
  retry, saving time.
- Disallow resumption for compressed stream.
  It is too complicated and not worthy to serialize and save
  internal states of decompressors to disk, so now it is
  impossible to resume a compressed download.
- Assume that the content encoding is "identity".
  This is implemented by disabling all compression features
  of reqwest, which disables automatic compression handshake.
  If not, the enclosed representation data length in Content-Length
  header may differ from the uncompressed data length.
  Setting transfer encoding is still okay, but reqwest does not
  do it automatically.
- Fix the download progress of compressed streams.
  Previously, progress bars are updated with the size of bytes
  written to destination file. However the amount of HTTP
  enclosed data is used as the total size.
  A counter layer is added so progress bars use the amount
  of transferred representation data instead of decompressed data.
  AcqRel ordering is used for atomic memory operations instead of
  SeqCst because there won't be two threads updating the counter at
  the same time, but we do want updates to be visible to all cores
  in case the runtime (tokio) switches executor thread in reads.
- Handle HTTP 416 Range Not Satisfiable error gracefully.
  A server may refuse partial requests by sending a full response
  or sending HTTP 416. In this case, restart with a complete request.
- Handle HTTP 400 Bad Request for partial requests.
  Per RFC 9110 section 14.2, a server may reject partial requests
  with invalid range. For example, if the origin file is replaced with
  a smaller one on the server, we may be sending a request where
  the start position of Range is greater than the file size
  on the server. However, the RFC didn't explicitly specify how should
  a server reject such requests.
  In practice, some server replies Bad Request.
- Update total size from both Content-Range if possible.
  Content-Range may carry the complete length of data, while
  Content-Length, length of body, may be incorrect for partial requests.
- Assume that a server not sending complete representation length,
  its reponse range must reach the end of file.
  A server may not send the complete representation length
  in Content-Range. In this case, it is impossible to know whether
  the reponse range extends to the EOF or not.
  If it does reach, when sending a partial request where the selected
  representation has no content (i.e. attempt to download next range),
  the server may ignore the Range header. Note that if it does not reach,
  the server may still ignore the Range for no reason.
  To avoid having to restart a complete download, instead, assume
  that the range must be complete. Checksum validation will
  save the world if it is not the case.

Signed-off-by: xtex <xtex@astrafall.org>