### PR TITLE
fix(oma-topics): backport CVE-2026-39958 control-character topic-name guard to 1.24.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test
 /*.deb
 /completions
 /man
+.idea/

--- a/i18n/en-US/oma.ftl
+++ b/i18n/en-US/oma.ftl
@@ -147,6 +147,7 @@ failed-to-read-decode-inrelease = Failed to read the decoded InRelease file.
 failed-to-operate-path = Failed to perform file operations in { $p }.
 failed-to-get-parent-path = Failed to get parent path of { $p }.
 failed-to-read-file-metadata = Failed to read file metadata for { $p }.
+illegal-topic-entry = Topic entry contains illegal character(s): { $name }.
 failed-to-get-rg-process-info = Failed to get process status for `rg'.
 failed-to-calculate-available-space = Failed to calculate available storage space.
 failed-to-create-http-client = Failed to create an HTTP client.

--- a/i18n/zh-CN/oma.ftl
+++ b/i18n/zh-CN/oma.ftl
@@ -142,6 +142,7 @@ failed-to-read-decode-inrelease = 无法读取解密后的 InRelease 文件。
 failed-to-operate-path = 无法在路径 { $p } 中执行文件操作。
 failed-to-get-parent-path = 无法获取路径 { $p } 的父目录。
 failed-to-read-file-metadata = 无法读取 { $p } 的文件元数据。
+illegal-topic-entry = 测试源配置条目包含无效字符：{ $name }。
 failed-to-get-rg-process-info = 无法获取 `rg' 的进程状态。
 failed-to-calculate-available-space = 无法计算可用存储空间。
 failed-to-create-http-client = 无法创建 HTTP 客户端。

--- a/i18n/zh-TW/oma.ftl
+++ b/i18n/zh-TW/oma.ftl
@@ -135,6 +135,7 @@ failed-to-read-decode-inrelease = 無法讀取解密後的 InRelease 檔案。
 failed-to-operate-path = 無法在路徑 { $p } 中執行檔案操作。
 failed-to-get-parent-path = 無法取得路徑 { $p } 的上層目錄。
 failed-to-read-file-metadata = 無法讀取 { $p } 的檔案後設資料。
+illegal-topic-entry = 測試庫設定項包含無效字元：{ $name }。
 failed-to-get-rg-process-info = 無法取得 `rg' 的行程狀態。
 failed-to-calculate-available-space = 無法計算可用儲存空間。
 failed-to-create-http-client = 無法建立 HTTP 用戶端。

--- a/oma-topics/src/lib.rs
+++ b/oma-topics/src/lib.rs
@@ -42,6 +42,8 @@ pub enum OmaTopicsError {
     ReadFile(String, serde_json::Error),
     #[error(transparent)]
     MirrorError(#[from] oma_mirror::MirrorError),
+    #[error("Topic entry contains illegal character(s): {0:?}")]
+    IllegalTopicEntry(String),
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -221,6 +223,10 @@ impl<'a> TopicManager<'a> {
         debug!("Enabled: {enabled_names:?}");
 
         if let Some(index) = index {
+            // Skip all control characters
+            if index.name.chars().any(|c| c.is_control()) {
+                return Err(OmaTopicsError::IllegalTopicEntry(index.name.clone()));
+            }
             if !enabled_names.contains(&&index.name) {
                 self.enabled.push(index.clone());
             }
@@ -459,6 +465,8 @@ async fn refresh_innter<'a>(
             x.arch
                 .as_ref()
                 .is_some_and(|x| x.contains(&arch.to_string()) || x.contains(&"all".to_string()))
+                // Skip all names with control characters in them
+                && !x.name.chars().any(|c| c.is_control())
         })
         .collect::<Vec<_>>();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -578,6 +578,14 @@ fn oma_topics_error(e: OmaTopicsError) -> OutputError {
             source: Some(Box::new(e)),
         },
         OmaTopicsError::MirrorError(mirror_error) => OutputError::from(mirror_error),
+
+        OmaTopicsError::IllegalTopicEntry(name) => OutputError {
+            description: fl!(
+                "illegal-topic-entry",
+                name = name.escape_default().to_string()
+            ),
+            source: None,
+        },
     }
 }
 


### PR DESCRIPTION
Backport of [`b361c0f2`](https://github.com/AOSC-Dev/oma/commit/b361c0f219bbf91a684610c76210f71f093dbc18) (PR #733) to `1.24.x`, addressing **CVE-2026-39958**: control-character topic names being accepted by `TopicManager::add` and `refresh_innter` in `oma-topics`.

Cherry-picked with `git cherry-pick -x`; the original author (Neko / @neko205-mx) is preserved and the commit carries the `(cherry picked from commit b361c0f2…)` trailer. The 3-way merge auto-resolved drift in the three `i18n/*.ftl` files and `src/error.rs`; the security-relevant hunks in `oma-topics/src/lib.rs` (the new `IllegalTopicEntry` variant + the two `is_control` guards) apply unchanged.

Resolves the porting question raised in #750. Happy to amend if you'd prefer a different shape (e.g. squashed without the `.gitignore` whitespace hunk).