### PR TITLE
fix: allow typing space in search box

### DIFF
--- a/src/tui/key_binding.rs
+++ b/src/tui/key_binding.rs
@@ -395,7 +395,9 @@ impl Tui<'_> {
 
     fn handle_space(&mut self) -> ControlFlow<()> {
         match self.mode {
-            Mode::Search => {}
+            Mode::Search => {
+                self.handle_input_text(' ');
+            }
             Mode::Packages => {
                 let selected = self.pkg_result_state.state.selected();
                 if let Some(i) = selected {


### PR DESCRIPTION
<img width="1148" height="453" alt="图片" src="https://github.com/user-attachments/assets/2ab7b593-69e6-4771-bb56-45e3862c3c61" />
