### PR TITLE
feat(oma): support CI environment (CI=1)

### DIFF
--- a/oma-utils/src/lib.rs
+++ b/oma-utils/src/lib.rs
@@ -32,6 +32,17 @@ pub fn is_termux() -> bool {
     std::env::var("TERMUX_VERSION").is_ok_and(|v| !v.is_empty())
 }
 
+/// Detect if we are running in a CI environment (e.g. GitHub Actions, GitLab
+/// CI). The `CI` environment variable is considered set when its value is a
+/// truthy string ("1", "true", ...).
+#[inline]
+pub fn is_ci() -> bool {
+    std::env::var("CI").is_ok_and(|v| {
+        let v = v.trim();
+        !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+    })
+}
+
 #[inline]
 pub fn concat_url(url: &str, path: &str) -> String {
     format!(
@@ -103,4 +114,42 @@ pub fn get_file_lock(lock_path: &Path) -> Result<OwnedFd, GetLockError> {
     }
 
     Ok(fd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_ci;
+
+    #[test]
+    fn test_is_ci() {
+        let original = std::env::var("CI").ok();
+
+        unsafe {
+            std::env::set_var("CI", "1");
+            assert!(is_ci());
+
+            std::env::set_var("CI", "true");
+            assert!(is_ci());
+
+            std::env::set_var("CI", "True");
+            assert!(is_ci());
+
+            std::env::set_var("CI", "0");
+            assert!(!is_ci());
+
+            std::env::set_var("CI", "false");
+            assert!(!is_ci());
+
+            std::env::set_var("CI", "");
+            assert!(!is_ci());
+
+            std::env::remove_var("CI");
+            assert!(!is_ci());
+
+            match original {
+                Some(v) => std::env::set_var("CI", v),
+                None => std::env::remove_var("CI"),
+            }
+        }
+    }
 }

--- a/oma-utils/src/lib.rs
+++ b/oma-utils/src/lib.rs
@@ -45,9 +45,7 @@ const FALSE_LITERALS: [&str; 6] = ["n", "no", "f", "false", "off", "0"];
 /// Convert a string literal representation of truth to true or false, like
 /// clap's `str_to_bool` behind [`BoolishValueParser`](https://docs.rs/clap/latest/clap/builder/struct.BoolishValueParser.html).
 ///
-/// `true` values are `y`, `yes`, `t`, `true`, `on`, and `1`; `false` values
-/// are `n`, `no`, `f`, `false`, `off`, and `0` (case-insensitive). Any other
-/// value is `None`.
+/// Treat true/false values as case-insensitive.
 #[inline]
 pub fn str_to_bool(val: impl AsRef<str>) -> Option<bool> {
     let pat = val.as_ref().to_ascii_lowercase();
@@ -62,11 +60,6 @@ pub fn str_to_bool(val: impl AsRef<str>) -> Option<bool> {
 
 /// Detect if we are running in a CI environment (e.g. GitHub Actions, GitLab
 /// CI).
-///
-/// The `CI` environment variable counts as set only when [`str_to_bool`]
-/// accepts its value as truthy (`"1"`, `"true"`, `"yes"`, `"on"`, `"y"`,
-/// `"t"`, case-insensitive). Explicit falses (`"0"`, `"false"`, `"no"`, ...)
-/// and unrecognized values are both treated as not-CI.
 #[inline]
 pub fn is_ci() -> bool {
     std::env::var("CI")

--- a/oma-utils/src/lib.rs
+++ b/oma-utils/src/lib.rs
@@ -32,15 +32,47 @@ pub fn is_termux() -> bool {
     std::env::var("TERMUX_VERSION").is_ok_and(|v| !v.is_empty())
 }
 
+/// True values are `y`, `yes`, `t`, `true`, `on`, and `1`; false values are
+/// `n`, `no`, `f`, `false`, `off`, and `0`.
+///
+/// Both lists are clap's `BoolishValueParser` literals verbatim; matching is
+/// case-insensitive. See:
+/// - https://github.com/clap-rs/clap/blob/v4.6.2/clap_builder/src/util/str_to_bool.rs#L2-L24
+///   (the literal lists and `str_to_bool`)
+const TRUE_LITERALS: [&str; 6] = ["y", "yes", "t", "true", "on", "1"];
+const FALSE_LITERALS: [&str; 6] = ["n", "no", "f", "false", "off", "0"];
+
+/// Convert a string literal representation of truth to true or false, like
+/// clap's `str_to_bool` behind [`BoolishValueParser`](https://docs.rs/clap/latest/clap/builder/struct.BoolishValueParser.html).
+///
+/// `true` values are `y`, `yes`, `t`, `true`, `on`, and `1`; `false` values
+/// are `n`, `no`, `f`, `false`, `off`, and `0` (case-insensitive). Any other
+/// value is `None`.
+#[inline]
+pub fn str_to_bool(val: impl AsRef<str>) -> Option<bool> {
+    let pat = val.as_ref().to_ascii_lowercase();
+    if TRUE_LITERALS.contains(&pat.as_str()) {
+        Some(true)
+    } else if FALSE_LITERALS.contains(&pat.as_str()) {
+        Some(false)
+    } else {
+        None
+    }
+}
+
 /// Detect if we are running in a CI environment (e.g. GitHub Actions, GitLab
-/// CI). The `CI` environment variable is considered set when its value is a
-/// truthy string ("1", "true", ...).
+/// CI).
+///
+/// The `CI` environment variable counts as set only when [`str_to_bool`]
+/// accepts its value as truthy (`"1"`, `"true"`, `"yes"`, `"on"`, `"y"`,
+/// `"t"`, case-insensitive). Explicit falses (`"0"`, `"false"`, `"no"`, ...)
+/// and unrecognized values are both treated as not-CI.
 #[inline]
 pub fn is_ci() -> bool {
-    std::env::var("CI").is_ok_and(|v| {
-        let v = v.trim();
-        !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
-    })
+    std::env::var("CI")
+        .ok()
+        .and_then(str_to_bool)
+        .unwrap_or(false)
 }
 
 #[inline]
@@ -134,10 +166,30 @@ mod tests {
             std::env::set_var("CI", "True");
             assert!(is_ci());
 
+            // The remaining BoolishValueParser truthy literals.
+            std::env::set_var("CI", "yes");
+            assert!(is_ci());
+            std::env::set_var("CI", "on");
+            assert!(is_ci());
+            std::env::set_var("CI", "y");
+            assert!(is_ci());
+            std::env::set_var("CI", "t");
+            assert!(is_ci());
+
             std::env::set_var("CI", "0");
             assert!(!is_ci());
 
             std::env::set_var("CI", "false");
+            assert!(!is_ci());
+
+            // Explicit falses beyond "0"/"false" are also not-CI.
+            std::env::set_var("CI", "no");
+            assert!(!is_ci());
+            std::env::set_var("CI", "off");
+            assert!(!is_ci());
+
+            // Unrecognized values are strict: not-CI.
+            std::env::set_var("CI", "2");
             assert!(!is_ci());
 
             std::env::set_var("CI", "");

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,6 +6,7 @@ use clap::{
 use enum_dispatch::enum_dispatch;
 use itertools::Itertools;
 use oma_console::OmaFormatter;
+use oma_utils::is_ci;
 
 use crate::{
     GlobalOptions,
@@ -117,8 +118,10 @@ impl OhManagerAilurus {
 
     #[inline]
     pub fn enable_ansi(&self) -> bool {
-        (self.global.color != ColorChoice::Never && is_terminal())
-            || self.global.color == ColorChoice::Always
+        // 在 CI 环境中禁用 ANSI，避免日志被转义序列污染。
+        !is_ci()
+            && ((self.global.color != ColorChoice::Never && is_terminal())
+                || self.global.color == ColorChoice::Always)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use apt_auth_config::AuthConfig;
 use clap::ColorChoice;
 use oma_apt_pkg::AptConfig;
 use oma_pm::oma_apt;
-use oma_utils::is_termux;
+use oma_utils::{is_ci, is_termux};
 use once_cell::sync::OnceCell;
 use reqwest::Client;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
@@ -28,7 +28,7 @@ pub struct OmaConfig {
     pub color: ColorChoice,
     pub follow_terminal_color: bool,
     cli_no_progress: bool,
-    pub no_check_dbus: bool,
+    cli_no_check_dbus: bool,
     pub check_battery: BatteryTristate,
     pub take_wake_lock: TakeWakeLockTristate,
     pub sysroot: PathBuf,
@@ -61,7 +61,7 @@ impl Default for OmaConfig {
             color: ColorChoice::Auto,
             follow_terminal_color: GeneralConfig::default_follow_terminal_color(),
             cli_no_progress: false,
-            no_check_dbus: GeneralConfig::default_no_check_dbus(),
+            cli_no_check_dbus: GeneralConfig::default_no_check_dbus(),
             check_battery: GeneralConfig::default_check_battery(),
             take_wake_lock: GeneralConfig::default_take_wake_lock(),
             sysroot: PathBuf::from("/"),
@@ -108,7 +108,7 @@ impl OmaConfig {
                 ..
             } = general;
 
-            oma_config.no_check_dbus = no_check_dbus;
+            oma_config.cli_no_check_dbus = no_check_dbus;
 
             #[cfg(feature = "aosc")]
             {
@@ -160,7 +160,7 @@ impl OmaConfig {
 
         self.no_bell |= no_bell;
         self.follow_terminal_color |= follow_terminal_color;
-        self.no_check_dbus |= no_check_dbus;
+        self.cli_no_check_dbus |= no_check_dbus;
         self.amo &= !no_amo;
 
         if let Some(download_threads) = download_threads {
@@ -193,7 +193,15 @@ impl OmaConfig {
                 || self.dry_run
                 || std::env::var("OMA_LOG").is_ok()
                 || self.color == ColorChoice::Never
+                || is_ci()
         })
+    }
+
+    /// Whether to skip the DBus check. It is always skipped in CI
+    /// environments, where a session/system bus is usually unavailable.
+    #[inline]
+    pub fn no_check_dbus(&self) -> bool {
+        self.cli_no_check_dbus || is_ci()
     }
 
     #[inline]

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -21,7 +21,7 @@ use crate::{
 type Result<T> = std::result::Result<T, OutputError>;
 
 pub fn dbus_check(yes: bool, config: &OmaConfig) -> Result<Option<OwnedFd>> {
-    if config.no_check_dbus {
+    if config.no_check_dbus() {
         no_check_dbus_warn();
         return Ok(None);
     }

--- a/src/install_progress.rs
+++ b/src/install_progress.rs
@@ -11,6 +11,8 @@ use oma_pm::{
     progress::{InstallProgressManager, get_apt_progress_string, terminal_height, terminal_width},
 };
 
+use oma_utils::is_ci;
+
 use crate::subcommand::utils::is_terminal;
 
 pub struct OmaInstallProgressManager {
@@ -104,11 +106,11 @@ impl InstallProgressManager for OmaInstallProgressManager {
     }
 
     fn no_interactive(&self) -> bool {
-        !is_terminal() || self.yes
+        !is_terminal() || self.yes || is_ci()
     }
 
     fn use_pty(&self) -> bool {
-        is_terminal()
+        is_terminal() && !is_ci()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use error::OutputError;
 use i18n_embed::{DesktopLanguageRequester, Localizer};
 use lang::LANGUAGE_LOADER;
 use oma_console::{terminal::wrap_content, writer::Writer};
-use oma_utils::{OsRelease, is_termux};
+use oma_utils::{OsRelease, is_ci, is_termux};
 use spdlog::{debug, info, prelude::error as log_error, warn};
 use tokio::runtime::Runtime;
 use tui::Tui;
@@ -270,7 +270,7 @@ fn init_localizer() {
 
 fn try_main(mut config: OmaConfig, matches: ArgMatches) -> Result<ExitHandle, OutputError> {
     crate::color::init_color(
-        config.color == ColorChoice::Never,
+        config.color == ColorChoice::Never || is_ci(),
         config.follow_terminal_color,
     );
 

--- a/src/root.rs
+++ b/src/root.rs
@@ -77,9 +77,34 @@ fn pkexec_oma() -> Result<()> {
     exit(out.status.code().unwrap_or(1));
 }
 
+/// Environment variables that oma reads and should be forwarded to the
+/// elevated process when using `systemd-run` (which starts services with a
+/// minimal environment). All `OMA_*` variables are forwarded automatically.
+const OMA_KNOWN_ENVS: &[&str] = &[
+    // logging
+    "RUST_LOG",
+    // history "Requested-By" logging
+    "SUDO_USER",
+    "SUDO_UID",
+    // platform detection
+    "TERMUX_VERSION",
+    "CI",
+    // color / terminal detection
+    "NO_COLOR",
+    "SSH_CONNECTION",
+    "TERM",
+    "DISPLAY",
+    "WAYLAND_DISPLAY",
+    // i18n (sys-locale)
+    "LANGUAGE",
+    "LC_ALL",
+    "LC_MESSAGES",
+    "LANG",
+];
+
 fn systemd_run_oma() -> Result<()> {
-    let oma_envs_args = std::env::vars()
-        .filter(|(k, _)| k.starts_with("OMA_"))
+    let envs_args = std::env::vars()
+        .filter(|(k, _)| k.starts_with("OMA_") || OMA_KNOWN_ENVS.contains(&k.as_str()))
         .map(|(k, v)| format!("--setenv={k}={v}"));
 
     let out = Command::new("systemd-run")
@@ -88,7 +113,7 @@ fn systemd_run_oma() -> Result<()> {
         .arg("--pty")
         .arg("--quiet")
         .arg("--unit=oma")
-        .args(oma_envs_args)
+        .args(envs_args)
         .arg("--collect")
         .args(std::env::args())
         .spawn()

--- a/src/subcommand/command_not_found.rs
+++ b/src/subcommand/command_not_found.rs
@@ -80,7 +80,7 @@ impl CliExecuter for CommandNotFound {
                 let mut map: AHashMap<String, String> = AHashMap::new();
                 let handle = RT.handle();
 
-                let amo = if config.amo && !config.no_check_dbus {
+                let amo = if config.amo && !config.no_check_dbus() {
                     handle.block_on(amo_connect()).ok()
                 } else {
                     None

--- a/src/subcommand/search.rs
+++ b/src/subcommand/search.rs
@@ -172,7 +172,7 @@ pub fn search(
         SearchEngine::Indicium(f) => {
             let query = keywords.join(" ");
 
-            if config.amo && !config.no_check_dbus {
+            if config.amo && !config.no_check_dbus() {
                 match RT.block_on(amo_search(&query)) {
                     Ok(r) => Ok(r),
                     Err(_) => local_indicium_search(config.apt_config(), f, query),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -147,7 +147,7 @@ impl CliExecuter for Tui {
         let autoremove = apt.count_pending_autoremovable_pkgs();
         let installed = apt.count_installed_packages();
 
-        let searcher = if config.amo && !config.no_check_dbus {
+        let searcher = if config.amo && !config.no_check_dbus() {
             match RT.block_on(Searcher::connect_amo()) {
                 Ok(searcher) => searcher,
                 Err(_) => local_searcher(config.apt_config(), &pb)?,


### PR DESCRIPTION
## Description

When the CI environment variable is set to a truthy value, oma runs in a non-interactive, output-friendly mode: progress bars (download/refresh and dpkg phases) are disabled, ANSI color output is suppressed, and the DBus check is skipped by default since a session/system bus is usually unavailable in CI runners.

## About AI

This PR draws inspiration from and modifies the Deepseek V4 flash. I have reviewed and amended some of the code, and updated some of the comments.

- Model: Deepseek v4 flash
-  Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)