### PR TITLE
ci: add build for loong64 on Debian 13

### DIFF
--- a/.github/workflows/deb_loong64.yml
+++ b/.github/workflows/deb_loong64.yml
@@ -12,6 +12,7 @@ jobs:
         target:
           [
             "lcr.loongnix.cn/library/debian:sid-20251209",
+            "ghcr.io/loong64/debian:trixie-slim"
             # "linuxdeepin/deepin:beige-loong64-v1.4.0", 编译 cargo-deb 会卡住
           ]
     container:
@@ -50,6 +51,10 @@ jobs:
           VER_SUFFIX="${VER_SUFFIX##*\/}"
           case "${TARGET_DISTRO}" in
               'lcr.loongnix.cn/library/debian'*)
+                  CODENAME='forky'
+                  VER_SUFFIX='debian14'
+                  ;;
+              'ghcr.io/loong64/debian:trixie-slim')
                   CODENAME='trixie'
                   VER_SUFFIX='debian13'
                   ;;


### PR DESCRIPTION
This pr adds Debian 13 to build platform. The `ghcr.io/loong64/debian:trixie-slim` image is created based on a community-maintained Debian 13 port at <https://loong13.debian.net/>

It also changes the suffix for Debian Sid from debian 13 trixie to debian 14 forky.