### PR TITLE
refactor: replace chrono with jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "pure-rust-locales",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1158,6 +1157,37 @@ dependencies = [
  "chrono",
  "lazy-regex",
  "num-bigint",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2484,6 +2514,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,7 +3292,6 @@ dependencies = [
  "anyhow",
  "apt-auth-config",
  "bon",
- "chrono",
  "clap",
  "clap-i18n-richformatter",
  "clap_complete",
@@ -3249,6 +3315,7 @@ dependencies = [
  "i18n-embed-fl-no-check-hashmap-on-ra",
  "indexmap",
  "itertools 0.15.0",
+ "jiff",
  "libc",
  "oma-apt-pkg",
  "oma-console",
@@ -3337,9 +3404,9 @@ version = "0.31.0"
 dependencies = [
  "aho-corasick",
  "ansi-to-tui",
- "chrono",
  "console",
  "indicatif",
+ "jiff",
  "ratatui",
  "spdlog-rs",
  "termbg-with-async-stdin",
@@ -3393,7 +3460,7 @@ dependencies = [
 name = "oma-history"
 version = "0.11.0"
 dependencies = [
- "chrono",
+ "jiff",
  "oma-pm-operation-type",
  "rusqlite",
  "serde",
@@ -3439,12 +3506,12 @@ dependencies = [
  "ahash",
  "anyhow",
  "bon",
- "chrono",
  "cxx",
  "deb822-lossless",
  "flume",
  "fs4",
  "glob-match",
+ "jiff",
  "oma-apt",
  "oma-fetch",
  "oma-pm-operation-type",
@@ -3476,10 +3543,10 @@ dependencies = [
  "ahash",
  "aho-corasick",
  "bon",
- "chrono",
  "deb822-fast",
  "fancy-regex 0.18.0",
  "flume",
+ "jiff",
  "oma-apt",
  "oma-apt-sources-lists",
  "oma-fetch",
@@ -3502,7 +3569,7 @@ name = "oma-repo-verify"
 version = "0.10.0"
 dependencies = [
  "anyhow",
- "chrono",
+ "jiff",
  "oma-apt-sources-lists",
  "sequoia-openpgp",
  "sequoia-policy-config",
@@ -3920,6 +3987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,12 +4097,6 @@ checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
-
-[[package]]
-name = "pure-rust-locales"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ oma-inquire = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true, features = ["tz-system", "tzdb-zoneinfo"] }
 rustix = { workspace = true, features = ["process", "stdio"] }
 libc = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["http2"] }
@@ -116,7 +116,7 @@ tokio = { version = "1.46.0", default-features = false }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 toml = "1"
-chrono = "0.4.38"
+jiff = { version = "0.2", default-features = false, features = ["std", "tz-fat"] }
 rustix = { version = "1", features = ["process", "stdio"] }
 libc = "0.2.159"
 reqwest = { version = "0.13", default-features = false, features = ["http2"] }

--- a/oma-console/Cargo.toml
+++ b/oma-console/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = { workspace = true, optional = true }
+jiff = { workspace = true, optional = true }
 console = { workspace = true, optional = true }
 indicatif = { workspace = true, optional = true }
 spdlog-rs = { workspace = true }
@@ -22,7 +22,7 @@ aho-corasick = { workspace = true, optional = true }
 tui-input = { workspace = true, optional = true }
 
 [features]
-print = ["dep:chrono", "dep:textwrap", "dep:console", "dep:termbg"]
+print = ["dep:jiff", "dep:textwrap", "dep:console", "dep:termbg"]
 pager = ["dep:ratatui", "dep:ansi-to-tui", "dep:console", "dep:aho-corasick", "dep:tui-input"]
 progress_bar_style = ["dep:indicatif"]
 default = ["print", "pager", "progress_bar_style"]

--- a/oma-console/src/print.rs
+++ b/oma-console/src/print.rs
@@ -2,8 +2,8 @@ use std::fmt::{self, Write};
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use chrono::{DateTime, SecondsFormat, Utc};
 use console::{Color, StyledObject, style};
+use jiff::Timestamp;
 use spdlog::{Level, debug, formatter::Formatter};
 use termbg::Theme;
 
@@ -288,8 +288,10 @@ impl OmaFormatter {
 
         if self.with_time {
             let time = {
-                let time = DateTime::<Utc>::from(record.time())
-                    .to_rfc3339_opts(SecondsFormat::Millis, true);
+                let time = format!(
+                    "{:.3}",
+                    Timestamp::try_from(record.time()).unwrap_or_default()
+                );
 
                 if self.with_ansi {
                     console::style(time).dim().to_string()

--- a/oma-history/Cargo.toml
+++ b/oma-history/Cargo.toml
@@ -16,4 +16,4 @@ spdlog-rs = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-chrono = { workspace = true }
+jiff = { workspace = true }

--- a/oma-history/examples/last_upgrade_date.rs
+++ b/oma-history/examples/last_upgrade_date.rs
@@ -6,6 +6,6 @@ fn main() {
 
     println!(
         "Last upgrade system date: {}",
-        chrono::DateTime::from_timestamp(n, 0).unwrap()
+        jiff::Timestamp::from_second(n).unwrap()
     );
 }

--- a/oma-pm/Cargo.toml
+++ b/oma-pm/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 oma-apt = { workspace = true }
 thiserror = { workspace = true }
-chrono = { workspace = true, features = ["unstable-locales"] }
+jiff = { workspace = true, features = ["tz-system", "tzdb-zoneinfo"] }
 glob-match = { workspace = true }
 oma-utils = { workspace = true, features = [
     "dpkg",

--- a/oma-pm/src/commit.rs
+++ b/oma-pm/src/commit.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use chrono::Local;
+use jiff::Zoned;
 use oma_apt::{
     error::AptErrors,
     progress::{AcquireProgress, InstallProgress},
@@ -185,7 +185,7 @@ impl<'a> DoInstall<'a> {
     }
 
     fn log(sysroot: &'a str, op: &OmaOperation) -> OmaAptResult<()> {
-        let end_time = Local::now().format(TIME_FORMAT).to_string();
+        let end_time = Zoned::now().strftime(TIME_FORMAT).to_string();
 
         let sysroot = Path::new(sysroot);
         let history = sysroot.join("var/log/oma/history");
@@ -202,7 +202,7 @@ impl<'a> DoInstall<'a> {
             .open(&history)
             .map_err(|e| OmaAptError::FailedOperateDirOrFile(history.display().to_string(), e))?;
 
-        let start_time = Local::now();
+        let start_time = Zoned::now().strftime("%Y-%m-%d %H:%M:%S %:z").to_string();
         writeln!(log, "Start-Date: {start_time}").ok();
 
         let args = std::env::args().collect::<Vec<_>>().join(" ");

--- a/oma-refresh/Cargo.toml
+++ b/oma-refresh/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { workspace = true, default-features = false, features = [
     "rt-multi-thread",
 ] }
 oma-apt-sources-lists = { workspace = true }
-chrono = { workspace = true, features = ["unstable-locales"] }
+jiff = { workspace = true }
 oma-topics = { workspace = true, optional = true, default-features = false }
 spdlog-rs = { workspace = true }
 oma-repo-verify = { workspace = true, default-features = false }

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -8,7 +8,7 @@ use std::{
 use ahash::{AHashMap, HashSet, HashSetExt};
 use aho_corasick::BuildError;
 use bon::Builder;
-use chrono::Utc;
+use jiff::Timestamp;
 
 use flume::Sender;
 #[cfg(feature = "apt")]
@@ -566,7 +566,7 @@ impl OmaRefresh {
                 .map_err(|e| RefreshError::InReleaseParseError(inrelease_path.clone(), e))?;
 
             if !m.is_flat() {
-                let now = Utc::now();
+                let now = Timestamp::now();
                 release
                     .check_date(&now)
                     .map_err(|e| RefreshError::InReleaseParseError(inrelease_path.clone(), e))?;

--- a/oma-refresh/src/inrelease.rs
+++ b/oma-refresh/src/inrelease.rs
@@ -1,5 +1,5 @@
-use chrono::{DateTime, FixedOffset, ParseError, Utc};
 use deb822_fast::{FromDeb822, FromDeb822Paragraph, Paragraph};
+use jiff::Timestamp;
 use oma_apt_sources_lists::Signature;
 use oma_repo_verify::verify_release_by_sysroot;
 use once_cell::sync::OnceCell;
@@ -129,7 +129,7 @@ impl Release {
         })
     }
 
-    pub fn check_date(&self, now: &DateTime<Utc>) -> Result<(), InReleaseError> {
+    pub fn check_date(&self, now: &Timestamp) -> Result<(), InReleaseError> {
         let date = self
             .source
             .date
@@ -148,7 +148,7 @@ impl Release {
         Ok(())
     }
 
-    pub fn check_valid_until(&self, now: &DateTime<Utc>) -> Result<(), InReleaseError> {
+    pub fn check_valid_until(&self, now: &Timestamp) -> Result<(), InReleaseError> {
         // Check if the `Valid-Until` field is valid only when it is defined.
         if let Some(valid_until_date) = &self.source.valid_until {
             let valid_until = parse_date(valid_until_date).map_err(|e| {
@@ -278,18 +278,18 @@ pub(crate) fn file_is_compress(name: &str) -> bool {
 #[derive(Debug, Error)]
 enum ParseDateError {
     #[error(transparent)]
-    ParseError(#[from] ParseError),
+    ParseError(#[from] jiff::Error),
     #[error("Could not parse date: {0}")]
     BadDate(ParseIntError),
 }
 
-fn parse_date(date: &str) -> Result<DateTime<FixedOffset>, ParseDateError> {
-    match DateTime::parse_from_rfc2822(date) {
-        Ok(res) => Ok(res),
+fn parse_date(date: &str) -> Result<Timestamp, ParseDateError> {
+    match jiff::fmt::rfc2822::parse(date) {
+        Ok(res) => Ok(res.timestamp()),
         Err(e) => {
             debug!("Failed to parse {}: {e}, trying to use date hack ...", date);
             let hack_date = date_hack(date).map_err(ParseDateError::BadDate)?;
-            Ok(DateTime::parse_from_rfc2822(&hack_date)?)
+            Ok(jiff::fmt::rfc2822::parse(&hack_date)?.timestamp())
         }
     }
 }
@@ -301,12 +301,12 @@ fn parse_date(date: &str) -> Result<DateTime<FixedOffset>, ParseDateError> {
 ///   Time, which is not allowed in RFC 1123 or 822/2822 (all calls for "GMT" or "UT", 822 allows "Z", and 2822 allows
 ///   "+0000").
 /// - This is used by many commercial software vendors, such as Google, Microsoft, and Spotify.
-/// - This is allowed in APT's RFC 1123 parser. However, as chrono requires full compliance with the
+/// - This is allowed in APT's RFC 1123 parser. However, as jiff requires full compliance with the
 ///   aforementioned RFC documents, "UTC" is considered illegal.
 ///
-/// Replace the "UTC" marker at the end of date strings to make it palatable to chronos.
+/// Replace the "UTC" marker at the end of date strings to make it palatable to jiff.
 ///
-/// and for non-standard X:YY:ZZ conversion to XX:YY:ZZ to make it palatable to chronos.
+/// and for non-standard X:YY:ZZ conversion to XX:YY:ZZ to make it palatable to jiff.
 fn date_hack(date: &str) -> Result<String, ParseIntError> {
     let mut split_time = date
         .split_ascii_whitespace()
@@ -320,7 +320,7 @@ fn date_hack(date: &str) -> Result<String, ParseIntError> {
 
         let mut time_split = c.split(':').map(|x| x.to_string()).collect::<Vec<_>>();
 
-        // X:YY:ZZ conversion to XX:YY:ZZ to make it palatable to chronos
+        // X:YY:ZZ conversion to XX:YY:ZZ to make it palatable to jiff
         for k in time_split.iter_mut() {
             match k.parse::<u64>()? {
                 0..=9 if k.len() == 1 => {
@@ -343,19 +343,19 @@ fn test_date_hack() {
     let a = "Thu, 02 May 2024  9:58:03 UTC";
     let hack = date_hack(&a).unwrap();
     assert_eq!(hack, "Thu, 02 May 2024 09:58:03 +0000");
-    let b = DateTime::parse_from_rfc2822(&hack);
+    let b = jiff::fmt::rfc2822::parse(&hack);
     assert!(b.is_ok());
 
     let a = "Thu, 02 May 2024 09:58:03 +0000";
     let hack = date_hack(&a).unwrap();
     assert_eq!(hack, "Thu, 02 May 2024 09:58:03 +0000");
-    let b = DateTime::parse_from_rfc2822(&hack);
+    let b = jiff::fmt::rfc2822::parse(&hack);
     assert!(b.is_ok());
 
     let a = "Thu, 02 May 2024  0:58:03 +0000";
     let hack = date_hack(&a).unwrap();
     assert_eq!(hack, "Thu, 02 May 2024 00:58:03 +0000");
-    let b = DateTime::parse_from_rfc2822(&hack);
+    let b = jiff::fmt::rfc2822::parse(&hack);
     assert!(b.is_ok());
 }
 

--- a/oma-repo-verify/Cargo.toml
+++ b/oma-repo-verify/Cargo.toml
@@ -12,7 +12,7 @@ sequoia-openpgp = { workspace = true }
 spdlog-rs = { workspace = true }
 oma-apt-sources-lists = { workspace = true }
 sequoia-policy-config = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
 
 [features]
 sequoia-openssl-backend = ["sequoia-openpgp/crypto-openssl"]

--- a/oma-repo-verify/src/lib.rs
+++ b/oma-repo-verify/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::bail;
-use chrono::{DateTime, NaiveDate, Utc};
+use jiff::civil::date;
 use oma_apt_sources_lists::Signature;
 use sequoia_openpgp::{
     Cert, KeyHandle,
@@ -200,29 +200,33 @@ fn policy() -> StandardPolicy<'static> {
 fn default_policy() -> StandardPolicy<'static> {
     let mut policy = StandardPolicy::new();
 
-    let expire_20240201: SystemTime = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2024, 2, 1).unwrap().into(),
-        Utc,
-    )
-    .into();
+    let expire_20240201: SystemTime = date(2024, 2, 1)
+        .at(0, 0, 0, 0)
+        .to_zoned(jiff::tz::TimeZone::UTC)
+        .unwrap()
+        .timestamp()
+        .into();
 
-    let expire_20280201: SystemTime = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2028, 2, 1).unwrap().into(),
-        Utc,
-    )
-    .into();
+    let expire_20280201: SystemTime = date(2028, 2, 1)
+        .at(0, 0, 0, 0)
+        .to_zoned(jiff::tz::TimeZone::UTC)
+        .unwrap()
+        .timestamp()
+        .into();
 
-    let expire_20300201: SystemTime = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2030, 2, 1).unwrap().into(),
-        Utc,
-    )
-    .into();
+    let expire_20300201: SystemTime = date(2030, 2, 1)
+        .at(0, 0, 0, 0)
+        .to_zoned(jiff::tz::TimeZone::UTC)
+        .unwrap()
+        .timestamp()
+        .into();
 
-    let expire_20260201: SystemTime = DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDate::from_ymd_opt(2026, 2, 1).unwrap().into(),
-        Utc,
-    )
-    .into();
+    let expire_20260201: SystemTime = date(2026, 2, 1)
+        .at(0, 0, 0, 0)
+        .to_zoned(jiff::tz::TimeZone::UTC)
+        .unwrap()
+        .timestamp()
+        .into();
 
     policy.reject_asymmetric_algo_at(AsymmetricAlgorithm::DSA2048, Some(expire_20240201));
     policy.reject_asymmetric_algo_at(AsymmetricAlgorithm::DSA3072, Some(expire_20240201));

--- a/src/core/commit_changes.rs
+++ b/src/core/commit_changes.rs
@@ -2,9 +2,9 @@ use std::{fs, path::Path, sync::atomic::Ordering, thread};
 
 use ahash::{HashMap, HashSet};
 use bon::Builder;
-use chrono::Local;
 use dialoguer::{Confirm, theme::ColorfulTheme};
 use flume::unbounded;
+use jiff::Timestamp;
 use oma_console::{indicatif::HumanBytes, pager::PagerExit, print::Action};
 use oma_history::{DATABASE_PATH, HistoryInfo};
 use oma_pm::{
@@ -184,7 +184,7 @@ impl CommitChanges<'_> {
 
         let id = history.write(HistoryInfo {
             summary: &op,
-            start_time: Local::now().timestamp(),
+            start_time: Timestamp::now().as_second(),
             success: false,
             is_fix_broken: is_fixbroken,
             is_undo,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -28,7 +28,7 @@ pub fn init_logger(oma: &OhManagerAilurus) -> anyhow::Result<PathBuf> {
             .expect("Failed to get state dir")
             .join("oma")
     })
-    .join(format!("oma.log.{}", chrono::Local::now().timestamp()));
+    .join(format!("oma.log.{}", jiff::Timestamp::now().as_second()));
 
     init_log_crate_proxy().unwrap();
 

--- a/src/subcommand/history_tui/key_binding.rs
+++ b/src/subcommand/history_tui/key_binding.rs
@@ -3,7 +3,7 @@ use std::{
     ops::ControlFlow,
 };
 
-use chrono::{Local, TimeZone, offset::LocalResult};
+use jiff::Timestamp;
 use ratatui::{
     backend::Backend,
     crossterm::{
@@ -109,12 +109,11 @@ impl<'a> HistorySelectTui<'a> {
                     .all_entries
                     .iter()
                     .filter(|entry| {
-                        let dt = match Local.timestamp_opt(entry.time, 0) {
-                            LocalResult::None => Local.timestamp_opt(0, 0).unwrap(),
-                            x => x.unwrap(),
-                        }
-                        .format("%H:%M:%S on %Y-%m-%d")
-                        .to_string();
+                        let dt = Timestamp::from_second(entry.time)
+                            .unwrap_or_default()
+                            .to_zoned(jiff::tz::TimeZone::system())
+                            .strftime("%H:%M:%S on %Y-%m-%d")
+                            .to_string();
 
                         entry.command.to_lowercase().contains(query)
                             || contains_query_pkg.contains(&entry.id)

--- a/src/subcommand/history_tui/mod.rs
+++ b/src/subcommand/history_tui/mod.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use chrono::{Local, LocalResult, TimeZone};
+use jiff::Timestamp;
 use oma_history::HistoryEntry;
 use ratatui::{
     Frame, Terminal,
@@ -198,12 +198,13 @@ impl<'a> HistorySelectTui<'a> {
                     Cell::from(line)
                 },
                 {
-                    let dt = match Local.timestamp_opt(item.time, 0) {
-                        LocalResult::None => Local.timestamp_opt(0, 0).unwrap(),
-                        x => x.unwrap(),
-                    };
+                    let dt = Timestamp::from_second(item.time)
+                        .unwrap_or_default()
+                        .to_zoned(jiff::tz::TimeZone::system())
+                        .strftime("%H:%M:%S on %Y-%m-%d")
+                        .to_string();
 
-                    Cell::new(dt.format("%H:%M:%S on %Y-%m-%d").to_string())
+                    Cell::new(dt)
                 },
             ])
         });

--- a/src/subcommand/mirror.rs
+++ b/src/subcommand/mirror.rs
@@ -12,8 +12,6 @@ use ahash::HashMap;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
-use chrono::DateTime;
-use chrono::TimeDelta;
 use clap::Args;
 use clap::Subcommand;
 use dialoguer::Sort;
@@ -402,8 +400,9 @@ fn get_latency(
         timeout,
     )?;
 
-    let origin_date =
-        DateTime::parse_from_rfc2822(&origin_date).context("Failed parse origin date")?;
+    let origin_date = jiff::fmt::rfc2822::parse(&origin_date)
+        .context("Failed parse origin date")?
+        .timestamp();
 
     let result = Mutex::new(vec![]);
 
@@ -429,20 +428,24 @@ fn get_latency(
         .map(|res| {
             (
                 res.0,
-                chrono::DateTime::parse_from_rfc2822(&res.1).expect("{} is not a rfc2822 fmt"),
+                jiff::fmt::rfc2822::parse(&res.1)
+                    .expect("{} is not a rfc2822 fmt")
+                    .timestamp(),
             )
         })
         .for_each(|res| {
-            let delta = origin_date - res.1;
+            let dur = origin_date.duration_since(res.1);
+            if dur.is_negative() {
+                panic!("Latency delta should not be < 0");
+            }
+            let delta_duration = dur.unsigned_abs();
 
-            result.lock().unwrap().push((res.0, Ok(delta)));
-
-            let delta_duration = delta.to_std().expect("Latency delta should not be < 0");
+            result.lock().unwrap().push((res.0, Ok(delta_duration)));
 
             if let Some(pb) = &pb {
-                pb.info(&format_latency(res.0, delta, delta_duration));
+                pb.info(&format_latency(res.0, delta_duration));
             } else {
-                info!("{}", format_latency(res.0, delta, delta_duration));
+                info!("{}", format_latency(res.0, delta_duration));
             }
         });
 
@@ -460,7 +463,7 @@ fn get_latency(
                 match time {
                     Ok(t) => serde_json::json!({
                         "status": "ok",
-                        "latency": t.num_seconds(),
+                        "latency": t.as_secs(),
                     }),
                     Err(e) => serde_json::json!({
                         "status": "fail",
@@ -480,13 +483,9 @@ fn get_latency(
             .iter()
             .filter_map(|x| {
                 if let Ok(time_delta) = x.1 {
-                    let hours = time_delta.num_hours();
-                    let secs = time_delta.num_seconds();
-                    let latency = format_duration(
-                        time_delta
-                            .to_std()
-                            .expect("Latency delta should not be < 0"),
-                    );
+                    let hours = time_delta.as_secs() / 3600;
+                    let secs = time_delta.as_secs() as i64;
+                    let latency = format_duration(time_delta);
 
                     let color_mirror_status = if hours <= 12 {
                         style(latency).green().to_string()
@@ -526,8 +525,8 @@ fn get_latency(
     Ok(ExitHandle::default().ring(true))
 }
 
-fn format_latency(mirror_name: &str, delta: TimeDelta, delta_duration: Duration) -> String {
-    if delta.is_zero() {
+fn format_latency(mirror_name: &str, delta_duration: Duration) -> String {
+    if delta_duration.is_zero() {
         fl!("oma-mirror-up-to-date", mirror = mirror_name)
     } else {
         let dur = format_duration(delta_duration).to_string();


### PR DESCRIPTION
## Description

chrono is soft-deprecated upstream (chronotope/chrono#1768) and jiff is the recommended replacement.

- Add `jiff` to the workspace (`std` + `tz-fat` base; `oma-pm` and the main binary add `tz-system` + `tzdb-zoneinfo` for system time zones).
- Parse InRelease RFC 2822 dates with jiff::fmt::rfc2822 instead of chrono's parse_from_rfc2822; the date_hack workaround is kept.
- Replace Local/Utc/DateTime/TimeDelta with Timestamp/Zoned, and use std::time::Duration for mirror latency.
- Format log timestamps with jiff Display precision ({:.3}).

## About AI

This PR was written in collaboration with Deepseek V4 Flash in a VS Code agent session. I have reviewed and amended the code, tested it thoroughly, and updated the comments.

- Model: Deepseek v4 flash
- Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)