### PR TITLE
Color formatter refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,6 +3389,7 @@ dependencies = [
  "enum_dispatch",
  "env_filter",
  "faster-hex",
+ "fluent-bundle",
  "flume",
  "fs4",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ oma-apt-pkg = { workspace = true, default-features = false, features = ["search"
 # i18n
 i18n-embed = { workspace = true}
 i18n-embed-fl = { workspace = true }
+fluent-bundle = { workspace = true }
 rust-embed = { workspace = true }
 oma-apt-sources-lists.workspace = true
 
@@ -207,6 +208,7 @@ i18n-embed = { version = "0.16.0", features = [
     "desktop-requester",
 ] }
 i18n-embed-fl = { version = "0.10.0", package = "i18n-embed-fl-no-check-hashmap-on-ra" }
+fluent-bundle = "0.16.0"
 rust-embed = "8.11.0"
 
 

--- a/oma-console/examples/pager.rs
+++ b/oma-console/examples/pager.rs
@@ -1,9 +1,6 @@
-use oma_console::{
-    pager::{OmaPager, Pager, PagerUIText},
-    print::OmaColorFormat,
-};
+use oma_console::pager::{OmaPager, Pager, PagerUIText};
 use ratatui::crossterm::style::Stylize;
-use std::{io, time::Duration};
+use std::io;
 
 struct OmaPagerUIText;
 
@@ -30,10 +27,9 @@ impl PagerUIText for OmaPagerUIText {
 }
 
 fn main() -> io::Result<()> {
-    let cf = OmaColorFormat::new(true, Duration::from_millis(100));
     let pager = OmaPager::new(
         Some("QAQ".to_string()),
-        &cf,
+        None,
         Box::new(OmaPagerUIText),
         false,
     );

--- a/oma-console/src/pager.rs
+++ b/oma-console/src/pager.rs
@@ -26,17 +26,17 @@ use spdlog::debug;
 use termbg::Theme;
 use tui_input::Input;
 
-use crate::{print::OmaColorFormat, writer::Writer};
+use crate::writer::Writer;
 
 const HIGHLIGHT_START: &str = "\x1b[7m";
 const HIGHLIGHT_END: &str = "\x1b[0m";
 
-pub enum Pager<'a> {
+pub enum Pager {
     Plain,
-    External(Box<OmaPager<'a>>),
+    External(Box<OmaPager>),
 }
 
-impl<'a> Pager<'a> {
+impl Pager {
     pub fn plain() -> Self {
         Self::Plain
     }
@@ -44,14 +44,14 @@ impl<'a> Pager<'a> {
     pub fn external(
         ui_text: Box<dyn PagerUIText>,
         title: Option<String>,
-        color_format: &'a OmaColorFormat,
+        theme: Option<Theme>,
         yn_mode: bool,
     ) -> io::Result<Self> {
         if !stdout().is_terminal() || !stderr().is_terminal() || !stdin().is_terminal() {
             return Ok(Pager::Plain);
         }
 
-        let app = OmaPager::new(title, color_format, ui_text, yn_mode);
+        let app = OmaPager::new(title, theme, ui_text, yn_mode);
         let res = Pager::External(Box::new(app));
 
         Ok(res)
@@ -118,7 +118,7 @@ enum PagerInner {
 }
 
 /// `OmaPager` is a structure that implements a pager displaying text-based content in a terminal UI.
-pub struct OmaPager<'a> {
+pub struct OmaPager {
     /// The internal state of the pager, which can be either `Working` or `Finished`.
     inner: PagerInner,
     /// The state of the vertical scrollbar.
@@ -139,8 +139,8 @@ pub struct OmaPager<'a> {
     title: Option<String>,
     /// The length of the inner content.
     inner_len: usize,
-    /// A reference to the color format used for the pager's theme.
-    theme: &'a OmaColorFormat,
+    /// The detected terminal theme (dark/light) used for the pager's theme.
+    theme: Option<Theme>,
     /// A vector containing the indices of search results.
     search_results: Vec<usize>,
     /// The index of the current search result being displayed.
@@ -157,7 +157,7 @@ pub struct OmaPager<'a> {
     search_input: Input,
 }
 
-impl Write for OmaPager<'_> {
+impl Write for OmaPager {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self.inner {
             PagerInner::Working(ref mut v) => v.extend_from_slice(buf),
@@ -205,10 +205,10 @@ impl From<PagerExit> for i32 {
     }
 }
 
-impl<'a> OmaPager<'a> {
+impl OmaPager {
     pub fn new(
         title: Option<String>,
-        theme: &'a OmaColorFormat,
+        theme: Option<Theme>,
         ui_text: Box<dyn PagerUIText>,
         yn_mode: bool,
     ) -> Self {
@@ -564,7 +564,7 @@ impl<'a> OmaPager<'a> {
 
         let chunks = Layout::vertical(layout).split(area);
 
-        let color = self.theme.theme;
+        let color = self.theme;
 
         let title_bg_color = match color {
             Some(Theme::Dark) => Color::Indexed(25),

--- a/oma-console/src/print.rs
+++ b/oma-console/src/print.rs
@@ -1,11 +1,8 @@
 use std::fmt::{self, Write};
 use std::sync::LazyLock;
-use std::time::Duration;
 
-use console::{Color, StyledObject, style};
 use jiff::Timestamp;
-use spdlog::{Level, debug, formatter::Formatter};
-use termbg::Theme;
+use spdlog::{Level, formatter::Formatter};
 
 pub use termbg;
 
@@ -21,129 +18,6 @@ static PREFIX_ERROR: LazyLock<String> =
 static PREFIX_TRACE: LazyLock<String> = LazyLock::new(|| console::style("TRACE").dim().to_string());
 static PREFIX_CRITICAL: LazyLock<String> =
     LazyLock::new(|| console::style("CRITICAL").red().bright().bold().to_string());
-
-#[derive(Clone)]
-enum StyleFollow {
-    OmaTheme,
-    TermTheme,
-}
-
-pub enum Action {
-    Emphasis,
-    Foreground,
-    Secondary,
-    EmphasisSecondary,
-    WARN,
-    Purple,
-    Note,
-    UpgradeTips,
-    PendingBg,
-}
-
-impl Action {
-    fn dark(&self) -> u8 {
-        match self {
-            Action::Emphasis => 148,
-            Action::Foreground => 72,
-            Action::Secondary => 182,
-            Action::EmphasisSecondary => 114,
-            Action::WARN => 214,
-            Action::Purple => 141,
-            Action::Note => 178,
-            Action::UpgradeTips => 87,
-            Action::PendingBg => 25,
-        }
-    }
-
-    fn light(&self) -> u8 {
-        match self {
-            Action::Emphasis => 142,
-            Action::Foreground => 72,
-            Action::Secondary => 167,
-            Action::EmphasisSecondary => 106,
-            Action::WARN => 208,
-            Action::Purple => 141,
-            Action::Note => 172,
-            Action::UpgradeTips => 63,
-            Action::PendingBg => 189,
-        }
-    }
-}
-/// OmaColorFormat
-///
-/// `OmaColorFormat` is a structure that defines the color format and theme settings for oma.
-pub struct OmaColorFormat {
-    /// A `StyleFollow` enum that indicates whether to follow the terminal theme or use the oma-defined theme.
-    follow: StyleFollow,
-    /// An optional `Theme` object that defined by oma.
-    pub theme: Option<Theme>,
-}
-
-impl OmaColorFormat {
-    pub fn new(follow: bool, duration: Duration) -> Self {
-        Self {
-            follow: if follow {
-                StyleFollow::TermTheme
-            } else {
-                StyleFollow::OmaTheme
-            },
-            theme: if !follow {
-                termbg::theme(duration)
-                    .map_err(|e| {
-                        debug!(
-                            "Failed to apply oma color schemes, falling back to default terminal colors: {e:?}."
-                        );
-                        e
-                    })
-                    .ok()
-            } else {
-                None
-            },
-        }
-    }
-    /// Convert input into StyledObject
-    ///
-    /// This function applies a color scheme to the given input string based on the specified action and the current terminal color schemes.
-    ///
-    /// # Arguments
-    ///
-    /// * `input` - The input data to be themed.
-    /// * `color` - An `Action` enum value that specifies the color to be applied.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `StyledObject` that contains the styled input data.
-    pub fn color_str<D>(&self, input: D, color: Action) -> StyledObject<D> {
-        match self.follow {
-            StyleFollow::OmaTheme => match self.theme {
-                Some(Theme::Dark) => match color {
-                    x @ Action::PendingBg => style(input).bg(Color::Color256(x.dark())).bold(),
-                    x => style(input).color256(x.dark()),
-                },
-                Some(Theme::Light) => match color {
-                    x @ Action::PendingBg => style(input).bg(Color::Color256(x.light())).bold(),
-                    x => style(input).color256(x.light()),
-                },
-                None => term_color(input, color),
-            },
-            StyleFollow::TermTheme => term_color(input, color),
-        }
-    }
-}
-
-fn term_color<D>(input: D, color: Action) -> StyledObject<D> {
-    match color {
-        Action::Emphasis => style(input).green(),
-        Action::Secondary => style(input).dim(),
-        Action::EmphasisSecondary => style(input).cyan(),
-        Action::WARN => style(input).yellow().bold(),
-        Action::Purple => style(input).magenta(),
-        Action::Note => style(input).yellow(),
-        Action::Foreground => style(input).cyan().bold(),
-        Action::UpgradeTips => style(input).blue().bold(),
-        Action::PendingBg => style(input).bg(Color::Blue).bold(),
-    }
-}
 
 const TIME_RFC3339_LEN: u16 = "1970-01-01T00:00:00.000Z".len() as u16 + 1;
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -29,6 +29,7 @@ pub enum Action {
     Purple,
     Note,
     UpgradeTips,
+    Error,
     PendingBg,
 }
 
@@ -50,6 +51,8 @@ impl Action {
             (Action::Note, Theme::Light) => 172,
             (Action::UpgradeTips, Theme::Dark) => 87,
             (Action::UpgradeTips, Theme::Light) => 63,
+            (Action::Error, Theme::Dark) => 203,
+            (Action::Error, Theme::Light) => 124,
             (Action::PendingBg, Theme::Dark) => 25,
             (Action::PendingBg, Theme::Light) => 189,
         }
@@ -173,6 +176,7 @@ fn term_color<D>(input: D, color: Action) -> StyledObject<D> {
         Action::Note => style(input).yellow(),
         Action::Foreground => style(input).cyan().bold(),
         Action::UpgradeTips => style(input).blue().bold(),
+        Action::Error => style(input).red().bold(),
         Action::PendingBg => style(input).bg(Color::Blue).bold(),
     }
 }
@@ -202,6 +206,10 @@ pub trait Colorize {
     where
         Self: Sized;
     fn upgrade_tips_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    #[allow(dead_code)] // reserved for error/removal styling (e.g. table.rs, args.rs)
+    fn error_color(self) -> StyledObject<Self>
     where
         Self: Sized;
     #[allow(dead_code)] // reserved for future background usage (e.g. pending bar)
@@ -234,6 +242,9 @@ impl<T> Colorize for T {
     }
     fn upgrade_tips_color(self) -> StyledObject<Self> {
         color_str(self, Action::UpgradeTips)
+    }
+    fn error_color(self) -> StyledObject<Self> {
+        color_str(self, Action::Error)
     }
     fn pending_bg_color(self) -> StyledObject<Self> {
         color_str(self, Action::PendingBg)

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,241 @@
+use std::env;
+use std::io::{IsTerminal, stderr, stdin};
+use std::sync::OnceLock;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use oma_console::print::termbg::Theme;
+use oma_console::{
+    console::{self, Color, StyledObject, style},
+    print::termbg,
+};
+use rustix::stdio::stdout;
+use spdlog::debug;
+
+use crate::NO_COLOR;
+use crate::dbus::is_ssh_from_loginctl;
+
+/// Time budget for probing the terminal theme (see `should_follow_terminal`).
+const TERMBG_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// A color role used to theme output for a given semantic.
+#[allow(dead_code)] // PendingBg is reserved for future background usage (e.g. pending bar).
+pub enum Action {
+    Emphasis,
+    Foreground,
+    Secondary,
+    EmphasisSecondary,
+    Warn,
+    Purple,
+    Note,
+    UpgradeTips,
+    PendingBg,
+}
+
+impl Action {
+    /// The 256-color palette entry for this role under `theme`.
+    fn palette(&self, theme: Theme) -> u8 {
+        match (self, theme) {
+            (Action::Emphasis, Theme::Dark) => 148,
+            (Action::Emphasis, Theme::Light) => 142,
+            (Action::Foreground, _) => 72,
+            (Action::Secondary, Theme::Dark) => 182,
+            (Action::Secondary, Theme::Light) => 167,
+            (Action::EmphasisSecondary, Theme::Dark) => 114,
+            (Action::EmphasisSecondary, Theme::Light) => 106,
+            (Action::Warn, Theme::Dark) => 214,
+            (Action::Warn, Theme::Light) => 208,
+            (Action::Purple, _) => 141,
+            (Action::Note, Theme::Dark) => 178,
+            (Action::Note, Theme::Light) => 172,
+            (Action::UpgradeTips, Theme::Dark) => 87,
+            (Action::UpgradeTips, Theme::Light) => 63,
+            (Action::PendingBg, Theme::Dark) => 25,
+            (Action::PendingBg, Theme::Light) => 189,
+        }
+    }
+}
+
+/// Resolved terminal theme, detected once at startup. `None` means fall back
+/// to the terminal's default (named) colors.
+static TERM_THEME: OnceLock<Option<Theme>> = OnceLock::new();
+
+/// Initialize oma's color system at startup: disable colors if requested,
+/// then detect the terminal theme and decide whether oma's own palette is
+/// used.
+pub fn init_color(no_color: bool, follow_terminal_color: bool) {
+    if no_color {
+        unsafe { env::set_var("NO_COLOR", "1") };
+        console::set_colors_enabled(false);
+        NO_COLOR.store(true, Ordering::Relaxed);
+    }
+
+    let theme = if should_follow_terminal(no_color, follow_terminal_color) {
+        None
+    } else {
+        termbg::theme(TERMBG_TIMEOUT)
+            .map_err(|e| {
+                debug!(
+                    "Failed to apply oma color schemes, falling back to default terminal colors: {e:?}."
+                );
+                e
+            })
+            .ok()
+    };
+
+    let _ = TERM_THEME.set(theme);
+}
+
+/// Whether oma should fall back to the terminal's default colors instead of
+/// using its own palette.
+///
+/// FIXME: Marking latency limits for oma's terminal color queries (via
+/// termbg). On slower terminals - i.e., SSH and unaccelerated
+/// graphical environments, any colored interfaces in oma may return a
+/// terminal color query string in the returned shell, confusing users.
+///
+///   (ssh)root@LoongUnion1 [ `~` ] ? 11;rgb:2323/2626/2727
+///
+/// Following advice from termbg here. Add latency limits to avoid this
+/// strange output on slower terminals.
+///
+/// For further investigation, we have some remaining questions:
+///
+/// 1. Why 100ms? We see that the termbg-based procs project using the
+///    same latency limit to workaround the aforementioned issue.
+///    It should be noted that this is nothing more than a "magic
+///    number" that we have tested to work.
+/// 2. The true cause or reproducing conditions for this issue is not
+///    yet clear, we found the same issue on a slower machine (Loongson
+///    3B4000) in a nearby datacenter (`~50ms`) with a faster one
+///    (Loongson 3C5000), which does not exhibit the issue; as well as
+///    on a faster machine (AMD EPYC 7H12) with high latency (`~450ms`).
+///
+/// Ref: https://github.com/dalance/procs/issues/221
+/// Ref: https://github.com/dalance/procs/commit/83305be6fb431695a070524328b66c7107ce98f3
+fn should_follow_terminal(no_color: bool, follow_terminal_color: bool) -> bool {
+    let mut follow = follow_terminal_color;
+
+    if !stdout().is_terminal() || !stderr().is_terminal() || !stdin().is_terminal() || no_color {
+        follow = true;
+    } else if env::var("SSH_CONNECTION").is_ok() || is_ssh_from_loginctl() {
+        debug!(
+            "You are running oma in an SSH session, using default terminal colors to avoid latency."
+        );
+        follow = true;
+    } else if env::var("TERM").is_err() || termbg::terminal() != termbg::Terminal::XtermCompatible {
+        debug!("Your terminal is: {:?}", termbg::terminal());
+        debug!(
+            "Unknown or unsupported terminal ($TERM is empty or unsupported) detected, using default terminal colors to avoid latency."
+        );
+        follow = true;
+    } else if let Ok(latency) = termbg::latency(Duration::from_millis(1000)) {
+        debug!("latency: {:?}", latency);
+        if latency * 2 > TERMBG_TIMEOUT {
+            debug!(
+                "Terminal latency is too long, falling back to default terminal colors, latency: {:?}.",
+                latency
+            );
+            follow = true;
+        }
+    } else {
+        debug!("Terminal latency is too long, falling back to default terminal colors.");
+        follow = true;
+    }
+
+    follow
+}
+
+/// The resolved terminal theme (dark/light), if a theme was detected.
+pub fn color_theme() -> Option<Theme> {
+    *TERM_THEME.get().unwrap_or(&None)
+}
+
+/// Style `input` with the color palette of the resolved terminal theme.
+pub(crate) fn color_str<D>(input: D, color: Action) -> StyledObject<D> {
+    match color_theme() {
+        Some(theme) => match color {
+            x @ Action::PendingBg => style(input).bg(Color::Color256(x.palette(theme))).bold(),
+            x => style(input).color256(x.palette(theme)),
+        },
+        None => term_color(input, color),
+    }
+}
+
+/// Fallback styling using the terminal's default (named) colors.
+fn term_color<D>(input: D, color: Action) -> StyledObject<D> {
+    match color {
+        Action::Emphasis => style(input).green(),
+        Action::Secondary => style(input).dim(),
+        Action::EmphasisSecondary => style(input).cyan(),
+        Action::Warn => style(input).yellow().bold(),
+        Action::Purple => style(input).magenta(),
+        Action::Note => style(input).yellow(),
+        Action::Foreground => style(input).cyan().bold(),
+        Action::UpgradeTips => style(input).blue().bold(),
+        Action::PendingBg => style(input).bg(Color::Blue).bold(),
+    }
+}
+
+/// Extension trait providing semantic color methods on any value, e.g.
+/// `name.warn_color()`, backed by [`color_str`].
+pub trait Colorize {
+    fn emphasis_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    fn foreground_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    fn secondary_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    fn emphasis_secondary_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    fn warn_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    fn purple_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    fn note_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    fn upgrade_tips_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+    #[allow(dead_code)] // reserved for future background usage (e.g. pending bar)
+    fn pending_bg_color(self) -> StyledObject<Self>
+    where
+        Self: Sized;
+}
+
+impl<T> Colorize for T {
+    fn emphasis_color(self) -> StyledObject<Self> {
+        color_str(self, Action::Emphasis)
+    }
+    fn foreground_color(self) -> StyledObject<Self> {
+        color_str(self, Action::Foreground)
+    }
+    fn secondary_color(self) -> StyledObject<Self> {
+        color_str(self, Action::Secondary)
+    }
+    fn emphasis_secondary_color(self) -> StyledObject<Self> {
+        color_str(self, Action::EmphasisSecondary)
+    }
+    fn warn_color(self) -> StyledObject<Self> {
+        color_str(self, Action::Warn)
+    }
+    fn purple_color(self) -> StyledObject<Self> {
+        color_str(self, Action::Purple)
+    }
+    fn note_color(self) -> StyledObject<Self> {
+        color_str(self, Action::Note)
+    }
+    fn upgrade_tips_color(self) -> StyledObject<Self> {
+        color_str(self, Action::UpgradeTips)
+    }
+    fn pending_bg_color(self) -> StyledObject<Self> {
+        color_str(self, Action::PendingBg)
+    }
+}

--- a/src/core/commit_changes.rs
+++ b/src/core/commit_changes.rs
@@ -5,7 +5,7 @@ use bon::Builder;
 use dialoguer::{Confirm, theme::ColorfulTheme};
 use flume::unbounded;
 use jiff::Timestamp;
-use oma_console::{indicatif::HumanBytes, pager::PagerExit, print::Action};
+use oma_console::{indicatif::HumanBytes, pager::PagerExit};
 use oma_history::{DATABASE_PATH, HistoryInfo};
 use oma_pm::{
     CommitConfig,
@@ -15,10 +15,11 @@ use oma_pm::{
 };
 use spdlog::{debug, error, info, warn};
 
+use crate::color::Colorize;
 #[cfg(feature = "aosc")]
 use crate::utils::get_lists_dir;
 use crate::{
-    NOT_ALLOW_CTRLC, color_formatter,
+    NOT_ALLOW_CTRLC,
     config::OmaConfig,
     core::space_tips,
     error::OutputError,
@@ -366,21 +367,12 @@ fn autoremovable_tips(count: u64, total_size: u64) {
     }
 
     let total_size = HumanBytes(total_size).to_string();
-    let cmd1 = color_formatter()
-        .color_str("oma list --autoremovable", Action::Emphasis)
-        .to_string();
-    let cmd2 = color_formatter()
-        .color_str("oma mark manual <packages>", Action::Note)
-        .to_string();
-    let cmd3 = color_formatter()
-        .color_str("oma autoremove", Action::Secondary)
-        .to_string();
-    let count = color_formatter()
-        .color_str(count, Action::Secondary)
-        .to_string();
-    let total_size = color_formatter()
-        .color_str(total_size, Action::Secondary)
-        .to_string();
+    let cmd1 = "oma list --autoremovable".emphasis_color();
+    let cmd2 = "oma mark manual <packages>".note_color();
+    let cmd3 = "oma autoremove".secondary_color();
+    let count = count.secondary_color();
+    let total_size = total_size.secondary_color();
+
     info!(
         "{}",
         fl!(
@@ -436,8 +428,8 @@ fn history_success_tips(dry_run: bool) {
 }
 
 fn undo_tips() {
-    let cmd = color_formatter().color_str("oma undo", Action::Emphasis);
-    info!("{}", fl!("history-tips-2", cmd = cmd.to_string()));
+    let cmd = "oma undo".emphasis_color();
+    info!("{}", fl!("history-tips-2", cmd = cmd));
 }
 
 fn display_suggest_tips(suggest: &[(String, String)], recommend: &[(String, String)]) {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
 use fs_extra::dir::get_size as get_dir_size;
-use oma_console::{indicatif::HumanBytes, print::Action};
+use oma_console::indicatif::HumanBytes;
 use oma_pm::apt::OmaApt;
 use spdlog::warn;
 
-use crate::{color_formatter, fl};
+use crate::{color::Colorize, fl};
 
 pub mod commit_changes;
 pub mod refresh;
@@ -33,9 +33,7 @@ pub fn space_tips(apt: &OmaApt, sysroot: impl AsRef<Path>) {
 
     if archive_dir_space != 0 {
         let human_space = HumanBytes(archive_dir_space).to_string();
-        let cmd = color_formatter()
-            .color_str("oma clean", Action::Secondary)
-            .to_string();
+        let cmd = "oma clean".secondary_color();
 
         warn!("{}", fl!("space-warn", size = human_space, cmd = cmd));
     } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -143,11 +143,11 @@ impl From<MirrorError> for OutputError {
     fn from(value: MirrorError) -> Self {
         match value {
             MirrorError::ReadFile { path, source } => Self::with_source(
-                fl!("failed-to-operate-path", p = path.display().to_string()),
+                fl!("failed-to-operate-path", p = path.display()),
                 source,
             ),
             MirrorError::ParseJson { path, source } => Self::with_source(
-                fl!("failed-to-parse-file", p = path.display().to_string()),
+                fl!("failed-to-parse-file", p = path.display()),
                 source,
             ),
             MirrorError::MirrorNotExist { mirror_name } => {
@@ -157,11 +157,11 @@ impl From<MirrorError> for OutputError {
                 Self::with_source(fl!("failed-to-serialize-struct"), source)
             }
             MirrorError::WriteFile { path, source } => Self::with_source(
-                fl!("failed-to-write-file", p = path.display().to_string()),
+                fl!("failed-to-write-file", p = path.display()),
                 source,
             ),
             MirrorError::CreateFile { path, source } => Self::with_source(
-                fl!("failed-to-create-file", p = path.display().to_string()),
+                fl!("failed-to-create-file", p = path.display()),
                 source,
             ),
             MirrorError::ApplyEmptySettings => fl!("mirrors-setting-empty").into(),
@@ -317,7 +317,7 @@ impl From<RefreshError> for OutputError {
                 ),
             },
             RefreshError::DuplicateComponents(url, component) => {
-                fl!("doplicate-component", url = url.to_string(), c = component).into()
+                fl!("doplicate-component", url = url.as_ref(), c = component).into()
             }
             RefreshError::SourceListsEmpty => fl!("sources-list-empty").into(),
             RefreshError::DownloadFailed(err) => {
@@ -328,7 +328,7 @@ impl From<RefreshError> for OutputError {
                 }
             }
             RefreshError::OperateFile(path, error) => Self::with_source(
-                fl!("failed-to-operate-path", p = path.display().to_string()),
+                fl!("failed-to-operate-path", p = path.display()),
                 error,
             ),
             RefreshError::WrongThreadCount(count) => {
@@ -390,7 +390,7 @@ fn oma_topics_error(e: OmaTopicsError) -> OutputError {
         OmaTopicsError::ReqwestError(e) => OutputError::from(e),
         OmaTopicsError::FailedSer => e.to_string().into(),
         OmaTopicsError::FailedGetParentPath(p) => {
-            fl!("failed-to-get-parent-path", p = p.display().to_string()).into()
+            fl!("failed-to-get-parent-path", p = p.display()).into()
         }
         OmaTopicsError::BrokenFile(p) => fl!("failed-to-read", p = p).into(),
         OmaTopicsError::ParseUrl(e, url) => {
@@ -586,7 +586,7 @@ pub fn oma_apt_error_to_output(err: OmaAptError) -> OutputError {
             OutputError::with_source(fl!("failed-to-calculate-available-space"), e)
         }
         OmaAptError::FailedGetParentPath(p) => {
-            fl!("failed-to-get-parent-path", p = p.display().to_string()).into()
+            fl!("failed-to-get-parent-path", p = p.display()).into()
         }
         OmaAptError::FailedGetCanonicalize(p, e) => {
             OutputError::with_source(format!("Failed canonicalize path: {p}"), e)
@@ -694,7 +694,7 @@ impl From<reqwest::Error> for OutputError {
         if let Some(filename) = filename
             && filename.len() <= 256
         {
-            return Self::with_source(fl!("download-failed", filename = filename.to_string()), e);
+            return Self::with_source(fl!("download-failed", filename = *filename), e);
         }
 
         fl!("download-failed-no-name").into()

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,28 +142,24 @@ impl From<oma_apt_pkg::Error> for OutputError {
 impl From<MirrorError> for OutputError {
     fn from(value: MirrorError) -> Self {
         match value {
-            MirrorError::ReadFile { path, source } => Self::with_source(
-                fl!("failed-to-operate-path", p = path.display()),
-                source,
-            ),
-            MirrorError::ParseJson { path, source } => Self::with_source(
-                fl!("failed-to-parse-file", p = path.display()),
-                source,
-            ),
+            MirrorError::ReadFile { path, source } => {
+                Self::with_source(fl!("failed-to-operate-path", p = path.display()), source)
+            }
+            MirrorError::ParseJson { path, source } => {
+                Self::with_source(fl!("failed-to-parse-file", p = path.display()), source)
+            }
             MirrorError::MirrorNotExist { mirror_name } => {
                 fl!("mirror-not-found", mirror = mirror_name.as_ref()).into()
             }
             MirrorError::SerializeJson { source } => {
                 Self::with_source(fl!("failed-to-serialize-struct"), source)
             }
-            MirrorError::WriteFile { path, source } => Self::with_source(
-                fl!("failed-to-write-file", p = path.display()),
-                source,
-            ),
-            MirrorError::CreateFile { path, source } => Self::with_source(
-                fl!("failed-to-create-file", p = path.display()),
-                source,
-            ),
+            MirrorError::WriteFile { path, source } => {
+                Self::with_source(fl!("failed-to-write-file", p = path.display()), source)
+            }
+            MirrorError::CreateFile { path, source } => {
+                Self::with_source(fl!("failed-to-create-file", p = path.display()), source)
+            }
             MirrorError::ApplyEmptySettings => fl!("mirrors-setting-empty").into(),
             MirrorError::ParseConfig { source } => {
                 Self::with_source("Failed to parse file", source)
@@ -327,10 +323,9 @@ impl From<RefreshError> for OutputError {
                     fl!("failed-refresh").into()
                 }
             }
-            RefreshError::OperateFile(path, error) => Self::with_source(
-                fl!("failed-to-operate-path", p = path.display()),
-                error,
-            ),
+            RefreshError::OperateFile(path, error) => {
+                Self::with_source(fl!("failed-to-operate-path", p = path.display()), error)
+            }
             RefreshError::WrongThreadCount(count) => {
                 fl!("wrong-thread-count", count = count).into()
             }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,9 +1,13 @@
+use std::borrow::Cow;
+use std::fmt::Display;
 use std::sync::LazyLock;
 
+use fluent_bundle::FluentValue;
 use i18n_embed::{
     DefaultLocalizer, LanguageLoader,
     fluent::{FluentLanguageLoader, fluent_language_loader},
 };
+use oma_console::console::StyledObject;
 use rust_embed::RustEmbed;
 
 pub const DEFAULT_LANGUAGE: &str = "en_US";
@@ -33,14 +37,98 @@ pub static LANGUAGE_LOADER: LazyLock<FluentLanguageLoader> = LazyLock::new(|| {
     loader
 });
 
+/// Values accepted as [`fl!`] message arguments.
+///
+/// Besides the types `i18n_embed_fl::fl!` accepts out of the box (`String`,
+/// `&str`, numbers, `Cow`, `Option`), this also covers styled strings such as
+/// `"name".emphasis_color()`, so call sites don't need explicit `.to_string()`.
+pub trait ToFluentValue {
+    fn to_fluent_value(self) -> FluentValue<'static>;
+}
+
+impl ToFluentValue for String {
+    fn to_fluent_value(self) -> FluentValue<'static> {
+        self.into()
+    }
+}
+
+impl ToFluentValue for &str {
+    fn to_fluent_value(self) -> FluentValue<'static> {
+        self.to_owned().into()
+    }
+}
+
+impl ToFluentValue for &String {
+    fn to_fluent_value(self) -> FluentValue<'static> {
+        self.clone().into()
+    }
+}
+
+impl ToFluentValue for Cow<'_, str> {
+    fn to_fluent_value(self) -> FluentValue<'static> {
+        self.into_owned().into()
+    }
+}
+
+impl<T: ToFluentValue> ToFluentValue for Option<T> {
+    fn to_fluent_value(self) -> FluentValue<'static> {
+        match self {
+            Some(v) => v.to_fluent_value(),
+            None => FluentValue::None,
+        }
+    }
+}
+
+macro_rules! impl_to_fluent_number {
+    ($($t:ty),* $(,)?) => {
+        $(impl ToFluentValue for $t {
+            fn to_fluent_value(self) -> FluentValue<'static> {
+                self.into()
+            }
+        })*
+    };
+}
+
+impl_to_fluent_number!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
+);
+
+impl<D: Display> ToFluentValue for StyledObject<D> {
+    fn to_fluent_value(self) -> FluentValue<'static> {
+        self.to_string().into()
+    }
+}
+
+impl ToFluentValue for std::path::Display<'_> {
+    fn to_fluent_value(self) -> FluentValue<'static> {
+        self.to_string().into()
+    }
+}
+
+impl ToFluentValue for std::io::Error {
+    fn to_fluent_value(self) -> FluentValue<'static> {
+        self.to_string().into()
+    }
+}
+
+/// Convert any [`ToFluentValue`] into a fluent message argument.
+#[inline]
+pub fn to_fluent_value(value: impl ToFluentValue) -> FluentValue<'static> {
+    value.to_fluent_value()
+}
+
 #[macro_export]
 macro_rules! fl {
     ($message_id:literal) => {{
         i18n_embed_fl::fl!($crate::lang::LANGUAGE_LOADER, $message_id)
     }};
 
-    ($message_id:literal, $($args:expr),*) => {{
-        i18n_embed_fl::fl!($crate::lang::LANGUAGE_LOADER, $message_id, $($args), *)
+    ($message_id:literal, $($key:ident = $value:expr),*) => {{
+        i18n_embed_fl::fl!(
+            $crate::lang::LANGUAGE_LOADER,
+            $message_id,
+            $($key = $crate::lang::to_fluent_value($value)),*
+        )
     }};
 }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -42,6 +42,13 @@ pub static LANGUAGE_LOADER: LazyLock<FluentLanguageLoader> = LazyLock::new(|| {
 /// Besides the types `i18n_embed_fl::fl!` accepts out of the box (`String`,
 /// `&str`, numbers, `Cow`, `Option`), this also covers styled strings such as
 /// `"name".emphasis_color()`, so call sites don't need explicit `.to_string()`.
+///
+/// The impls below re-implement, as a trait, the `From<...> for FluentValue`
+/// conversions fluent itself provides (string, borrowed string, `Cow`, and
+/// `Option` variants), so that call sites can go through [`to_fluent_value`]
+/// and arbitrary `Display`/styled values can be plugged in too. See:
+/// - https://github.com/projectfluent/fluent-rs/blob/fluent-bundle@0.16.0/fluent-bundle/src/types/mod.rs#L292-L326
+///   (the `From<...> for FluentValue` impls)
 pub trait ToFluentValue {
     fn to_fluent_value(self) -> FluentValue<'static>;
 }
@@ -79,6 +86,10 @@ impl<T: ToFluentValue> ToFluentValue for Option<T> {
     }
 }
 
+// The integer conversions mirror fluent's `from_num!` macro, which generates
+// `From<$int> for FluentValue` for exactly these types. See:
+// - https://github.com/projectfluent/fluent-rs/blob/fluent-bundle@0.16.0/fluent-bundle/src/types/number.rs#L184-L246
+//   (the `from_num!` macro and its `i8`..`usize` type list)
 macro_rules! impl_to_fluent_number {
     ($($t:ty),* $(,)?) => {
         $(impl ToFluentValue for $t {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ use std::sync::atomic::AtomicBool;
 
 use oma_console::console;
 
+use crate::color::Colorize;
 use crate::config::OmaConfig;
 use crate::config_file::ConfigFile;
 use crate::exit_handle::ExitHandle;
@@ -330,7 +331,7 @@ fn display_error(e: OutputError) -> io::Result<()> {
         if cause.len() > 1 {
             for (i, c) in cause.iter().enumerate() {
                 if i == 0 {
-                    WRITER.write_prefix(&console::style("TRACE").magenta().to_string())?;
+                    WRITER.write_prefix(&"TRACE".purple_color().to_string())?;
                 } else {
                     WRITER.write_prefix("")?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
-use std::env::{self, args};
+use std::env::args;
 use std::ffi::CString;
-use std::io::{self, IsTerminal, stderr, stdin};
+use std::io;
 use std::path::{Path, PathBuf};
 
 use std::process::{Command, exit};
 use std::sync::{LazyLock, OnceLock};
-use std::time::Duration;
 
 mod args;
+mod color;
 mod completions;
 mod config;
 mod config_file;
@@ -31,22 +31,16 @@ use clap::builder::FalseyValueParser;
 use clap::{ArgAction, ArgMatches, Args, ColorChoice, CommandFactory, FromArgMatches};
 use clap_complete::CompleteEnv;
 use clap_i18n_richformatter::CommandI18nExt;
-use dbus::is_ssh_from_loginctl;
 use error::OutputError;
 use i18n_embed::{DesktopLanguageRequester, Localizer};
 use lang::LANGUAGE_LOADER;
-use oma_console::{
-    print::{OmaColorFormat, termbg},
-    terminal::wrap_content,
-    writer::Writer,
-};
+use oma_console::{terminal::wrap_content, writer::Writer};
 use oma_utils::{OsRelease, is_termux};
-use rustix::stdio::stdout;
 use spdlog::{debug, info, prelude::error as log_error, warn};
 use tokio::runtime::Runtime;
 use tui::Tui;
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 
 use oma_console::console;
 
@@ -62,7 +56,6 @@ use anyhow::Chain;
 static NOT_DISPLAY_ABORT: AtomicBool = AtomicBool::new(false);
 static NOT_ALLOW_CTRLC: AtomicBool = AtomicBool::new(false);
 static DEFAULT_USER_AGENT: &str = concat!("oma/", env!("CARGO_PKG_VERSION"));
-static COLOR_FORMATTER: OnceLock<OmaColorFormat> = OnceLock::new();
 static RT: LazyLock<Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -275,7 +268,11 @@ fn init_localizer() {
 }
 
 fn try_main(mut config: OmaConfig, matches: ArgMatches) -> Result<ExitHandle, OutputError> {
-    init_color_formatter(&config);
+    crate::color::init_color(
+        config.color == ColorChoice::Never,
+        config.follow_terminal_color,
+    );
+
     let subcmd = config.take_subcmd();
 
     match subcmd {
@@ -314,80 +311,6 @@ fn try_main(mut config: OmaConfig, matches: ArgMatches) -> Result<ExitHandle, Ou
             }
         }
     }
-}
-
-fn init_color_formatter(config: &OmaConfig) {
-    let mut follow_term_color = config.follow_terminal_color;
-    let no_color = config.color == ColorChoice::Never;
-
-    if no_color {
-        unsafe { env::set_var("NO_COLOR", "1") };
-        console::set_colors_enabled(false);
-        NO_COLOR.store(true, Ordering::Relaxed);
-    }
-
-    COLOR_FORMATTER.get_or_init(|| {
-        // FIXME: Marking latency limits for oma's terminal color queries (via
-        // termbg). On slower terminals - i.e., SSH and unaccelerated
-        // graphical environments, any colored interfaces in oma may return a
-        // terminal color query string in the returned shell, confusing users.
-        //
-        //   (ssh)root@LoongUnion1 [ ~ ] ? 11;rgb:2323/2626/2727
-        //
-        // Following advice from termbg here. Add latency limits to avoid this
-        // strange output on slower terminals.
-        //
-        // For further investigation, we have some remaining questions:
-        //
-        // 1. Why 100ms? We see that the termbg-based procs project using the
-        //    same latency limit to workaround the aforementioned issue.
-        //    It should be noted that this is nothing more than a "magic
-        //    number" that we have tested to work.
-        // 2. The true cause or reproducing conditions for this issue is not
-        //    yet clear, we found the same issue on a slower machine (Loongson
-        //    3B4000) in a nearby datacenter (~50ms) with a faster one
-        //    (Loongson 3C5000), which does not exhibit the issue; as well as
-        //    on a faster machine (AMD EPYC 7H12) with high latency (~450ms).
-        //
-        // Ref: https://github.com/dalance/procs/issues/221
-        // Ref: https://github.com/dalance/procs/commit/83305be6fb431695a070524328b66c7107ce98f3
-        let timeout = Duration::from_millis(100);
-
-        if !stdout().is_terminal() || !stderr().is_terminal() || !stdin().is_terminal() || no_color
-        {
-            follow_term_color = true;
-        } else if env::var("SSH_CONNECTION").is_ok() || is_ssh_from_loginctl()  {
-            debug!(
-                "You are running oma in an SSH session, using default terminal colors to avoid latency."
-            );
-            follow_term_color = true;
-        } else if env::var("TERM").is_err() || termbg::terminal() != termbg::Terminal::XtermCompatible {
-            debug!("Your terminal is: {:?}", termbg::terminal());
-            debug!(
-                "Unknown or unsupported terminal ($TERM is empty or unsupported) detected, using default terminal colors to avoid latency."
-            );
-            follow_term_color = true;
-        } else if let Ok(latency) = termbg::latency(Duration::from_millis(1000)) {
-            debug!("latency: {:?}", latency);
-            if latency * 2 > timeout {
-                debug!(
-                    "Terminal latency is too long, falling back to default terminal colors, latency: {:?}.",
-                    latency
-                );
-                follow_term_color = true;
-            }
-        } else {
-            debug!("Terminal latency is too long, falling back to default terminal colors.");
-            follow_term_color = true;
-        }
-
-        OmaColorFormat::new(follow_term_color, timeout)
-    });
-}
-
-#[inline]
-fn color_formatter() -> &'static OmaColorFormat {
-    COLOR_FORMATTER.get().unwrap()
 }
 
 fn display_error(e: OutputError) -> io::Result<()> {

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -12,13 +12,12 @@ use anyhow::Chain;
 use oma_console::{
     indicatif::{MultiProgress, ProgressBar as IndicatifProgressBar, ProgressStyle},
     pb::{global_progress_bar_style, progress_bar_style, spinner_style},
-    print::Action,
 };
 use oma_fetch::{Event, SingleDownloadError};
 use reqwest::StatusCode;
 
 use crate::{WRITER, fl, install_progress::OSC94, msg, root::is_root};
-use crate::{color_formatter, error::OutputError};
+use crate::{color::Colorize, error::OutputError};
 use oma_refresh::db::Event as RefreshEvent;
 
 use oma_utils::human_bytes::HumanBytes;
@@ -387,15 +386,9 @@ impl ProgressRenderer {
                         "{}",
                         fl!(
                             "unsupported-sources-list",
-                            p = color_formatter()
-                                .color_str(path.to_string_lossy(), Action::Emphasis)
-                                .to_string(),
-                            list = color_formatter()
-                                .color_str(".list", Action::Secondary)
-                                .to_string(),
-                            sources = color_formatter()
-                                .color_str(".sources", Action::Secondary)
-                                .to_string()
+                            p = path.to_string_lossy().emphasis_color(),
+                            list = ".list".secondary_color(),
+                            sources = ".sources".secondary_color()
                         )
                     );
                 }

--- a/src/root.rs
+++ b/src/root.rs
@@ -59,7 +59,7 @@ fn other_permission_tools_run_oma(cmd: &str) -> Result<()> {
         .args(std::env::args())
         .spawn()
         .and_then(|x| x.wait_with_output())
-        .map_err(|e| anyhow!(fl!("execute-cmd-fail", cmd = cmd, e = e.to_string())))?;
+        .map_err(|e| anyhow!(fl!("execute-cmd-fail", cmd = cmd, e = e)))?;
 
     exit(out.status.code().unwrap_or(1));
 }
@@ -72,7 +72,7 @@ fn pkexec_oma() -> Result<()> {
         .args(std::env::args())
         .spawn()
         .and_then(|x| x.wait_with_output())
-        .map_err(|e| anyhow!(fl!("execute-cmd-fail", cmd = "pkexec", e = e.to_string())))?;
+        .map_err(|e| anyhow!(fl!("execute-cmd-fail", cmd = "pkexec", e = e)))?;
 
     exit(out.status.code().unwrap_or(1));
 }

--- a/src/subcommand/command_not_found.rs
+++ b/src/subcommand/command_not_found.rs
@@ -4,7 +4,6 @@ use std::io::stderr;
 use ahash::AHashMap;
 use anyhow::Context;
 use clap::Args;
-use oma_console::print::Action;
 use oma_contents::OmaContentsError;
 use oma_contents::searcher::{Mode, search};
 use oma_pm::apt::{OmaApt, OmaAptArgs};
@@ -16,7 +15,7 @@ use crate::error::OutputError;
 use crate::exit_handle::{ExitHandle, ExitStatus};
 use crate::table::PagerPrinter;
 use crate::utils::get_lists_dir;
-use crate::{RT, color_formatter, due_to, fl};
+use crate::{RT, color::Colorize, due_to, fl};
 
 use crate::args::CliExecuter;
 
@@ -120,13 +119,8 @@ impl CliExecuter for CommandNotFound {
                     };
 
                     let entry = (
-                        color_formatter()
-                            .color_str(pkg, Action::Emphasis)
-                            .bold()
-                            .to_string(),
-                        color_formatter()
-                            .color_str(file, Action::Secondary)
-                            .to_string(),
+                        pkg.emphasis_color().bold().to_string(),
+                        file.secondary_color().to_string(),
                         desc,
                     );
 

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -2,7 +2,6 @@ use std::{borrow::Cow, io::stdout, sync::atomic::Ordering};
 
 use clap::Args;
 use clap_complete::ArgValueCompleter;
-use oma_console::print::Action;
 use oma_pm::{
     apt::{OmaApt, OmaAptArgs},
     oma_apt::{PackageSort, PkgCurrentState, PkgSelectedState},
@@ -13,7 +12,7 @@ use crate::{
     NOT_DISPLAY_ABORT, completions::pkgnames_completions, config::OmaConfig,
     exit_handle::ExitHandle, fl,
 };
-use crate::{color_formatter, error::OutputError, table::PagerPrinter};
+use crate::{color::Colorize, error::OutputError, table::PagerPrinter};
 use anyhow::anyhow;
 
 use crate::args::CliExecuter;
@@ -225,13 +224,13 @@ impl CliExecuter for List {
                     printer
                         .println(format!(
                             "{}/{} {} {arch} {s}",
-                            color_formatter().color_str(&name, Action::Emphasis).bold(),
-                            color_formatter().color_str(branches_str, Action::Secondary),
+                            name.as_str().emphasis_color().bold(),
+                            branches_str.secondary_color(),
                             if let Some(new_version) = new_version {
                                 version_str = Cow::Owned(format!("{version_str} -> {new_version}"));
-                                color_formatter().color_str(version_str, Action::WARN)
+                                version_str.warn_color()
                             } else {
-                                color_formatter().color_str(version_str, Action::EmphasisSecondary)
+                                version_str.emphasis_secondary_color()
                             }
                         ))
                         .ok();

--- a/src/subcommand/mark.rs
+++ b/src/subcommand/mark.rs
@@ -2,15 +2,15 @@ use std::borrow::Cow;
 
 use clap::{Args, ValueEnum};
 use clap_complete::ArgValueCompleter;
-use oma_console::print::Action;
 use oma_pm::{
     apt::{OmaApt, OmaAptArgs},
     matches::{GetArchMethod, PackagesMatcher},
 };
 use spdlog::info;
 
+use crate::color::Colorize;
 use crate::{
-    color_formatter, completions::pkgnames_completions, config::OmaConfig, error::OutputError,
+    completions::pkgnames_completions, config::OmaConfig, error::OutputError,
     exit_handle::ExitHandle, root::root, success,
 };
 
@@ -92,9 +92,7 @@ impl CliExecuter for Mark {
         };
 
         for (pkg, is_set) in set {
-            let pkg = color_formatter()
-                .color_str(pkg, Action::Emphasis)
-                .to_string();
+            let pkg = pkg.emphasis_color();
 
             match action {
                 MarkAction::Hold if is_set => {

--- a/src/subcommand/remove.rs
+++ b/src/subcommand/remove.rs
@@ -37,7 +37,7 @@ pub struct Remove {
     /// Install package(s) without fsync(2)
     #[arg(
         long,
-        help = fl!("clap-force-unsafe-io-help", dangerous = crate::console::style(format!("{}", fl!("clap-dangerous"))).red().to_string()))]
+        help = fl!("clap-force-unsafe-io-help", dangerous = crate::console::style(format!("{}", fl!("clap-dangerous"))).red()))]
     force_unsafe_io: bool,
     /// Ignore repository and package dependency issues
     #[arg(long, help = fl!("clap-force-yes-help"))]

--- a/src/subcommand/search.rs
+++ b/src/subcommand/search.rs
@@ -7,7 +7,7 @@ use oma_apt_pkg::search::{
     TextSearch,
 };
 use oma_apt_pkg::{AptConfig, AptDb, DpkgState};
-use oma_console::{console::style, pager::Pager, terminal::gen_prefix};
+use oma_console::{pager::Pager, terminal::gen_prefix};
 use oma_pm::matches::SearchEngine;
 use oma_utils::zbus::proxy;
 use spdlog::debug;
@@ -90,7 +90,7 @@ impl Display for SearchResultDisplay<'_> {
         }
 
         let prefix = match i.status {
-            PackageStatus::Avail => style("AVAIL").dim(),
+            PackageStatus::Avail => "AVAIL".secondary_color(),
             PackageStatus::Installed => "INSTALLED".foreground_color(),
             PackageStatus::Upgrade => "UPGRADE".warn_color(),
         }

--- a/src/subcommand/search.rs
+++ b/src/subcommand/search.rs
@@ -7,14 +7,15 @@ use oma_apt_pkg::search::{
     TextSearch,
 };
 use oma_apt_pkg::{AptConfig, AptDb, DpkgState};
-use oma_console::{console::style, pager::Pager, print::Action, terminal::gen_prefix};
+use oma_console::{console::style, pager::Pager, terminal::gen_prefix};
 use oma_pm::matches::SearchEngine;
 use oma_utils::zbus::proxy;
 use spdlog::debug;
 use zbus::Connection;
 
+use crate::color::Colorize;
 use crate::{
-    RT, WRITER, color_formatter, completions::pkgnames_completions, config::OmaConfig,
+    RT, WRITER, completions::pkgnames_completions, config::OmaConfig,
     config_file::SearchEngine as ConfigSearchEngine, exit_handle::ExitHandle, fl,
 };
 use crate::{error::OutputError, table::oma_display_with_normal_output};
@@ -51,15 +52,9 @@ impl Display for SearchResultDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let i = self.0;
         let mut pkg_info_line = if i.is_base {
-            color_formatter()
-                .color_str(&i.name, Action::Purple)
-                .bold()
-                .to_string()
+            i.name.as_str().purple_color().bold().to_string()
         } else {
-            color_formatter()
-                .color_str(&i.name, Action::Emphasis)
-                .bold()
-                .to_string()
+            i.name.as_str().emphasis_color().bold().to_string()
         };
 
         pkg_info_line.push(' ');
@@ -67,13 +62,14 @@ impl Display for SearchResultDisplay<'_> {
         if i.status == PackageStatus::Upgrade {
             pkg_info_line.push_str(&format!(
                 "{} -> {}",
-                color_formatter().color_str(i.old_version.as_ref().unwrap(), Action::WARN),
-                color_formatter().color_str(&i.new_version, Action::EmphasisSecondary)
+                i.old_version.as_ref().unwrap().warn_color(),
+                i.new_version.as_str().emphasis_secondary_color()
             ));
         } else {
             pkg_info_line.push_str(
-                &color_formatter()
-                    .color_str(&i.new_version, Action::EmphasisSecondary)
+                &i.new_version
+                    .as_str()
+                    .emphasis_secondary_color()
                     .to_string(),
             );
         }
@@ -90,19 +86,13 @@ impl Display for SearchResultDisplay<'_> {
 
         if !pkg_tags.is_empty() {
             pkg_info_line.push(' ');
-            pkg_info_line.push_str(
-                &color_formatter()
-                    .color_str(format!("[{}]", pkg_tags.join(",")), Action::Note)
-                    .to_string(),
-            );
+            pkg_info_line.push_str(&format!("[{}]", pkg_tags.join(",")).note_color().to_string());
         }
 
         let prefix = match i.status {
             PackageStatus::Avail => style("AVAIL").dim(),
-            PackageStatus::Installed => {
-                color_formatter().color_str("INSTALLED", Action::Foreground)
-            }
-            PackageStatus::Upgrade => color_formatter().color_str("UPGRADE", Action::WARN),
+            PackageStatus::Installed => "INSTALLED".foreground_color(),
+            PackageStatus::Upgrade => "UPGRADE".warn_color(),
         }
         .to_string();
 
@@ -114,13 +104,9 @@ impl Display for SearchResultDisplay<'_> {
             .into_iter()
             .for_each(|(prefix, body)| {
                 write!(f, "{}", gen_prefix(prefix, 10)).ok();
-                writeln!(
-                    f,
-                    "{}",
-                    color_formatter().color_str(body.trim(), Action::Secondary)
-                )
-                // Keep original behavior
-                .ok();
+                writeln!(f, "{}", body.trim().secondary_color())
+                    // Keep original behavior
+                    .ok();
             });
 
         Ok(())

--- a/src/subcommand/tree.rs
+++ b/src/subcommand/tree.rs
@@ -17,6 +17,7 @@ use oma_pm::{
 };
 use spdlog::{debug, trace};
 
+use crate::color::Colorize;
 use crate::{
     CliExecuter, completions::pkgnames_completions, config::OmaConfig, error::OutputError,
     exit_handle::ExitHandle, fl, table::oma_display_with_normal_output,
@@ -103,9 +104,9 @@ impl Display for PkgWrapper<'_> {
         f.write_str(&self.package.fullname(true))?;
 
         if let Some(comp_and_version) = &self.comp_and_version {
-            write!(f, " {}", style(format!("({comp_and_version})")).yellow())?;
+            write!(f, " {}", format!("({comp_and_version})").note_color())?;
         } else if let Some(cand) = self.package.candidate() {
-            write!(f, " {}", style(format!("({})", cand.version())).yellow())?;
+            write!(f, " {}", format!("({})", cand.version()).note_color())?;
         }
 
         Ok(())

--- a/src/subcommand/utils.rs
+++ b/src/subcommand/utils.rs
@@ -5,7 +5,7 @@ use std::io::stdout;
 use std::os::fd::OwnedFd;
 use std::path::Path;
 
-use crate::color_formatter;
+use crate::color::Colorize;
 use crate::dbus::find_another_oma;
 use crate::error::OutputError;
 use crate::fl;
@@ -16,7 +16,6 @@ use crate::utils::get_lists_dir;
 use anyhow::Context;
 use dialoguer::console;
 use indexmap::IndexSet;
-use oma_console::print::Action;
 use oma_contents::searcher::Mode;
 use oma_contents::searcher::search;
 use oma_pm::CustomDownloadMessage;
@@ -57,12 +56,8 @@ pub(crate) fn handle_no_result(no_result: Vec<&str>, no_progress: bool) -> Resul
                 "{}",
                 fl!(
                     "no-result-bincontents-tips-2",
-                    pkg = color_formatter()
-                        .color_str(pkg, Action::Emphasis)
-                        .to_string(),
-                    cmd = color_formatter()
-                        .color_str(cmd, Action::Secondary)
-                        .to_string()
+                    pkg = pkg.emphasis_color(),
+                    cmd = cmd.secondary_color()
                 )
             );
         }

--- a/src/table.rs
+++ b/src/table.rs
@@ -4,16 +4,16 @@ use std::io::Write;
 use std::sync::LazyLock;
 use std::sync::atomic::Ordering;
 
+use crate::color::Colorize;
 use crate::console::style;
 use crate::error::OutputError;
 use crate::subcommand::utils::is_terminal;
-use crate::{NO_COLOR, NOT_DISPLAY_ABORT, WRITER, color_formatter, fl};
+use crate::{NO_COLOR, NOT_DISPLAY_ABORT, WRITER, fl};
 use ahash::HashMap;
 use ahash::HashSet;
 use dialoguer::console;
 use oma_console::indicatif::HumanBytes;
 use oma_console::pager::{Pager, PagerExit, PagerUIText};
-use oma_console::print::Action;
 use oma_history::{InstallHistoryEntry, RemoveHistoryEntry};
 use oma_pm::apt::{InstallEntry, InstallOperation, RemoveEntry, RemoveTag};
 
@@ -56,9 +56,7 @@ impl From<&InstallHistoryEntry> for InstallEntryDisplay {
         let name = match value.operation {
             InstallOperation::Install => style(&value.pkg_name).green().to_string(),
             InstallOperation::ReInstall => style(&value.pkg_name).blue().to_string(),
-            InstallOperation::Upgrade => color_formatter()
-                .color_str(&value.pkg_name, Action::UpgradeTips)
-                .to_string(),
+            InstallOperation::Upgrade => value.pkg_name.as_str().upgrade_tips_color().to_string(),
             InstallOperation::Downgrade => style(&value.pkg_name).yellow().to_string(),
             InstallOperation::Download => value.pkg_name.to_string(),
             InstallOperation::Default => unreachable!(),
@@ -160,9 +158,7 @@ impl From<&InstallEntry> for InstallEntryDisplay {
         let name = match value.op() {
             InstallOperation::Install => style(value.name()).green().to_string(),
             InstallOperation::ReInstall => style(value.name()).blue().to_string(),
-            InstallOperation::Upgrade => color_formatter()
-                .color_str(value.name(), Action::UpgradeTips)
-                .to_string(),
+            InstallOperation::Upgrade => value.name().upgrade_tips_color().to_string(),
             InstallOperation::Downgrade => style(value.name()).yellow().to_string(),
             InstallOperation::Download => value.name().to_string(),
             InstallOperation::Default => unreachable!(),
@@ -206,10 +202,7 @@ impl From<&InstallEntry> for InstallEntryDisplay {
     }
 }
 
-pub fn oma_display_with_normal_output(
-    is_question: bool,
-    len: usize,
-) -> Result<Pager<'static>, OutputError> {
+pub fn oma_display_with_normal_output(is_question: bool, len: usize) -> Result<Pager, OutputError> {
     if !is_question {
         NOT_DISPLAY_ABORT.store(true, Ordering::Relaxed);
     }
@@ -223,7 +216,7 @@ pub fn oma_display_with_normal_output(
                 download_and_install_size: None,
             }),
             None,
-            color_formatter(),
+            crate::color::color_theme(),
             false,
         )
         .map_err(|e| OutputError::with_source("Failed to get pager", e))?
@@ -416,7 +409,7 @@ pub fn table_for_install_pending(
                 download_and_install_size: Some((total_download_size, disk_size)),
             }),
             Some(fl!("pending-op")),
-            color_formatter(),
+            crate::color::color_theme(),
             yn_mode,
         )
         .map_err(|e| OutputError::with_source("Failed to get pager", e))?
@@ -492,7 +485,7 @@ pub fn table_for_history_pending(
             download_and_install_size: Some((total_download_size, disk_size)),
         }),
         Some(fl!("pending-op")),
-        color_formatter(),
+        crate::color::color_theme(),
         false,
     )
     .map_err(|e| OutputError::with_source("Failed to get pager", e))?;
@@ -627,7 +620,7 @@ fn print_pending_inner<W: Write>(
                 .println(format!(
                     "{} {}{}\n",
                     fl!("count-pkg-has-desc", count = update.len()),
-                    color_formatter().color_str(fl!("upgraded"), Action::UpgradeTips),
+                    fl!("upgraded").upgrade_tips_color(),
                     fl!("colon")
                 ))
                 .ok();
@@ -772,7 +765,7 @@ fn print_tum(
                         "tum-1-with-security",
                         updates = tum.len(),
                         security = security_count,
-                        security_str = style(fl!("security")).red().bold().to_string()
+                        security_str = style(fl!("security")).red().bold()
                     )
                 ))
                 .ok();
@@ -853,13 +846,11 @@ fn review_msg<W: Write>(printer: &mut PagerPrinter<W>) {
             "{}\n",
             fl!(
                 "oma-may",
-                a = style(fl!("install")).green().to_string(),
-                b = style(fl!("remove")).red().to_string(),
-                c = color_formatter()
-                    .color_str(fl!("upgrade"), Action::UpgradeTips)
-                    .to_string(),
-                d = style(fl!("downgrade")).yellow().to_string(),
-                e = style(fl!("reinstall")).blue().to_string()
+                a = style(fl!("install")).green(),
+                b = style(fl!("remove")).red(),
+                c = fl!("upgrade").upgrade_tips_color(),
+                d = style(fl!("downgrade")).yellow(),
+                e = style(fl!("reinstall")).blue()
             )
         ))
         .ok();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,7 +27,9 @@ macro_rules! success {
         use oma_console::writer::Writeln as _;
         let s = format!($($arg)+);
         spdlog::debug!("{s}");
-        $crate::WRITER.writeln(&oma_console::console::style("SUCCESS").green().bold().to_string(), &s).ok();
+        $crate::WRITER
+            .writeln(&$crate::color::Colorize::emphasis_color("SUCCESS").bold().to_string(), &s)
+            .ok();
     };
 }
 
@@ -38,6 +40,8 @@ macro_rules! due_to {
         use oma_console::writer::Writeln as _;
         let s = format!($($arg)+);
         spdlog::debug!("{s}");
-        $crate::WRITER.writeln(&oma_console::console::style("DUE TO").yellow().bold().to_string(), &s).ok();
+        $crate::WRITER
+            .writeln(&$crate::color::Colorize::note_color("DUE TO").bold().to_string(), &s)
+            .ok();
     };
 }


### PR DESCRIPTION
## Description

Rework oma's output coloring and make `fl!` message arguments accept styled and display values without `.to_string()`.

### Color output

Replace the verbose `color_formatter().color_str(x, Action::Y)` wrapper and the `OmaColorFormat` / `Action` types with a `Colorize` trait in the main crate (`src/color.rs`), so call sites can write `x.emphasis_color()`, `x.warn_color()`, etc.

- Move the color roles and the adaptive dark/light 256-color palette out of `oma-console` into the main crate.
- `src/color.rs::init_color` now owns the whole startup detection — disabling colors (`--color never` / `NO_COLOR`), tty checks, and the SSH / `TERM` / latency fallbacks that used to live in `main.rs` — and stores the resolved `termbg::Theme` once.
- `oma-console` keeps only formatting and pager utilities; `OmaPager` receives the detected `termbg::Theme` directly instead of a color-format reference.
- Adaptive theming is preserved: dark and light 256-color palettes are picked from the detected theme, falling back to the terminal's default (named) colors when the theme cannot be resolved.

### `fl!` argument ergonomics

`i18n_embed_fl::fl!` requires every argument to convert into a `FluentValue`, so colored strings (`StyledObject`) and `Display`-only values forced an explicit `.to_string()` at call sites.

- Wrap each `fl!` argument with a `ToFluentValue` conversion in `src/lang.rs` (backed by a direct `fluent-bundle` dependency). It covers owned/borrowed strings, numbers (kept numeric so future plural rules keep working), `Cow`, `Option`, styled strings, and common display wrappers such as `std::path::Display` and `std::io::Error`.
- Remove the now-redundant `.to_string()` calls from every `fl!` argument across the codebase.

## About AI

This PR draws inspiration from and modifies the Deepseek V4 flash. I have reviewed and amended some of the code, and updated some of the comments.

- Model: Deepseek v4 flash
- Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)