### PR TITLE
ci: drop generate-manpage calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,17 +198,17 @@ assets = [
         "644",
     ],
     [
-        "man/en_US/*.1",
+        "data/man/en_US/*.1",
         "usr/share/man/man1/",
         "644",
     ],
     [
-        "man/zh_CN/*.1",
+        "data/man/zh_CN/*.1",
         "usr/share/man/zh_CN/man1/",
         "644",
     ],
     [
-        "man/zh_TW/*.1",
+        "data/man/zh_TW/*.1",
         "usr/share/man/zh_TW/man1/",
         "644",
     ],

--- a/justfile
+++ b/justfile
@@ -11,7 +11,4 @@ deb:
     COMPLETE=bash ./target/release/oma > completions/oma.bash
     COMPLETE=zsh ./target/release/oma > completions/_oma
     COMPLETE=fish ./target/release/oma > completions/oma.fish
-    LANG=C ./target/release/oma generate-manpages
-    LANG=zh_CN.UTF-8 ./target/release/oma generate-manpages
-    LANG=zh_TW.UTF-8 ./target/release/oma generate-manpages
     cargo deb -Z xz --features "{{ features }}"


### PR DESCRIPTION
Since commit 01b73b4dd05f "ci: add manpage auto generate (#741)", manpages for non-AOSC OS targets are generated on a per-commit basis. There is no need to do so again here. Drop these calls.