### PR TITLE
fix(oma-fetch): close progress bars on request-phase errors

### DIFF
--- a/oma-fetch/Cargo.toml
+++ b/oma-fetch/Cargo.toml
@@ -46,7 +46,14 @@ anyhow = { workspace = true }
 ahash = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "net",
+    "io-util",
+    "fs",
+    "time",
+] }
 flume = { workspace = true }
 
 [features]

--- a/oma-fetch/src/download.rs
+++ b/oma-fetch/src/download.rs
@@ -610,6 +610,7 @@ impl SingleDownloader {
                         // some servers reply with Bad Request when Range is invalid
                         // so retry once
                         if downloaded_size == 0 {
+                            callback(Event::ProgressDone(self.download_list_index)).await;
                             return Err(ProgressedError::new(
                                 SingleDownloadError::ReqwestMiddlewareError { source: e },
                                 reported,
@@ -621,6 +622,7 @@ impl SingleDownloader {
                         }
                     }
                     _ => {
+                        callback(Event::ProgressDone(self.download_list_index)).await;
                         return Err(ProgressedError::new(
                             SingleDownloadError::ReqwestMiddlewareError { source: e },
                             reported,
@@ -628,6 +630,7 @@ impl SingleDownloader {
                     }
                 },
                 Err(_) => {
+                    callback(Event::ProgressDone(self.download_list_index)).await;
                     return Err(ProgressedError::new(
                         SingleDownloadError::SendRequestTimeout,
                         reported,
@@ -993,6 +996,10 @@ impl SingleDownloader {
                 if bytes != 0 {
                     callback(Event::GlobalProgressSub(bytes)).await;
                 }
+                // Undo this source's bar: the copy loop cannot report a
+                // `ProgressDone` itself (it never mounted a bar), so do it
+                // here before handing the error up.
+                callback(Event::ProgressDone(self.download_list_index)).await;
                 Err(error)
             }
         }

--- a/oma-fetch/tests/bar_lifecycle.rs
+++ b/oma-fetch/tests/bar_lifecycle.rs
@@ -1,0 +1,95 @@
+use std::{path::PathBuf, time::Duration};
+
+use oma_fetch::{DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType, Event};
+use reqwest::ClientBuilder;
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpListener;
+
+/// A server that accepts a connection, reads the request, then stalls
+/// forever. The client's request phase therefore times out
+/// (`SendRequestTimeout`).
+async fn stall_server() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        while let Ok((mut socket, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                let _ = socket.read(&mut buf).await;
+                // never respond
+                std::future::pending::<()>().await;
+            });
+        }
+    });
+    port
+}
+
+/// Every bar that is opened (`NewProgressSpinner` / `NewProgressBar`) must be
+/// closed (`ProgressDone` / `DownloadDone`) once the download finishes, no
+/// matter which error path was taken. A leaked bar is exactly what makes the
+/// terminal show more progress entries than there are worker threads.
+#[tokio::test]
+async fn every_bar_is_closed_on_request_timeout() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .unwrap();
+
+    let port = stall_server().await;
+    let source = DownloadSource {
+        url: format!("http://127.0.0.1:{port}/pkg.deb"),
+        source_type: DownloadSourceType::Http,
+    };
+    let entry = DownloadEntry::builder()
+        .source(vec![source])
+        .filename("pkg.deb".to_string())
+        .dir(PathBuf::from("/tmp/oma-fetch-bar-test"))
+        .allow_resume(true)
+        .build();
+
+    let client = ClientBuilder::new().user_agent("oma").build().unwrap();
+
+    let (tx, rx) = flume::unbounded();
+    let download_manager = DownloadManager::builder()
+        .client(client.into())
+        .download_list(Box::new([entry]))
+        .threads(1)
+        .timeout(Duration::from_secs(2))
+        .build();
+
+    let lifecycle = tokio::spawn(async move {
+        let mut opened = 0usize;
+        let mut closed = 0usize;
+        while let Ok(event) = rx.recv_async().await {
+            match &event {
+                Event::NewProgressSpinner { .. } | Event::NewProgressBar { .. } => opened += 1,
+                Event::ProgressDone(_) | Event::DownloadDone { .. } => closed += 1,
+                _ => {}
+            }
+            if let Event::AllDone = event {
+                break;
+            }
+        }
+        (opened, closed)
+    });
+
+    tokio::fs::create_dir_all("/tmp/oma-fetch-bar-test")
+        .await
+        .unwrap();
+
+    let _summary = download_manager
+        .start_download(move |event| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send_async(event).await;
+            }
+        })
+        .await;
+
+    let (opened, closed) = lifecycle.await.unwrap();
+
+    assert_eq!(
+        opened, closed,
+        "bar lifecycle is unbalanced: {opened} opened but only {closed} closed \
+         (a leaked spinner/bar would pile up on screen)"
+    );
+}


### PR DESCRIPTION
## Description

Attempts that fail before the response arrives (SendRequestTimeout, ReqwestMiddlewareError) or a failing local copy never fired ProgressDone, so the spinner/bar mounted by NewProgressSpinner/ NewProgressBar stayed in the MultiProgress until AllDone. On a network drop this piles one leaked bar per freshly-started file onto the terminal, so the visible progress entries exceed the configured threads.

Fire ProgressDone on those error paths so every bar that is opened is also closed. Add a bar-lifecycle integration test that asserts the opened/closed event counts match.

## About AI

This PR was written in collaboration with Deepseek V4 Flash in a VS Code agent session. I have reviewed and amended the code, tested it thoroughly, and updated the comments.

- Model: Deepseek v4 flash
- Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)
