### PR TITLE
spdlog indicatif

### DIFF
--- a/src/core/commit_changes.rs
+++ b/src/core/commit_changes.rs
@@ -24,14 +24,12 @@ use crate::{
     error::OutputError,
     exit_handle::{ExitHandle, ExitStatus},
     fl,
-    install_progress::{NoInstallProgressManager, OmaInstallProgressManager, osc94_progress},
+    install_progress::{NoInstallProgressManager, OSC94, OmaInstallProgressManager},
     lang::{DEFAULT_LANGUAGE, SYSTEM_LANG},
     msg,
-    pb::{NoProgressBar, OmaMultiProgressBar, RenderPackagesDownloadProgress},
+    pb::{ProgressBar, ProgressRenderer},
     subcommand::{
-        clean::clean_download_packages_cache,
-        remove::ask_user_do_as_i_say,
-        utils::{create_progress_spinner, download_message},
+        clean::clean_download_packages_cache, remove::ask_user_do_as_i_say, utils::download_message,
     },
     success,
     table::table_for_install_pending,
@@ -196,12 +194,8 @@ impl CommitChanges<'_> {
 
         let no_progress = config.no_progress();
 
-        thread::spawn(move || {
-            let mut pb: Box<dyn RenderPackagesDownloadProgress> = if no_progress {
-                Box::new(NoProgressBar::default())
-            } else {
-                Box::new(OmaMultiProgressBar::default())
-            };
+        let handle = thread::spawn(move || {
+            let mut pb = ProgressRenderer::new(no_progress);
             pb.render_progress(&rx, false);
         });
 
@@ -225,7 +219,11 @@ impl CommitChanges<'_> {
             },
         );
 
-        osc94_progress(100.0, true);
+        // Wait for the renderer thread to process the remaining events so no
+        // progress bar is left on screen when we continue.
+        handle.join().ok();
+
+        OSC94.finish();
 
         match res {
             Ok(_) => {
@@ -310,7 +308,7 @@ fn fix_broken(
     autoremove: bool,
     is_upgrade: bool,
 ) -> Result<(), OutputError> {
-    let pb = create_progress_spinner(no_progress, fl!("resolving-dependencies"));
+    let pb = ProgressBar::new_spinner(fl!("resolving-dependencies"), !no_progress);
 
     let res = Ok(()).and_then(|_| -> Result<(), OmaAptError> {
         let solver = oma_apt::raw::config::find("APT::Solver".to_string(), "internal".to_string());
@@ -326,9 +324,7 @@ fn fix_broken(
         if fix_dpkg_status {
             let (needs_reconfigure, needs_retrigger) = apt.is_needs_fix_dpkg_status()?;
             if needs_retrigger || needs_reconfigure {
-                if let Some(ref pb) = pb {
-                    pb.inner.finish_and_clear()
-                }
+                pb.finish_and_clear();
                 info!("{}", fl!("fixing-status"));
                 apt.fix_dpkg_status(needs_reconfigure, needs_retrigger)?;
             }
@@ -343,9 +339,7 @@ fn fix_broken(
         Ok(())
     });
 
-    if let Some(pb) = pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     res?;
 

--- a/src/core/refresh.rs
+++ b/src/core/refresh.rs
@@ -7,11 +7,7 @@ use oma_utils::dpkg::dpkg_arch;
 use spdlog::{debug, info};
 
 use crate::{
-    config::OmaConfig,
-    error::OutputError,
-    fl,
-    pb::{NoProgressBar, OmaMultiProgressBar, RenderRefreshProgress},
-    utils::get_lists_dir,
+    config::OmaConfig, error::OutputError, fl, pb::ProgressRenderer, utils::get_lists_dir,
 };
 
 #[derive(Debug, Builder)]
@@ -55,20 +51,22 @@ impl Refresh<'_> {
 
         let no_progress = config.no_progress();
 
-        thread::spawn(move || {
-            let mut pb: Box<dyn RenderRefreshProgress> = if no_progress {
-                Box::new(NoProgressBar::default())
-            } else {
-                Box::new(OmaMultiProgressBar::default())
-            };
+        let handle = thread::spawn(move || {
+            let mut pb = ProgressRenderer::new(no_progress);
             pb.render_refresh_progress(&rx);
         });
 
-        refresh.start(move |event| {
+        let res = refresh.start(move |event| {
             if let Err(e) = tx.send(event) {
                 debug!("{}", e);
             }
-        })?;
+        });
+
+        // Wait for the renderer thread to process the remaining events so no
+        // progress bar is left on screen when we continue.
+        handle.join().ok();
+
+        res?;
 
         Ok(())
     }

--- a/src/exit_handle.rs
+++ b/src/exit_handle.rs
@@ -7,7 +7,7 @@ use std::{
 use oma_console::pager::PagerExit;
 use spdlog::info;
 
-use crate::{NOT_ALLOW_CTRLC, NOT_DISPLAY_ABORT, WRITER, fl, install_progress::osc94_progress};
+use crate::{NOT_ALLOW_CTRLC, NOT_DISPLAY_ABORT, WRITER, fl, install_progress::OSC94};
 
 pub struct ExitHandle {
     ring: bool,
@@ -82,7 +82,7 @@ pub fn signal_handler() {
     }
 
     // Force drop osc94 progress
-    osc94_progress(0.0, true);
+    OSC94.finish();
 
     let not_display_abort = NOT_DISPLAY_ABORT.load(Ordering::Relaxed);
 

--- a/src/install_progress.rs
+++ b/src/install_progress.rs
@@ -1,4 +1,10 @@
-use std::io::Write;
+use std::{
+    io::Write,
+    sync::{
+        LazyLock,
+        atomic::{AtomicU32, Ordering},
+    },
+};
 
 use oma_pm::{
     oma_apt::raw::config as apt_config,
@@ -53,7 +59,7 @@ impl InstallProgressManager for OmaInstallProgressManager {
         let percent_100 = (percent_1 * 100.0).round();
         let percent_for_dpkg = 50.0 + percent_100 * 0.5;
 
-        osc94_progress(percent_for_dpkg, false);
+        OSC94.set(percent_for_dpkg);
 
         let mut percent_str = percent_100.to_string();
 
@@ -106,19 +112,51 @@ impl InstallProgressManager for OmaInstallProgressManager {
     }
 }
 
-#[inline]
-pub fn osc94_progress(percent: f32, finish: bool) {
-    // From https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC
-    // ESC ] 9 ; 4 ; st ; pr ST
-    // When st is 0: remove progress.
-    // When st is 1: set progress value to pr (number, 0-100).
-    // When st is 2: set error state in taskbar, pr is optional.
-    // When st is 3: set indeterminate state, pr is ignored.
-    // When st is 4: set paused state, pr is optional.
-    eprint!(
-        "\x1b]9;4;{};{percent:.0}\x1b\\",
-        if !finish { 1 } else { 0 }
-    );
+/// Terminal taskbar progress via OSC 94, shared by the download renderer
+/// thread, the dpkg progress manager and the exit handler. The only shared
+/// state is the last reported integer percent, so a plain atomic is enough:
+/// updates are lock-free and redundant writes are throttled away.
+pub static OSC94: LazyLock<Osc94> = LazyLock::new(Osc94::default);
+
+/// See [`OSC94`].
+#[derive(Default)]
+pub struct Osc94 {
+    last: AtomicU32,
+}
+
+impl Osc94 {
+    /// Report `percent` (0-100) to the taskbar. The write is skipped when the
+    /// rounded value equals the last one reported.
+    pub fn set(&self, percent: f32) {
+        let percent = percent.round() as u32;
+        if self.last.swap(percent, Ordering::Relaxed) != percent {
+            Self::write_set(percent);
+        }
+    }
+
+    /// Remove the taskbar progress. Always writes, regardless of throttling,
+    /// so a later [`Self::set`] with a different value reports again.
+    pub fn finish(&self) {
+        self.last.store(100, Ordering::Relaxed);
+        Self::write_remove();
+    }
+
+    /// Write the OSC 94 escape sequence that sets the taskbar progress.
+    ///
+    /// From https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC
+    /// `ESC ] 9 ; 4 ; st ; pr ST`:
+    /// - st 0: remove progress
+    /// - st 1: set progress value to pr (number, 0-100)
+    /// - st 2: set error state, pr optional
+    /// - st 3: indeterminate state, pr ignored
+    /// - st 4: paused state, pr optional
+    fn write_set(percent: u32) {
+        eprint!("\x1b]9;4;1;{percent}\x1b\\");
+    }
+
+    fn write_remove() {
+        eprint!("\x1b]9;4;0;0\x1b\\");
+    }
 }
 
 pub struct NoInstallProgressManager;

--- a/src/install_progress.rs
+++ b/src/install_progress.rs
@@ -112,7 +112,7 @@ impl InstallProgressManager for OmaInstallProgressManager {
     }
 }
 
-/// Terminal taskbar progress via OSC 94, shared by the download renderer
+/// Terminal percentage progress via OSC 94, shared by the download renderer
 /// thread, the dpkg progress manager and the exit handler. The only shared
 /// state is the last reported integer percent, so a plain atomic is enough:
 /// updates are lock-free and redundant writes are throttled away.
@@ -125,8 +125,8 @@ pub struct Osc94 {
 }
 
 impl Osc94 {
-    /// Report `percent` (0-100) to the taskbar. The write is skipped when the
-    /// rounded value equals the last one reported.
+    /// Report `percent` (0-100) as terminal progress. The write is skipped when
+    /// the rounded value equals the last one reported.
     pub fn set(&self, percent: f32) {
         let percent = percent.round() as u32;
         if self.last.swap(percent, Ordering::Relaxed) != percent {
@@ -134,14 +134,14 @@ impl Osc94 {
         }
     }
 
-    /// Remove the taskbar progress. Always writes, regardless of throttling,
+    /// Clear the terminal progress. Always writes, regardless of throttling,
     /// so a later [`Self::set`] with a different value reports again.
     pub fn finish(&self) {
         self.last.store(100, Ordering::Relaxed);
         Self::write_remove();
     }
 
-    /// Write the OSC 94 escape sequence that sets the taskbar progress.
+    /// Write the OSC 94 escape sequence that reports percentage progress.
     ///
     /// From https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC
     /// `ESC ] 9 ; 4 ; st ; pr ST`:

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -11,10 +11,11 @@ use spdlog::{
     Level, LevelFilter, Logger, debug,
     error::SendToChannelError,
     init_log_crate_proxy, log_crate_proxy, set_default_logger,
-    sink::{AsyncPoolSink, FileSink, StdStreamSink},
+    sink::{AsyncPoolSink, FileSink, WriteSink},
     warn,
 };
 
+use crate::pb::ProgressAwareWriter;
 use crate::{args::OhManagerAilurus, config::OmaConfig, root::is_root};
 
 pub fn init_logger(oma: &OhManagerAilurus) -> anyhow::Result<PathBuf> {
@@ -85,10 +86,10 @@ pub fn init_logger(oma: &OhManagerAilurus) -> anyhow::Result<PathBuf> {
         }
     };
 
-    let stream_sink = StdStreamSink::builder()
+    let stream_sink = WriteSink::builder()
         .formatter(formatter)
         .level_filter(level_filter)
-        .stderr()
+        .target(ProgressAwareWriter)
         .build()
         .unwrap();
 

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -415,7 +415,7 @@ impl ProgressRenderer {
 }
 
 impl ProgressRenderer {
-    /// Report the download phase through the terminal's taskbar (OSC 94).
+    /// Report the download phase as terminal percentage progress (OSC 94).
     fn update_osc94(&self, is_refresh: bool, download_only: bool) {
         if let Some((pos, len)) = self.sink.position_len() {
             osc94(is_refresh, download_only, pos, len);
@@ -472,8 +472,8 @@ impl ProgressRenderer {
                 if download_only {
                     OSC94.finish();
                 } else if !is_refresh {
-                    // Hand the taskbar over to the dpkg phase: the download
-                    // phase occupies 0-50%, the dpkg phase 50-100%.
+                    // Hand the progress reporting over to the dpkg phase: the
+                    // download phase occupies 0-50%, the dpkg phase 50-100%.
                     OSC94.set(50.0);
                 }
                 return true;
@@ -496,9 +496,9 @@ fn total_width(total: usize) -> usize {
     total.to_string().len()
 }
 
-/// Report download progress through the terminal's taskbar (OSC 94), used by
+/// Report download progress as terminal percentage progress (OSC 94), used by
 /// `oma install` and `oma download`. The download phase occupies 0-50% of the
-/// taskbar for installs (the dpkg phase fills the remaining 50-100% via
+/// progress for installs (the dpkg phase fills the remaining 50-100% via
 /// `OmaInstallProgressManager`) and 0-100% for `oma download`. Refresh never
 /// reports anything.
 fn osc94(is_refresh: bool, download_only: bool, pos: u64, len: u64) {

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -1,399 +1,278 @@
 use std::{
     borrow::Cow,
     cell::OnceCell,
+    io::{self, IsTerminal, Write},
+    ops::Deref,
+    sync::LazyLock,
     time::{Duration, Instant},
 };
 
 use ahash::{HashMap, RandomState};
+use anyhow::Chain;
 use oma_console::{
-    console::style,
-    indicatif::{MultiProgress, ProgressBar},
+    indicatif::{MultiProgress, ProgressBar as IndicatifProgressBar, ProgressStyle},
     pb::{global_progress_bar_style, progress_bar_style, spinner_style},
     print::Action,
-    terminal::gen_prefix,
-    writer::Writeln,
 };
 use oma_fetch::{Event, SingleDownloadError};
 use reqwest::StatusCode;
 
-use anyhow::Chain;
+use crate::{WRITER, fl, install_progress::OSC94, msg, root::is_root};
+use crate::{color_formatter, error::OutputError};
 use oma_refresh::db::Event as RefreshEvent;
 
-use crate::{WRITER, fl, install_progress::osc94_progress, msg, root::is_root};
-use crate::{color_formatter, error::OutputError};
 use oma_utils::human_bytes::HumanBytes;
-use spdlog::{debug, error, info, warn};
+use spdlog::{error, info, warn};
 
-pub trait RenderPackagesDownloadProgress {
-    fn render_progress(&mut self, rx: &flume::Receiver<Event>, download_only: bool);
+/// The global `MultiProgress` every progress bar is attached to. When no bar
+/// is active, [`MultiProgress::println`] falls back to printing the line
+/// directly to the terminal.
+static GLOBAL_MP: LazyLock<MultiProgress> = LazyLock::new(MultiProgress::new);
+
+/// A progress bar that is automatically attached to the global `MultiProgress`
+/// when created, so callers never touch the underlying `MultiProgress`
+/// directly (mirroring `tracing-indicatif`). All operations delegate to the
+/// wrapped indicatif bar via [`Deref`]; when progress is disabled a hidden
+/// no-op bar is returned instead, so callers never have to handle an `Option`.
+pub struct ProgressBar {
+    inner: IndicatifProgressBar,
 }
 
-pub trait RenderRefreshProgress {
-    fn render_refresh_progress(&mut self, rx: &flume::Receiver<RefreshEvent>);
-}
+impl ProgressBar {
+    /// Create a spinner progress bar and attach it to the global
+    /// `MultiProgress`. When `enabled` is false a hidden no-op bar is returned
+    /// instead.
+    pub fn new_spinner(msg: impl Into<Cow<'static, str>>, enabled: bool) -> Self {
+        if !enabled {
+            return Self::hidden();
+        }
 
-pub trait Print {
-    fn info(&self, msg: &str);
-    fn warn(&self, msg: &str);
-    fn error(&self, msg: &str);
-}
-
-pub struct OmaProgressBar {
-    pub inner: ProgressBar,
-}
-
-impl Print for OmaProgressBar {
-    #[inline]
-    fn info(&self, msg: &str) {
-        self.writeln(&style("INFO").blue().bold().to_string(), msg)
-            .ok();
-    }
-
-    #[inline]
-    fn warn(&self, msg: &str) {
-        self.writeln(&style("WARNING").yellow().bold().to_string(), msg)
-            .ok();
-    }
-
-    #[inline]
-    fn error(&self, msg: &str) {
-        self.writeln(&style("ERROR").red().bold().to_string(), msg)
-            .ok();
-    }
-}
-
-impl OmaProgressBar {
-    pub fn new_spinner(spinner_message: Option<impl Into<Cow<'static, str>>>) -> Self {
-        let pb = ProgressBar::new_spinner();
+        // Mount before configuring: drawing a bar before it is added to the
+        // `MultiProgress` writes straight to the terminal, which the
+        // `MultiProgress` cannot track or undo.
+        let pb = GLOBAL_MP.add(IndicatifProgressBar::new_spinner());
         let (sty, inv) = spinner_style();
         pb.set_style(sty);
         pb.enable_steady_tick(inv);
+        pb.set_message(msg);
 
-        if let Some(msg) = spinner_message {
-            pb.set_message(msg);
+        Self { inner: pb }
+    }
+
+    /// Create a determinate progress bar with a custom style and attach it to
+    /// the global `MultiProgress`. When `enabled` is false a hidden no-op bar
+    /// is returned instead.
+    pub fn new(len: u64, style: ProgressStyle, enabled: bool) -> Self {
+        if !enabled {
+            return Self::hidden();
         }
 
+        let pb = GLOBAL_MP.add(IndicatifProgressBar::new(len));
+        pb.set_style(style);
+
         Self { inner: pb }
     }
 
-    #[allow(dead_code)]
-    pub fn new(pb: ProgressBar) -> Self {
+    /// Create a spinner progress bar and insert it at a specific position,
+    /// used by the multi-bar download/refresh renderer to keep ordering.
+    pub(crate) fn insert_spinner(at: usize, msg: impl Into<Cow<'static, str>>) -> Self {
+        let pb = GLOBAL_MP.insert(at, IndicatifProgressBar::new_spinner());
+        let (sty, inv) = spinner_style();
+        pb.set_style(sty);
+        pb.enable_steady_tick(inv);
+        pb.set_message(msg);
+
         Self { inner: pb }
     }
-}
 
-impl Drop for OmaProgressBar {
-    fn drop(&mut self) {
+    /// Create a determinate progress bar and insert it at a specific position.
+    pub(crate) fn insert_bar(at: usize, len: u64, style: ProgressStyle) -> Self {
+        let pb = GLOBAL_MP.insert(at, IndicatifProgressBar::new(len));
+        pb.set_style(style);
+
+        Self { inner: pb }
+    }
+
+    /// Finish this bar and remove it from the global `MultiProgress`. Safe to
+    /// call more than once (e.g. from an explicit call site and again from
+    /// `Drop`): after the first call the bar is finished, so later calls are
+    /// no-ops.
+    pub fn finish_and_clear(&self) {
+        if self.inner.is_finished() {
+            return;
+        }
         self.inner.finish_and_clear();
+        GLOBAL_MP.remove(&self.inner);
+    }
+
+    fn hidden() -> Self {
+        Self {
+            inner: IndicatifProgressBar::hidden(),
+        }
     }
 }
 
-impl Writeln for OmaProgressBar {
-    fn writeln(&self, prefix: &str, msg: &str) -> std::io::Result<()> {
-        WRITER
-            .get_terminal()
-            .wrap_content(prefix, msg)
-            .into_iter()
-            .for_each(|(prefix, body)| {
-                self.inner
-                    .println(format!("{}{}", gen_prefix(prefix, 10), body));
-            });
+impl Deref for ProgressBar {
+    type Target = IndicatifProgressBar;
 
-        Ok(())
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
-pub struct OmaMultiProgressBar {
-    mb: MultiProgress,
+impl Drop for ProgressBar {
+    fn drop(&mut self) {
+        self.finish_and_clear();
+    }
+}
+
+/// A `Write` that renders log lines above the active progress bars when the
+/// terminal supports them, and to stderr otherwise.
+#[derive(Default)]
+pub struct ProgressAwareWriter;
+
+impl Write for ProgressAwareWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if io::stderr().is_terminal() {
+            let line = String::from_utf8_lossy(buf)
+                .trim_end_matches('\n')
+                .to_string();
+            GLOBAL_MP.println(line)?;
+        } else {
+            io::stderr().write_all(buf)?;
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        io::stderr().flush()
+    }
+}
+
+/// A sink that renders download progress events. [`ProgressRenderer`] picks a
+/// concrete sink based on `--no-progress`: interactive bars on the global
+/// `MultiProgress`, or plain textual progress lines.
+pub trait ProgressSink {
+    fn new_global_bar(&mut self, total_size: u64);
+    fn global_add(&mut self, num: u64);
+    fn global_sub(&mut self, num: u64);
+    fn new_spinner(&mut self, index: usize, total: usize, msg: String);
+    fn new_bar(&mut self, index: usize, total: usize, msg: String, size: u64);
+    fn inc(&mut self, index: usize, size: u64);
+    fn done(&mut self, index: usize);
+    fn refresh_spinner(&mut self, msg: String);
+    fn finish_all(&mut self);
+    /// Current global (position, length), used for the OSC 94 title update.
+    fn position_len(&self) -> Option<(u64, u64)>;
+}
+
+/// Progress sink that renders interactive bars on the global `MultiProgress`.
+struct BarProgress {
     pb_map: HashMap<usize, ProgressBar>,
 }
 
-impl Default for OmaMultiProgressBar {
-    fn default() -> Self {
+impl BarProgress {
+    fn new() -> Self {
         Self {
-            mb: MultiProgress::new(),
             pb_map: HashMap::with_hasher(RandomState::new()),
         }
     }
 }
 
-impl Print for OmaMultiProgressBar {
-    #[inline]
-    fn info(&self, msg: &str) {
-        self.writeln(&style("INFO").blue().bold().to_string(), msg)
-            .ok();
+impl ProgressSink for BarProgress {
+    fn new_global_bar(&mut self, total_size: u64) {
+        let pb = ProgressBar::insert_bar(
+            0,
+            total_size,
+            global_progress_bar_style(WRITER.get_length()),
+        );
+        self.pb_map.insert(0, pb);
     }
 
-    #[inline]
-    fn warn(&self, msg: &str) {
-        self.writeln(&style("WARNING").yellow().bold().to_string(), msg)
-            .ok();
+    fn global_add(&mut self, num: u64) {
+        if let Some(gpb) = self.pb_map.get(&0) {
+            gpb.inc(num);
+        }
     }
 
-    #[inline]
-    fn error(&self, msg: &str) {
-        self.writeln(&style("ERROR").red().bold().to_string(), msg)
-            .ok();
+    fn global_sub(&mut self, num: u64) {
+        if let Some(gpb) = self.pb_map.get(&0) {
+            gpb.set_position(gpb.position().saturating_sub(num));
+        }
+    }
+
+    fn new_spinner(&mut self, index: usize, total: usize, msg: String) {
+        // A previous attempt may have left a bar at this slot without a
+        // ProgressDone (e.g. an early request-phase failure): drop it before
+        // inserting so the ordering stays 1:1 with files and retries do not
+        // pile up dead bars.
+        if let Some(old) = self.pb_map.remove(&(index + 1)) {
+            old.finish_and_clear();
+        }
+        let total_width = total_width(total);
+        let pb = ProgressBar::insert_spinner(
+            index + 1,
+            format!("({:>total_width$}/{total}) {msg}", index + 1),
+        );
+        self.pb_map.insert(index + 1, pb);
+    }
+
+    fn new_bar(&mut self, index: usize, total: usize, msg: String, size: u64) {
+        // See new_spinner: clear any leftover bar at this slot before
+        // inserting so retries do not accumulate dead bars.
+        if let Some(old) = self.pb_map.remove(&(index + 1)) {
+            old.finish_and_clear();
+        }
+        let pb = ProgressBar::insert_bar(index + 1, size, progress_bar_style(WRITER.get_length()));
+        let total_width = total_width(total);
+        pb.set_message(format!("({:>total_width$}/{total}) {msg}", index + 1));
+        self.pb_map.insert(index + 1, pb);
+    }
+
+    fn inc(&mut self, index: usize, size: u64) {
+        if let Some(pb) = self.pb_map.get(&(index + 1)) {
+            pb.inc(size);
+        }
+    }
+
+    fn done(&mut self, index: usize) {
+        if let Some(pb) = self.pb_map.remove(&(index + 1)) {
+            pb.finish_and_clear();
+        }
+    }
+
+    fn refresh_spinner(&mut self, msg: String) {
+        let pb = ProgressBar::insert_spinner(1, msg);
+        self.pb_map.insert(1, pb);
+    }
+
+    fn finish_all(&mut self) {
+        // Finish and remove every bar still mounted (e.g. a download that
+        // errored before sending `ProgressDone`) so nothing is left on screen.
+        for (_, pb) in self.pb_map.drain() {
+            pb.finish_and_clear();
+        }
+    }
+
+    fn position_len(&self) -> Option<(u64, u64)> {
+        self.pb_map
+            .get(&0)
+            .and_then(|gpb| gpb.length().map(|len| (gpb.position(), len)))
     }
 }
 
-impl Writeln for OmaMultiProgressBar {
-    fn writeln(&self, prefix: &str, msg: &str) -> std::io::Result<()> {
-        for (prefix, body) in WRITER.get_terminal().wrap_content(prefix, msg).into_iter() {
-            self.mb
-                .println(format!("{}{}", gen_prefix(prefix, 10), body))?;
-        }
-
-        Ok(())
-    }
+/// Progress sink for `--no-progress` mode: no bars are drawn, download
+/// progress is printed as plain lines and refresh stages as log lines.
+struct TextProgress {
+    timer: Instant,
+    total_size: OnceCell<u64>,
+    old_downloaded: u64,
+    progress: u64,
 }
 
-impl RenderRefreshProgress for OmaMultiProgressBar {
-    fn render_refresh_progress(&mut self, rx: &flume::Receiver<RefreshEvent>) {
-        while let Ok(event) = rx.recv() {
-            match event {
-                RefreshEvent::DownloadEvent(event) => {
-                    self.download_event(event, true, false);
-                }
-                RefreshEvent::ScanningTopic => {
-                    let (sty, inv) = spinner_style();
-                    let pb = self
-                        .mb
-                        .insert(1, ProgressBar::new_spinner().with_style(sty));
-                    pb.set_message(fl!("refreshing-topic-metadata"));
-                    pb.enable_steady_tick(inv);
-                    self.pb_map.insert(1, pb);
-                }
-                RefreshEvent::ClosingTopic(topic) => {
-                    self.info(&fl!("scan-topic-is-removed", name = topic));
-                }
-                RefreshEvent::TopicNotInMirror { topic, mirror } => {
-                    self.warn(&fl!("topic-not-in-mirror", topic = topic, mirror = mirror));
-                    self.warn(&fl!("skip-write-mirror"));
-                }
-                RefreshEvent::RunInvokeScript => {
-                    let (sty, inv) = spinner_style();
-                    let pb = self
-                        .mb
-                        .insert(1, ProgressBar::new_spinner().with_style(sty));
-                    pb.set_message(fl!("oma-refresh-success-invoke"));
-                    pb.enable_steady_tick(inv);
-                    self.pb_map.insert(1, pb);
-                }
-                RefreshEvent::Done => break,
-                RefreshEvent::SourceListFileNotSupport { path } => {
-                    self.warn(&fl!(
-                        "unsupported-sources-list",
-                        p = color_formatter()
-                            .color_str(path.to_string_lossy(), Action::Emphasis)
-                            .to_string(),
-                        list = color_formatter()
-                            .color_str(".list", Action::Secondary)
-                            .to_string(),
-                        sources = color_formatter()
-                            .color_str(".sources", Action::Secondary)
-                            .to_string()
-                    ));
-                }
-            }
-        }
-    }
-}
-
-impl RenderPackagesDownloadProgress for OmaMultiProgressBar {
-    fn render_progress(&mut self, rx: &flume::Receiver<Event>, download_only: bool) {
-        while let Ok(event) = rx.recv() {
-            if self.download_event(event, false, download_only) {
-                break;
-            }
-        }
-    }
-}
-
-impl OmaMultiProgressBar {
-    fn download_event(&mut self, event: Event, is_refresh: bool, download_only: bool) -> bool {
-        match event {
-            Event::ChecksumMismatch {
-                index: _,
-                filename,
-                times,
-            } => {
-                self.error(&fl!("checksum-mismatch-retry", c = filename, retry = times));
-            }
-            Event::GlobalProgressAdd(num) => {
-                if let Some(gpb) = self.pb_map.get(&0) {
-                    gpb.inc(num);
-                    let pos = gpb.position();
-                    osc94(is_refresh, download_only, pos, gpb);
-                }
-            }
-            Event::GlobalProgressSub(num) => {
-                if let Some(gpb) = self.pb_map.get(&0) {
-                    gpb.set_position(gpb.position().saturating_sub(num));
-                    osc94(is_refresh, download_only, gpb.position(), gpb);
-                }
-            }
-            Event::ProgressDone(index) => {
-                // Remove the bar from the MultiProgress as well, not just
-                // finish/clear it: a later NewProgressSpinner/NewProgressBar
-                // re-inserts at the same index, and `insert` shifts any
-                // lingering member down, so every retry would otherwise pile
-                // up one more dead bar on screen.
-                if let Some(pb) = self.pb_map.remove(&(index + 1)) {
-                    pb.finish_and_clear();
-                    self.mb.remove(&pb);
-                }
-            }
-            Event::NewProgressSpinner { index, total, msg } => {
-                // A previous attempt may have left a bar at this slot without
-                // a ProgressDone (e.g. an early request-phase failure): drop
-                // it before inserting so the ordering stays 1:1 with files.
-                if let Some(old) = self.pb_map.remove(&(index + 1)) {
-                    old.finish_and_clear();
-                    self.mb.remove(&old);
-                }
-                let (sty, inv) = spinner_style();
-                let pb = self
-                    .mb
-                    .insert(index + 1, ProgressBar::new_spinner().with_style(sty));
-                let total_width = total_width(total);
-                pb.set_message(format!("({:>total_width$}/{total}) {msg}", index + 1));
-                pb.enable_steady_tick(inv);
-                self.pb_map.insert(index + 1, pb);
-            }
-            Event::NewProgressBar {
-                index,
-                total,
-                msg,
-                size,
-            } => {
-                // See NewProgressSpinner: clear any leftover bar at this slot
-                // before inserting so retries do not accumulate dead bars.
-                if let Some(old) = self.pb_map.remove(&(index + 1)) {
-                    old.finish_and_clear();
-                    self.mb.remove(&old);
-                }
-                let sty = progress_bar_style(WRITER.get_length());
-                let pb = self
-                    .mb
-                    .insert(index + 1, ProgressBar::new(size).with_style(sty));
-                let total_width = total_width(total);
-                pb.set_message(format!("({:>total_width$}/{total}) {msg}", index + 1));
-                self.pb_map.insert(index + 1, pb);
-            }
-            Event::ProgressInc { index, size } => {
-                if let Some(pb) = self.pb_map.get(&(index + 1)) {
-                    pb.inc(size);
-                }
-            }
-            Event::NextUrl {
-                index: _,
-                file_name,
-                err,
-            } => {
-                self.handle_download_err(file_name, is_refresh, err);
-                self.info(&fl!("can-not-get-source-next-url"));
-            }
-            Event::DownloadDone { index: _, msg } => {
-                spdlog::debug!("Downloaded {msg}");
-            }
-            Event::AllDone => {
-                if let Some(gpb) = &self.pb_map.get(&0) {
-                    gpb.finish_and_clear();
-                }
-                if download_only {
-                    osc94_progress(100.0, true);
-                }
-                return true;
-            }
-            Event::NewGlobalProgressBar(total_size) => {
-                let sty = global_progress_bar_style(WRITER.get_length());
-                let pb = self
-                    .mb
-                    .insert(0, ProgressBar::new(total_size).with_style(sty));
-                self.pb_map.insert(0, pb);
-            }
-            Event::Failed { file_name, error } => {
-                self.handle_download_err(file_name, is_refresh, error);
-            }
-            Event::Timeout { filename, times } => {
-                self.error(&fl!("timeout-retry", c = filename, retry = times));
-            }
-        };
-
-        false
-    }
-
-    fn handle_download_err(
-        &mut self,
-        file_name: String,
-        is_refresh: bool,
-        error: SingleDownloadError,
-    ) {
-        if let SingleDownloadError::ReqwestMiddlewareError { ref source } = error
-            && source
-                .status()
-                .is_some_and(|x| x == StatusCode::UNAUTHORIZED)
-        {
-            if !is_root() {
-                self.info(&fl!("auth-need-permission"));
-            } else {
-                self.info(&fl!("lack-auth-config-1"));
-                self.info(&fl!("lack-auth-config-2"));
-            }
-        }
-
-        let err = OutputError::from(error);
-        let errs = Chain::new(&err).collect::<Vec<_>>();
-        let first_cause = errs.first().unwrap().to_string();
-        let last = errs.iter().skip(1).last();
-
-        if let Some(last_cause) = last {
-            let reason = format!("{first_cause}: {last_cause}");
-            self.error_display(&file_name, is_refresh, reason);
-        } else if is_refresh {
-            self.error_display(&file_name, is_refresh, first_cause);
-        }
-
-        debug!("{:#?}", errs);
-    }
-
-    fn error_display(&mut self, file_name: &String, is_refresh: bool, reason: String) {
-        if is_refresh {
-            self.error(&fl!(
-                "download-file-failed-with-reason",
-                filename = file_name,
-                reason = reason
-            ));
-        } else {
-            self.error(&fl!(
-                "download-package-failed-with-reason",
-                filename = file_name,
-                reason = reason
-            ));
-        }
-    }
-}
-
-#[inline]
-fn total_width(total: usize) -> usize {
-    total.to_string().len()
-}
-
-fn osc94(is_refresh: bool, download_only: bool, pos: u64, gpb: &ProgressBar) {
-    if let Some(len) = gpb.length()
-        && !is_refresh
-    {
-        let mut pos = (pos as f32 / len as f32) * 100.0;
-        if !download_only {
-            pos *= 0.5;
-        }
-        osc94_progress(pos, false);
-    }
-}
-
-impl Default for NoProgressBar {
-    fn default() -> Self {
+impl TextProgress {
+    fn new() -> Self {
         Self {
             timer: Instant::now(),
             total_size: OnceCell::new(),
@@ -401,99 +280,8 @@ impl Default for NoProgressBar {
             progress: 0,
         }
     }
-}
 
-pub struct NoProgressBar {
-    timer: Instant,
-    total_size: OnceCell<u64>,
-    old_downloaded: u64,
-    progress: u64,
-}
-
-impl RenderPackagesDownloadProgress for NoProgressBar {
-    fn render_progress(&mut self, rx: &flume::Receiver<Event>, _download_only: bool) {
-        while let Ok(event) = rx.recv() {
-            if self.download_event(event, false) {
-                break;
-            }
-        }
-    }
-}
-
-impl RenderRefreshProgress for NoProgressBar {
-    fn render_refresh_progress(&mut self, rx: &flume::Receiver<RefreshEvent>) {
-        while let Ok(event) = rx.recv() {
-            match event {
-                RefreshEvent::DownloadEvent(event) => {
-                    self.download_event(event, true);
-                }
-                RefreshEvent::ClosingTopic(topic) => {
-                    info!("{}", fl!("scan-topic-is-removed", name = topic));
-                }
-                RefreshEvent::TopicNotInMirror { topic, mirror } => {
-                    warn!(
-                        "{}",
-                        fl!("topic-not-in-mirror", topic = topic, mirror = mirror)
-                    );
-                    warn!("{}", fl!("skip-write-mirror"));
-                }
-                RefreshEvent::RunInvokeScript => {
-                    info!("{}", fl!("oma-refresh-success-invoke"));
-                }
-                RefreshEvent::Done => break,
-                _ => {}
-            }
-        }
-    }
-}
-
-impl NoProgressBar {
-    fn download_event(&mut self, event: Event, is_refresh: bool) -> bool {
-        match event {
-            Event::ChecksumMismatch {
-                index: _,
-                filename,
-                times,
-            } => {
-                error!(
-                    "{}",
-                    fl!("checksum-mismatch-retry", c = filename, retry = times)
-                );
-            }
-            Event::GlobalProgressAdd(inc) => {
-                self.progress += inc;
-                self.print_progress();
-            }
-            Event::GlobalProgressSub(num) => {
-                self.progress = self.progress.saturating_sub(num);
-                self.old_downloaded = self.old_downloaded.saturating_sub(num);
-                self.print_progress();
-            }
-            Event::NextUrl {
-                index: _,
-                file_name,
-                err,
-            } => {
-                handle_no_pb_download_error(file_name, err, is_refresh);
-                info!("{}", fl!("can-not-get-source-next-url"));
-            }
-            Event::DownloadDone { index: _, msg } => {
-                WRITER.writeln("DONE", &msg).ok();
-            }
-            Event::AllDone => return true,
-            Event::NewGlobalProgressBar(total_size) => {
-                self.total_size.get_or_init(|| total_size);
-            }
-            Event::Failed { file_name, error } => {
-                handle_no_pb_download_error(file_name, error, is_refresh);
-            }
-            _ => {}
-        };
-
-        false
-    }
-
-    fn print_progress(&mut self) {
+    fn print(&mut self) {
         let elapsed = self.timer.elapsed();
         if elapsed >= Duration::from_secs(3) {
             if let Some(total_size) = self.total_size.get() {
@@ -512,7 +300,219 @@ impl NoProgressBar {
     }
 }
 
-fn handle_no_pb_download_error(file_name: String, error: SingleDownloadError, is_refresh: bool) {
+impl ProgressSink for TextProgress {
+    fn new_global_bar(&mut self, total_size: u64) {
+        self.total_size.get_or_init(|| total_size);
+    }
+
+    fn global_add(&mut self, num: u64) {
+        self.progress += num;
+        self.print();
+    }
+
+    fn global_sub(&mut self, num: u64) {
+        self.progress = self.progress.saturating_sub(num);
+        self.old_downloaded = self.old_downloaded.saturating_sub(num);
+        self.print();
+    }
+
+    fn new_spinner(&mut self, _index: usize, _total: usize, _msg: String) {}
+
+    fn new_bar(&mut self, _index: usize, _total: usize, _msg: String, _size: u64) {}
+
+    fn inc(&mut self, _index: usize, _size: u64) {}
+
+    fn done(&mut self, _index: usize) {}
+
+    fn refresh_spinner(&mut self, msg: String) {
+        info!("{}", msg);
+    }
+
+    fn finish_all(&mut self) {}
+
+    fn position_len(&self) -> Option<(u64, u64)> {
+        None
+    }
+}
+
+/// Renders download/refresh progress events by dispatching them to a
+/// [`ProgressSink`], chosen at construction based on `--no-progress`.
+pub struct ProgressRenderer {
+    sink: Box<dyn ProgressSink + Send>,
+}
+
+impl ProgressRenderer {
+    pub fn new(no_progress: bool) -> Self {
+        if no_progress {
+            Self {
+                sink: Box::new(TextProgress::new()),
+            }
+        } else {
+            Self {
+                sink: Box::new(BarProgress::new()),
+            }
+        }
+    }
+}
+
+impl ProgressRenderer {
+    pub(crate) fn render_refresh_progress(&mut self, rx: &flume::Receiver<RefreshEvent>) {
+        while let Ok(event) = rx.recv() {
+            match event {
+                RefreshEvent::DownloadEvent(event) => {
+                    self.download_event(event, true, false);
+                }
+                RefreshEvent::ScanningTopic => {
+                    self.sink.refresh_spinner(fl!("refreshing-topic-metadata"));
+                }
+                RefreshEvent::ClosingTopic(topic) => {
+                    info!("{}", fl!("scan-topic-is-removed", name = topic));
+                }
+                RefreshEvent::TopicNotInMirror { topic, mirror } => {
+                    warn!(
+                        "{}",
+                        fl!("topic-not-in-mirror", topic = topic, mirror = mirror)
+                    );
+                    warn!("{}", fl!("skip-write-mirror"));
+                }
+                RefreshEvent::RunInvokeScript => {
+                    self.sink.refresh_spinner(fl!("oma-refresh-success-invoke"));
+                }
+                RefreshEvent::Done => {
+                    self.sink.finish_all();
+                    break;
+                }
+                RefreshEvent::SourceListFileNotSupport { path } => {
+                    warn!(
+                        "{}",
+                        fl!(
+                            "unsupported-sources-list",
+                            p = color_formatter()
+                                .color_str(path.to_string_lossy(), Action::Emphasis)
+                                .to_string(),
+                            list = color_formatter()
+                                .color_str(".list", Action::Secondary)
+                                .to_string(),
+                            sources = color_formatter()
+                                .color_str(".sources", Action::Secondary)
+                                .to_string()
+                        )
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl ProgressRenderer {
+    pub(crate) fn render_progress(&mut self, rx: &flume::Receiver<Event>, download_only: bool) {
+        while let Ok(event) = rx.recv() {
+            if self.download_event(event, false, download_only) {
+                break;
+            }
+        }
+    }
+}
+
+impl ProgressRenderer {
+    /// Report the download phase through the terminal's taskbar (OSC 94).
+    fn update_osc94(&self, is_refresh: bool, download_only: bool) {
+        if let Some((pos, len)) = self.sink.position_len() {
+            osc94(is_refresh, download_only, pos, len);
+        }
+    }
+
+    fn download_event(&mut self, event: Event, is_refresh: bool, download_only: bool) -> bool {
+        match event {
+            Event::ChecksumMismatch {
+                index: _,
+                filename,
+                times,
+            } => {
+                error!(
+                    "{}",
+                    fl!("checksum-mismatch-retry", c = filename, retry = times)
+                );
+            }
+            Event::GlobalProgressAdd(num) => {
+                self.sink.global_add(num);
+                self.update_osc94(is_refresh, download_only);
+            }
+            Event::GlobalProgressSub(num) => {
+                self.sink.global_sub(num);
+                self.update_osc94(is_refresh, download_only);
+            }
+            Event::ProgressDone(index) => self.sink.done(index),
+            Event::NewProgressSpinner { index, total, msg } => {
+                self.sink.new_spinner(index, total, msg);
+            }
+            Event::NewProgressBar {
+                index,
+                total,
+                msg,
+                size,
+            } => {
+                self.sink.new_bar(index, total, msg, size);
+            }
+            Event::ProgressInc { index, size } => self.sink.inc(index, size),
+            Event::NextUrl {
+                index: _,
+                file_name,
+                err,
+            } => {
+                handle_download_error(file_name, is_refresh, err);
+                info!("{}", fl!("can-not-get-source-next-url"));
+            }
+            Event::DownloadDone { index, msg } => {
+                spdlog::debug!("Downloaded {msg}");
+                self.sink.done(index);
+            }
+            Event::AllDone => {
+                self.sink.finish_all();
+                if download_only {
+                    OSC94.finish();
+                } else if !is_refresh {
+                    // Hand the taskbar over to the dpkg phase: the download
+                    // phase occupies 0-50%, the dpkg phase 50-100%.
+                    OSC94.set(50.0);
+                }
+                return true;
+            }
+            Event::NewGlobalProgressBar(total_size) => self.sink.new_global_bar(total_size),
+            Event::Failed { file_name, error } => {
+                handle_download_error(file_name, is_refresh, error);
+            }
+            Event::Timeout { filename, times } => {
+                error!("{}", fl!("timeout-retry", c = filename, retry = times));
+            }
+        };
+
+        false
+    }
+}
+
+#[inline]
+fn total_width(total: usize) -> usize {
+    total.to_string().len()
+}
+
+/// Report download progress through the terminal's taskbar (OSC 94), used by
+/// `oma install` and `oma download`. The download phase occupies 0-50% of the
+/// taskbar for installs (the dpkg phase fills the remaining 50-100% via
+/// `OmaInstallProgressManager`) and 0-100% for `oma download`. Refresh never
+/// reports anything.
+fn osc94(is_refresh: bool, download_only: bool, pos: u64, len: u64) {
+    if is_refresh || len == 0 {
+        return;
+    }
+    let mut percent = (pos as f32 / len as f32) * 100.0;
+    if !download_only {
+        percent *= 0.5;
+    }
+    OSC94.set(percent.clamp(0.0, 100.0));
+}
+
+fn handle_download_error(file_name: String, is_refresh: bool, error: SingleDownloadError) {
     if let SingleDownloadError::ReqwestMiddlewareError { ref source } = error
         && source
             .status()

--- a/src/subcommand/clean.rs
+++ b/src/subcommand/clean.rs
@@ -3,7 +3,7 @@ use std::io::ErrorKind;
 use std::path::Path;
 
 use crate::config::OmaConfig;
-use crate::subcommand::utils::create_progress_spinner;
+use crate::pb::ProgressBar;
 
 use crate::exit_handle::ExitHandle;
 use crate::fl;
@@ -93,7 +93,7 @@ pub fn clean_download_packages_cache(
 ) -> Result<u64, OutputError> {
     let mut total_clean_size = 0;
 
-    let pb = create_progress_spinner(no_progress, fl!("cleaning"));
+    let pb = ProgressBar::new_spinner(fl!("cleaning"), !no_progress);
 
     remove(&download_dir.join("partial"), &mut total_clean_size);
 
@@ -149,9 +149,7 @@ pub fn clean_download_packages_cache(
         }
     }
 
-    if let Some(pb) = pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     Ok(total_clean_size)
 }

--- a/src/subcommand/contents_find.rs
+++ b/src/subcommand/contents_find.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 
 use crate::args::CliExecuter;
 
-use super::utils::create_progress_spinner;
+use crate::pb::ProgressBar;
 
 enum CliMode {
     Provides,
@@ -133,7 +133,7 @@ fn execute(
         _ => {}
     }
 
-    let pb = create_progress_spinner(no_progress || no_pager, fl!("searching"));
+    let pb = ProgressBar::new_spinner(fl!("searching"), !(no_progress || no_pager));
 
     let mut res = IndexSet::with_hasher(ahash::RandomState::new());
     let mut count = 0;
@@ -144,10 +144,7 @@ fn execute(
         } else if !res.contains(&line) {
             res.insert(line);
             count += 1;
-            if let Some(pb) = &pb {
-                pb.inner
-                    .set_message(fl!("search-with-result-count", count = count));
-            }
+            pb.set_message(fl!("search-with-result-count", count = count));
         }
     };
 
@@ -158,9 +155,7 @@ fn execute(
         cb,
     )?;
 
-    if let Some(pb) = &pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     if no_pager {
         return Ok(ExitHandle::default());

--- a/src/subcommand/download.rs
+++ b/src/subcommand/download.rs
@@ -12,7 +12,7 @@ use spdlog::error;
 use crate::completions::pkgnames_completions;
 use crate::config::OmaConfig;
 use crate::exit_handle::ExitHandle;
-use crate::pb::{NoProgressBar, OmaMultiProgressBar, RenderPackagesDownloadProgress};
+use crate::pb::ProgressRenderer;
 use crate::{error::OutputError, subcommand::utils::handle_no_result};
 use crate::{fl, success};
 
@@ -62,12 +62,8 @@ impl CliExecuter for Download {
 
         let no_progress = config.no_progress();
 
-        thread::spawn(move || {
-            let mut pb: Box<dyn RenderPackagesDownloadProgress> = if no_progress {
-                Box::new(NoProgressBar::default())
-            } else {
-                Box::new(OmaMultiProgressBar::default())
-            };
+        let handle = thread::spawn(move || {
+            let mut pb = ProgressRenderer::new(no_progress);
             pb.render_progress(&rx, true);
         });
 
@@ -84,7 +80,13 @@ impl CliExecuter for Download {
                     error!("{}", e);
                 }
             },
-        )?;
+        );
+
+        // Wait for the renderer thread to process the remaining events so no
+        // progress bar is left on screen when we continue.
+        handle.join().ok();
+
+        let summary = summary?;
 
         if !summary.success.is_empty() {
             success!(

--- a/src/subcommand/mirror.rs
+++ b/src/subcommand/mirror.rs
@@ -26,7 +26,6 @@ use inquire::ui::RenderConfig;
 use inquire::ui::StyleSheet;
 use inquire::ui::Styled;
 use oma_console::indicatif::HumanBytes;
-use oma_console::indicatif::ProgressBar;
 use oma_console::indicatif::ProgressStyle;
 use oma_mirror::MirrorManager;
 use oma_mirror::parser::MirrorConfig;
@@ -56,14 +55,12 @@ use crate::lang::SYSTEM_LANG;
 use crate::menu::multiselect;
 use crate::menu::select_tui_display_msg;
 use crate::menu::tui_select_list_size;
-use crate::pb::OmaProgressBar;
-use crate::pb::Print;
+use crate::pb::ProgressBar;
 use crate::root::is_root;
 use crate::root::root;
 use crate::success;
 use crate::table::PagerPrinter;
 
-use super::utils::create_progress_spinner;
 use crate::args::CliExecuter;
 
 const REPO_TEST_SHA256: &str = "1e2a82e7babb443b2b26b61ce5dd2bd25b06b30422b42ee709fddd2cc3ffe231";
@@ -385,11 +382,7 @@ fn get_latency(
 
     let mirrors = mm.mirrors_iter()?.collect::<Vec<_>>();
 
-    let pb = if !no_progress && !json {
-        Some(progress_bar(mirrors.len() as u64 - 5))
-    } else {
-        None
-    };
+    let pb = progress_bar(mirrors.len() as u64 - 5, !no_progress && !json);
 
     let origin_date = get_mirror_date(
         "https://repo-hk.aosc.io/debs/dists/stable/InRelease",
@@ -414,11 +407,7 @@ fn get_latency(
         .map(|(m, url)| (m, get_mirror_date(&url, client, m, &pb, true, timeout)))
         .filter_map(|(m, res)| {
             res.map_err(|e| {
-                if let Some(pb) = &pb {
-                    pb.error(&format!("{}: {}", m, e));
-                } else {
-                    error!("{}: {}", m, e);
-                }
+                error!("{}: {}", m, e);
                 result.lock().unwrap().push((m, Err(anyhow!("{e}"))));
                 e
             })
@@ -442,16 +431,10 @@ fn get_latency(
 
             result.lock().unwrap().push((res.0, Ok(delta_duration)));
 
-            if let Some(pb) = &pb {
-                pb.info(&format_latency(res.0, delta_duration));
-            } else {
-                info!("{}", format_latency(res.0, delta_duration));
-            }
+            info!("{}", format_latency(res.0, delta_duration));
         });
 
-    if let Some(pb) = &pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     let result = result.into_inner().unwrap();
 
@@ -538,7 +521,7 @@ fn get_mirror_date(
     url: &str,
     client: &blocking::Client,
     m: &str,
-    p: &Option<OmaProgressBar>,
+    p: &ProgressBar,
     error_without_url: bool,
     timeout: f64,
 ) -> anyhow::Result<String> {
@@ -570,9 +553,7 @@ fn get_mirror_date(
         .date
         .with_context(|| format!("mirror {} no date field found", m))?;
 
-    if let Some(p) = p {
-        p.inner.inc(1);
-    }
+    p.inc(1);
 
     Ok(date)
 }
@@ -601,17 +582,11 @@ fn speedtest(
 
     let mirrors = mm.mirrors_iter()?.collect::<Vec<_>>();
 
-    let pb = if !config.no_progress() {
-        Some(progress_bar(mirrors.len() as u64))
-    } else {
-        None
-    };
+    let pb = progress_bar(mirrors.len() as u64, !config.no_progress());
 
     let mut score_map = HashMap::with_hasher(ahash::RandomState::new());
 
-    if let Some(ref pb) = pb {
-        pb.info(&fl!("mirror-speedtest-start"));
-    }
+    info!("{}", fl!("mirror-speedtest-start"));
 
     for (name, mirror) in mirrors {
         let mut sha256 = IoWrapper(Sha256::new());
@@ -635,38 +610,22 @@ fn speedtest(
                         name,
                         HumanBytes((10.0 * 1024.0 * 1024.0 / dur.as_secs_f64()) as u64)
                     );
-                    if let Some(ref pb) = pb {
-                        pb.info(&msg);
-                    } else {
-                        info!("{msg}");
-                    }
+                    info!("{msg}");
                 } else {
                     let msg = format!("{name}: Checksum verification failed.");
-                    if let Some(ref pb) = pb {
-                        pb.error(&msg);
-                    } else {
-                        error!("{msg}");
-                    }
+                    error!("{msg}");
                 }
             }
             Err(e) => {
                 let msg = format!("{}: {}", name, e.without_url());
-                if let Some(ref pb) = pb {
-                    pb.error(&msg);
-                } else {
-                    error!("{}", msg);
-                }
+                error!("{msg}");
             }
         }
 
-        if let Some(ref pb) = pb {
-            pb.inner.inc(1);
-        }
+        pb.inc(1);
     }
 
-    if let Some(ref pb) = pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     let mut printer = PagerPrinter::new(stdout());
 
@@ -742,13 +701,13 @@ fn speedtest(
 }
 
 #[inline]
-fn progress_bar(mirrors_len: u64) -> OmaProgressBar {
-    OmaProgressBar::new(
-        ProgressBar::new(mirrors_len).with_style(
-            ProgressStyle::with_template("{spinner:.green} ({pos}/{len}) [{wide_bar:.cyan/blue}]")
-                .unwrap()
-                .progress_chars("=>-"),
-        ),
+fn progress_bar(mirrors_len: u64, enabled: bool) -> ProgressBar {
+    ProgressBar::new(
+        mirrors_len,
+        ProgressStyle::with_template("{spinner:.green} ({pos}/{len}) [{wide_bar:.cyan/blue}]")
+            .unwrap()
+            .progress_chars("=>-"),
+        enabled,
     )
 }
 
@@ -779,7 +738,7 @@ fn refresh_enabled_topics_sources_list(
     client: &ClientWithMiddleware,
     no_progress: bool,
 ) -> Result<(), OutputError> {
-    let pb = create_progress_spinner(no_progress, fl!("refreshing-topic-metadata"));
+    let pb = ProgressBar::new_spinner(fl!("refreshing-topic-metadata"), !no_progress);
 
     let try_refresh = Ok(()).and_then(|_| -> Result<(), OutputError> {
         let arch = dpkg_arch("/")?;
@@ -800,9 +759,7 @@ fn refresh_enabled_topics_sources_list(
         Ok(())
     });
 
-    if let Some(pb) = pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     try_refresh?;
 

--- a/src/subcommand/refresh.rs
+++ b/src/subcommand/refresh.rs
@@ -2,15 +2,14 @@ use clap::Args;
 use oma_pm::apt::{OmaApt, OmaAptArgs};
 use spdlog::info;
 
+use crate::args::CliExecuter;
 use crate::config::OmaConfig;
+use crate::core::refresh::Refresh as RefreshInner;
 use crate::core::space_tips;
 use crate::exit_handle::ExitHandle;
+use crate::pb::ProgressBar;
 use crate::{error::OutputError, root::root};
 use crate::{fl, success};
-
-use super::utils::create_progress_spinner;
-use crate::args::CliExecuter;
-use crate::core::refresh::Refresh as RefreshInner;
 
 #[derive(Debug, Args)]
 pub struct Refresh;
@@ -32,14 +31,12 @@ impl CliExecuter for Refresh {
 
         let apt = OmaApt::new(vec![], oma_apt_args, false)?;
 
-        let pb = create_progress_spinner(config.no_progress(), fl!("reading-database"));
+        let pb = ProgressBar::new_spinner(fl!("reading-database"), !config.no_progress());
 
         let (upgradable, upgradable_but_held) = apt.count_pending_upgradable_pkgs();
         let autoremovable = apt.count_pending_autoremovable_pkgs();
 
-        if let Some(pb) = pb {
-            pb.inner.finish_and_clear();
-        }
+        pb.finish_and_clear();
 
         let mut s = vec![];
 

--- a/src/subcommand/remove.rs
+++ b/src/subcommand/remove.rs
@@ -13,9 +13,10 @@ use crate::config::OmaConfig;
 use crate::core::commit_changes::CommitChanges;
 use crate::exit_handle::ExitHandle;
 use crate::fl;
+use crate::pb::ProgressBar;
 use crate::{dbus::dbus_check, error::OutputError, root::root};
 
-use super::utils::{create_progress_spinner, handle_no_result, lock_oma};
+use super::utils::{handle_no_result, lock_oma};
 use crate::args::CliExecuter;
 
 #[derive(Debug, Args)]
@@ -183,16 +184,14 @@ impl CliExecuter for Remove {
             }
         }
 
-        let pb = create_progress_spinner(config.no_progress(), fl!("resolving-dependencies"));
+        let pb = ProgressBar::new_spinner(fl!("resolving-dependencies"), !config.no_progress());
 
         #[cfg(feature = "aosc")]
         check_is_current_kernel_deleting(&config, &pkgs, &pb)?;
 
         let context = apt.remove(pkgs, remove_config, no_autoremove)?;
 
-        if let Some(pb) = pb {
-            pb.inner.finish_and_clear()
-        }
+        pb.finish_and_clear();
 
         if !context.is_empty() {
             for c in context {
@@ -220,14 +219,12 @@ impl CliExecuter for Remove {
 fn check_is_current_kernel_deleting(
     config: &OmaConfig,
     pkgs: &[oma_pm::pkginfo::OmaPackageWithoutVersion],
-    pb: &Option<crate::pb::OmaProgressBar>,
+    pb: &crate::pb::ProgressBar,
 ) -> Result<(), OutputError> {
     use anyhow::Context;
     use once_cell::sync::OnceCell;
 
-    if let Some(pb) = pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     let image_name = OnceCell::new();
     let current_kernel_ver = OnceCell::new();

--- a/src/subcommand/search.rs
+++ b/src/subcommand/search.rs
@@ -21,8 +21,7 @@ use crate::{
 use crate::{error::OutputError, table::oma_display_with_normal_output};
 
 use crate::args::CliExecuter;
-
-use super::utils::create_progress_spinner;
+use crate::pb::ProgressBar;
 
 #[proxy(
     interface = "io.aosc.Amo1",
@@ -139,7 +138,7 @@ impl CliExecuter for Search {
 
         let no_pager = no_pager || config.search_contents_println;
 
-        let pb = create_progress_spinner(config.no_progress() || json, fl!("searching"));
+        let pb = ProgressBar::new_spinner(fl!("searching"), !(config.no_progress() || json));
         let res = search(
             &pattern,
             match config.search_engine {
@@ -150,9 +149,7 @@ impl CliExecuter for Search {
             &config,
         )?;
 
-        if let Some(pb) = pb {
-            pb.inner.finish_and_clear();
-        }
+        pb.finish_and_clear();
 
         let mut pager = if !no_pager && !json {
             oma_display_with_normal_output(false, res.len() * 2)?

--- a/src/subcommand/topics.rs
+++ b/src/subcommand/topics.rs
@@ -30,9 +30,10 @@ use crate::{
     root::root,
 };
 
-use super::utils::{create_progress_spinner, lock_oma};
+use super::utils::lock_oma;
 
 use crate::args::CliExecuter;
+use crate::pb::ProgressBar;
 
 use crate::fl;
 use anyhow::Context;
@@ -501,15 +502,13 @@ fn select_prompt(
 }
 
 fn refresh_topics(no_progress: bool, tm: &mut TopicManager) -> Result<(), OutputError> {
-    let pb = create_progress_spinner(no_progress, fl!("refreshing-topic-metadata"));
+    let pb = ProgressBar::new_spinner(fl!("refreshing-topic-metadata"), !no_progress);
 
     tm.refresh()?;
     tm.remove_closed_topics()?;
     tm.write_enabled(false)?;
 
-    if let Some(pb) = pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     Ok(())
 }

--- a/src/subcommand/tree.rs
+++ b/src/subcommand/tree.rs
@@ -22,7 +22,8 @@ use crate::{
     exit_handle::ExitHandle, fl, table::oma_display_with_normal_output,
 };
 
-use super::utils::{create_progress_spinner, handle_no_result};
+use super::utils::handle_no_result;
+use crate::pb::ProgressBar;
 
 use termtree::Tree as TermTree;
 
@@ -140,7 +141,7 @@ impl CliExecuter for Tree {
 
         let mut res = vec![];
 
-        let pb = create_progress_spinner(config.no_progress() || no_pager, fl!("loading-tree"));
+        let pb = ProgressBar::new_spinner(fl!("loading-tree"), !(config.no_progress() || no_pager));
 
         for p in pkgs {
             let depth = 1;
@@ -178,9 +179,7 @@ impl CliExecuter for Tree {
             }
         }
 
-        if let Some(pb) = pb {
-            pb.inner.finish_and_clear();
-        }
+        pb.finish_and_clear();
 
         if no_pager {
             return Ok(ExitHandle::default());

--- a/src/subcommand/utils.rs
+++ b/src/subcommand/utils.rs
@@ -11,14 +11,12 @@ use crate::error::OutputError;
 use crate::fl;
 use crate::get_lock;
 use crate::msg;
-use crate::pb::OmaProgressBar;
+use crate::pb::ProgressBar;
 use crate::utils::get_lists_dir;
 use anyhow::Context;
 use dialoguer::console;
-use dialoguer::console::style;
 use indexmap::IndexSet;
 use oma_console::print::Action;
-use oma_console::writer::Writeln;
 use oma_contents::searcher::Mode;
 use oma_contents::searcher::search;
 use oma_pm::CustomDownloadMessage;
@@ -33,29 +31,13 @@ pub(crate) fn handle_no_result(no_result: Vec<&str>, no_progress: bool) -> Resul
 
     let mut bin = IndexSet::with_hasher(ahash::RandomState::new());
 
-    let pb = create_progress_spinner(no_progress, fl!("searching"));
+    let pb = ProgressBar::new_spinner(fl!("searching"), !no_progress);
 
     for word in no_result {
         if word == "266" {
-            if let Some(ref pb) = pb {
-                pb.writeln(
-                    &style("ERROR").red().bold().to_string(),
-                    "无法找到匹配关键字为艾露露的软件包",
-                )
-                .ok();
-            } else {
-                error!("无法找到匹配关键字为艾露露的软件包");
-            }
+            error!("无法找到匹配关键字为艾露露的软件包");
         } else {
-            if let Some(ref pb) = pb {
-                pb.writeln(
-                    &style("ERROR").red().bold().to_string(),
-                    &fl!("could-not-find-pkg-from-keyword", c = word),
-                )
-                .ok();
-            } else {
-                error!("{}", fl!("could-not-find-pkg-from-keyword", c = word));
-            }
+            error!("{}", fl!("could-not-find-pkg-from-keyword", c = word));
 
             search(get_lists_dir(), Mode::BinProvides, word, |(pkg, file)| {
                 if file == format!("/usr/bin/{word}") {
@@ -66,9 +48,7 @@ pub(crate) fn handle_no_result(no_result: Vec<&str>, no_progress: bool) -> Resul
         }
     }
 
-    if let Some(ref pb) = pb {
-        pb.inner.finish_and_clear();
-    }
+    pb.finish_and_clear();
 
     if !bin.is_empty() {
         info!("{}", fl!("no-result-bincontents-tips"));
@@ -129,14 +109,6 @@ pub fn download_message() -> Option<CustomDownloadMessage> {
 
         format!("{} ({})", name_and_version, entry.arch()).into()
     }))
-}
-
-pub fn create_progress_spinner(no_progress: bool, msg: String) -> Option<OmaProgressBar> {
-    if !no_progress {
-        OmaProgressBar::new_spinner(Some(msg)).into()
-    } else {
-        None
-    }
 }
 
 pub fn is_terminal() -> bool {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -10,12 +10,8 @@ use spdlog::{debug, info};
 use zbus::Connection;
 
 use crate::{
-    RT,
-    args::CliExecuter,
-    config::OmaConfig,
-    exit_handle::ExitHandle,
-    subcommand::{search::AmoProxy, utils::create_progress_spinner},
-    tui::render::PackageStatus,
+    RT, args::CliExecuter, config::OmaConfig, exit_handle::ExitHandle, pb::ProgressBar,
+    subcommand::search::AmoProxy, tui::render::PackageStatus,
 };
 use crate::{
     core::{commit_changes::CommitChanges, refresh::Refresh},
@@ -145,7 +141,7 @@ impl CliExecuter for Tui {
 
         let mut apt = OmaApt::new(vec![], oma_apt_args, false)?;
 
-        let pb = create_progress_spinner(config.no_progress(), fl!("reading-database"));
+        let pb = ProgressBar::new_spinner(fl!("reading-database"), !config.no_progress());
 
         let (upgradable, upgradable_but_held) = apt.count_pending_upgradable_pkgs();
         let autoremove = apt.count_pending_autoremovable_pkgs();
@@ -160,9 +156,7 @@ impl CliExecuter for Tui {
             local_searcher(&pb)?
         };
 
-        if let Some(pb) = pb {
-            pb.inner.finish_and_clear();
-        }
+        pb.finish_and_clear();
 
         let mut terminal = prepare_create_tui()
             .map_err(|e| OutputError::with_source("BUG: Failed to create crossterm instance", e))?;
@@ -224,7 +218,7 @@ impl CliExecuter for Tui {
     }
 }
 
-fn local_searcher(pb: &Option<crate::pb::OmaProgressBar>) -> Result<Searcher, OutputError> {
+fn local_searcher(pb: &ProgressBar) -> Result<Searcher, OutputError> {
     let lists_dir = apt_config::find_dir(
         "Dir::State::lists".to_string(),
         "var/lib/apt/lists".to_string(),
@@ -247,10 +241,7 @@ fn local_searcher(pb: &Option<crate::pb::OmaProgressBar>) -> Result<Searcher, Ou
         &search_cache,
         SearchType::Live,
         |n| {
-            if let Some(ref pb) = *pb {
-                pb.inner
-                    .set_message(fl!("reading-database-with-count", count = n));
-            }
+            pb.set_message(fl!("reading-database-with-count", count = n));
         },
     )?;
     Ok(Searcher::Local(Box::new(searcher)))


### PR DESCRIPTION
## Description

Unify progress bars and stderr logging under one global indicatif `MultiProgress`, and route every spdlog stderr message through it.

- Add `ProgressAwareWriter` and point the spdlog `WriteSink` at it (was `StdStreamSink::stderr()`), so log lines render above the active progress bars instead of corrupting them
- Add a `ProgressBar` wrapper that mounts onto the global `MultiProgress` (`GLOBAL_MP`); `finish_and_clear()` + `Drop` clean up bars, removing the `Option<ProgressBar>` / `create_progress_spinner` handling
- Fix progress bars lingering after `oma refresh`: constructors now mount before configure (indicatif "inadvertent draw before add"), `AllDone`/`Done` drain every remaining bar, renderer threads are joined
- Add a `ProgressSink` trait with `BarProgress` (interactive bars) and `TextProgress` (`--no-progress` plain lines); `ProgressRenderer` becomes a dispatcher with no `no_progress` branches
- Replace the stateless `osc94_progress` with an `Osc94` object (global `OSC94` static backed by an `AtomicU32`) that skips redundant progress updates, clamps to 0–100, handles zero-length downloads, and hands the progress to the dpkg phase at 50%

Verified with `cargo test --workspace` / `clippy` / `fmt`, plus PTY-based manual runs of `oma refresh` (bar and `--no-progress` modes) showing a clean final screen.

## About AI

This PR was written in collaboration with Deepseek V4 Flash in a VS Code agent session. I have reviewed and amended the code, tested it thoroughly, and updated the comments.

- Model: Deepseek v4 flash
- Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)
