### PR TITLE
feat: add Ubuntu 26.04 LTS (Resolute) support

### DIFF
--- a/.github/workflows/deb_amd64.yml
+++ b/.github/workflows/deb_amd64.yml
@@ -14,7 +14,7 @@ jobs:
             "ubuntu:20.04",
             "ubuntu:22.04",
             "ubuntu:24.04",
-            "ubuntu:25.04",
+            "ubuntu:26.04",
             "debian:11",
             "debian:12",
             "debian:13",
@@ -74,8 +74,8 @@ jobs:
               'ubuntu:24.04')
                   CODENAME='noble'
                   ;;
-              'ubuntu:25.04')
-                  CODENAME='plucky'
+              'ubuntu:26.04')
+                  CODENAME='resolute'
                   ;;
               'linuxdeepin/deepin')
                   CODENAME='beige'

--- a/.github/workflows/deb_arm64.yml
+++ b/.github/workflows/deb_arm64.yml
@@ -14,7 +14,7 @@ jobs:
             "arm64v8/ubuntu:20.04",
             "arm64v8/ubuntu:22.04",
             "arm64v8/ubuntu:24.04",
-            "arm64v8/ubuntu:25.04",
+            "arm64v8/ubuntu:26.04",
             "arm64v8/debian:11",
             "arm64v8/debian:12",
             "arm64v8/debian:13",
@@ -87,8 +87,8 @@ jobs:
               'arm64v8/ubuntu:24.04')
                   CODENAME='noble'
                   ;;
-              'arm64v8/ubuntu:25.04')
-                  CODENAME='plucky'
+              'arm64v8/ubuntu:26.04')
+                  CODENAME='resolute'
                   ;;
               'linuxdeepin/deepin:beige-arm64-v1.4.0')
                   CODENAME='beige'

--- a/data/installer/get-oma.sh
+++ b/data/installer/get-oma.sh
@@ -90,6 +90,9 @@ _parse_os_release() {
 			# Ubuntu >= 25.04 uses libapt-pkg7.0
 			_oma_codename='plucky'
 			_non_lts='1'
+		elif [ "$VERSION_ID" = '26.04' ]; then
+			_oma_codename='resolute'
+			_non_lts='0'
 		else
 			echo "
 >>> oma 暂不支持 Ubuntu ${VERSION_ID}，抱歉！


### PR DESCRIPTION
## Summary

- Add Ubuntu 26.04 LTS (Resolute) detection to the installer script (`data/installer/get-oma.sh`)
- Update amd64 CI workflow to build debs for Ubuntu 26.04 instead of 25.04
- Update arm64 CI workflow to build debs for Ubuntu 26.04 instead of 25.04

## Test Plan

- [x] `oma --version` — binary executes correctly
- [x] `sudo oma refresh` — libapt-pkg7.0 ABI compatible, all sources refreshed
- [x] `sudo oma search` — package search works
- [x] `sudo oma show` — package info display works
- [x] `sudo oma list --installed` — local database access works
- [x] `sudo oma download --dry-run` — dependency resolution works
- [x] `sudo oma depends` — dependency tree works
- [x] `sudo oma upgrade` — upgrade check works
- [x] `sudo oma install` — applied changes to your system.
- [x] CI builds and publishes deb for `resolute` codename

Tested on: Ubuntu 26.04 LTS amd64 with plucky deb (1.25.2-1)

Tools: codex + gpt-5.5 xhigh