### PR TITLE
Add `Package` Struct on `oma-apt-pkg`

### DIFF
--- a/oma-apt-pkg/Cargo.toml
+++ b/oma-apt-pkg/Cargo.toml
@@ -22,6 +22,7 @@ apt-lists = [
     "dep:zstd",
     "dep:liblzma",
     "dep:rayon",
+    "dep:debversion",
 ]
 apt-sources = ["apt-config", "filename", "dep:oma-apt-sources-lists"]
 dpkg-status = []

--- a/oma-apt-pkg/src/apt_db.rs
+++ b/oma-apt-pkg/src/apt_db.rs
@@ -639,11 +639,13 @@ impl AptDb {
         }
         match &self.repo {
             Repo::Owned(map) => map.get_key_value(name).map(|(k, _)| k.as_str()),
+            // rkyv `ArchivedHashMap::get_key_value` is a hash lookup, like
+            // the owned map — never scan the archived keys linearly (that
+            // would make per-package lookups O(all packages)).
             Repo::Archived(archived) => archived
                 .archived()
                 .entries
-                .iter()
-                .find(|(k, _)| k.as_str() == name)
+                .get_key_value(name)
                 .map(|(k, _)| k.as_str()),
         }
     }

--- a/oma-apt-pkg/src/apt_db.rs
+++ b/oma-apt-pkg/src/apt_db.rs
@@ -23,6 +23,7 @@ use crate::apt_lists::{
 use crate::apt_sources::SourceLookup;
 use crate::cache;
 use crate::cache::CacheFile;
+use crate::package::Package;
 use crate::package_matcher::PackageMatcher;
 
 /// Magic for the package-database cache file (`Dir::Cache::oma-aptdb`);
@@ -158,22 +159,25 @@ pub enum QueryError {
     Matcher(#[from] crate::package_matcher::MatcherError),
 }
 
+/// One resolved query: the [`Package`] view of the matched package plus its
+/// version/source filtered versions.
+#[derive(Debug)]
+pub struct ResolvedPackage<'a> {
+    /// The package view, providing package-level info (name, version
+    /// count, installed state) without re-borrowing the database.
+    pub pkg: Package<'a>,
+    /// The (version/source filtered) versions for this query — all
+    /// versions of the package, a single version (`pkg=1.2.3`), one branch
+    /// (`pkg/suite`) or a local `.deb`'s own version. Versions borrowed
+    /// from the database when no filtering needed them owned.
+    pub versions: Vec<Cow<'a, PackageVersion>>,
+}
+
 /// Result of resolving package queries.
 #[derive(Debug)]
 pub struct QueryResolution<'a> {
-    /// Display groups in query order; each group holds the (version/source
-    /// filtered) versions for one query — all versions of a package, a
-    /// single version (`pkg=1.2.3`), one branch (`pkg/suite`) or a local
-    /// `.deb`. Versions borrowed from the database when no filtering needed
-    /// them owned.
-    pub groups: Vec<Vec<Cow<'a, PackageVersion>>>,
-    /// Number of distinct versions each group's package has across the whole
-    /// database (a version shared by several sources counts once). Parallel
-    /// to [`groups`](Self::groups), computed while the database is still
-    /// accessible; the display layer uses it to report "N additional
-    /// versions" even when the group itself is version-filtered (e.g. a
-    /// local `.deb` query resolves to `pkg=<version>`).
-    pub version_counts: Vec<usize>,
+    /// Resolved queries in query order.
+    pub resolved: Vec<ResolvedPackage<'a>>,
     /// Queries that matched no package.
     pub no_match: Vec<String>,
 }
@@ -309,6 +313,21 @@ impl AptDb {
         }
     }
 
+    /// Number of versions of `name` without materializing them — the
+    /// memory-mapped path reads the rkyv vector length directly instead of
+    /// deserializing every version just to count.
+    pub(crate) fn version_count(&self, name: &str) -> usize {
+        if let Some(overlay) = self.overlay.get(name) {
+            return overlay.len();
+        }
+        match &self.repo {
+            Repo::Owned(map) => map.get(name).map_or(0, |v| v.len()),
+            Repo::Archived(archived) => {
+                archived.archived().entries.get(name).map_or(0, |v| v.len())
+            }
+        }
+    }
+
     /// The mutable version list for `name`, copying the repo's versions in
     /// when the repo is memory-mapped (copy-on-write: overlay entries shadow
     /// the repo so merges keep the eager semantics).
@@ -422,20 +441,26 @@ impl AptDb {
 
         let matcher = PackageMatcher::new(self);
         let mut no_match = Vec::new();
-        let mut groups = Vec::new();
-        let mut version_counts = Vec::new();
+        let mut resolved = Vec::new();
 
         // Resolve each `.deb` against its own version directly — the
         // control file's `(name, version)` go straight into
         // `match_from_version` instead of being formatted into a
         // `name=version` pattern and re-parsed. A `.deb` without a
-        // `Version` resolves to all versions.
+        // `Version` resolves to all versions; either way it resolves to
+        // exactly one group.
         for (name, version) in deb_versions {
-            version_counts.push(self.distinct_version_count(&name));
-            match version {
-                Some(v) => groups.extend(matcher.match_from_version(&name, &v)?),
-                None => groups.extend(matcher.match_pkgs_and_versions_from_glob(&name)?),
-            }
+            let versions = match version {
+                Some(v) => matcher.match_from_version(&name, &v)?,
+                None => matcher.match_pkgs_and_versions_from_glob(&name)?,
+            };
+            resolved.push(ResolvedPackage {
+                pkg: Package::new(self, name.clone()),
+                versions: versions
+                    .into_iter()
+                    .next()
+                    .expect("a `.deb` resolves to exactly one group"),
+            });
         }
 
         // Resolve the remaining name/glob/version/branch expressions.
@@ -443,27 +468,25 @@ impl AptDb {
             let (matched, no_result) =
                 matcher.match_pkgs_and_versions(names.iter().map(String::as_str))?;
 
-            for group in matched {
+            for versions in matched {
                 // Groups are never empty (the matcher drops empty matches),
-                // so the first version carries the package name for the
-                // distinct-version count.
-                version_counts.push(
-                    group
-                        .first()
-                        .map_or(0, |v| self.distinct_version_count(&v.entry.package)),
-                );
-
-                groups.push(group);
+                // so the first version carries the package name.
+                let name = versions
+                    .first()
+                    .expect("groups are never empty")
+                    .entry
+                    .package
+                    .clone();
+                resolved.push(ResolvedPackage {
+                    pkg: Package::new(self, name),
+                    versions,
+                });
             }
 
             no_match = no_result.into_iter().map(str::to_owned).collect();
         }
 
-        Ok(QueryResolution {
-            groups,
-            version_counts,
-            no_match,
-        })
+        Ok(QueryResolution { resolved, no_match })
     }
 
     /// Build from entries with parallel source tracking. Test-only: the
@@ -572,44 +595,8 @@ impl AptDb {
     /// for the pretty form.
     ///
     /// See [`PackageEntry::fullname`].
-    pub fn fullname<'a>(&self, entry: &'a PackageEntry, pretty: bool) -> Cow<'a, str> {
+    pub(crate) fn fullname<'a>(&self, entry: &'a PackageEntry, pretty: bool) -> Cow<'a, str> {
         entry.fullname(pretty, &self.native_arch)
-    }
-
-    /// The candidate entry for a package name (highest version), as an
-    /// owned copy (deserialized from the memory map, or cloned from owned
-    /// data).
-    pub fn get_candidate(&self, name: &str) -> Option<PackageEntry> {
-        let versions = self.versions(name);
-        let best = versions.iter().max_by_key(|v| v.parsed_version())?;
-        Some(best.entry.clone())
-    }
-
-    /// Iterate the entries of `name` matching `version` exactly.
-    ///
-    /// Borrowed from the in-memory map when the repo is owned, owned
-    /// (deserialized on the fly) when it comes from the memory map. The
-    /// filter closure captures `version`, so the returned iterator is
-    /// bounded by both `self` and `version`.
-    pub fn get<'a>(
-        &'a self,
-        name: &str,
-        version: &'a str,
-    ) -> Box<dyn Iterator<Item = Cow<'a, PackageEntry>> + 'a> {
-        let versions = self.versions(name);
-        match versions {
-            Cow::Borrowed(slice) => Box::new(
-                slice
-                    .iter()
-                    .filter(move |v| v.entry.version.as_deref().is_some_and(|v| v == version))
-                    .map(|v| Cow::Borrowed(&v.entry)),
-            ),
-            Cow::Owned(vec) => Box::new(
-                vec.into_iter()
-                    .filter(move |v| v.entry.version.as_deref().is_some_and(|v| v == version))
-                    .map(|v| Cow::Owned(v.entry)),
-            ),
-        }
     }
 
     /// Iterate over all package entries (across all names and versions).
@@ -643,33 +630,52 @@ impl AptDb {
         overlay.chain(repo)
     }
 
-    /// Find all entries matching a package name.
-    pub fn get_all(&self, name: &str) -> Box<dyn Iterator<Item = Cow<'_, PackageEntry>> + '_> {
-        match self.versions(name) {
-            Cow::Borrowed(slice) => Box::new(slice.iter().map(|v| Cow::Borrowed(&v.entry))),
-            Cow::Owned(vec) => Box::new(vec.into_iter().map(|v| Cow::Owned(v.entry))),
+    /// The canonical `'a`-borrowed package name for `name`, if the database
+    /// knows it — the overlay or repo map key. Lets [`Package`] handles
+    /// borrow the map key instead of cloning a transient query string.
+    fn canonical_name<'a>(&'a self, name: &str) -> Option<&'a str> {
+        if let Some((key, _)) = self.overlay.get_key_value(name) {
+            return Some(key.as_str());
+        }
+        match &self.repo {
+            Repo::Owned(map) => map.get_key_value(name).map(|(k, _)| k.as_str()),
+            Repo::Archived(archived) => archived
+                .archived()
+                .entries
+                .iter()
+                .find(|(k, _)| k.as_str() == name)
+                .map(|(k, _)| k.as_str()),
         }
     }
 
-    /// Number of distinct versions of a package across the whole database.
-    /// Versions are already deduplicated (each [`PackageVersion`] is one
-    /// version), so this is simply the version count.
-    pub(crate) fn distinct_version_count(&self, name: &str) -> usize {
-        self.versions(name).len()
+    /// The [`Package`] view of `name`, or `None` if the database knows no
+    /// such package. The name is borrowed from the database's map key, so
+    /// no allocation is needed for a known package.
+    pub fn package(&self, name: &str) -> Option<Package<'_>> {
+        Some(Package::new(self, self.canonical_name(name)?))
     }
 
-    /// All package names known to the database — overlay names first,
-    /// shadowing repo names.
-    pub fn packages(&self) -> Box<dyn Iterator<Item = &str> + '_> {
-        let overlay = self.overlay.keys().map(|s| s.as_str());
-        let repo: Box<dyn Iterator<Item = &str> + '_> = match &self.repo {
-            Repo::Owned(map) => Box::new(map.keys().map(|s| s.as_str())),
-            Repo::Archived(archived) => {
-                Box::new(archived.archived().entries.iter().map(|(k, _)| k.as_str()))
-            }
+    /// Iterate every package in the database as a [`Package`] view — one
+    /// item per package name (overlay names first, shadowing repo names,
+    /// like [`Self::packages`]).
+    pub fn packages_iter(&self) -> impl Iterator<Item = Package<'_>> + '_ {
+        let overlay = self
+            .overlay
+            .keys()
+            .map(|name| Package::new(self, name.as_str()));
+
+        let repo: Box<dyn Iterator<Item = Package<'_>> + '_> = match &self.repo {
+            Repo::Owned(map) => Box::new(map.keys().map(|name| Package::new(self, name.as_str()))),
+            Repo::Archived(archived) => Box::new(
+                archived
+                    .archived()
+                    .entries
+                    .iter()
+                    .map(|(name, _)| Package::new(self, name.as_str())),
+            ),
         };
-        // Overlay names shadow repo names (dedup by name).
-        Box::new(overlay.chain(repo.filter(move |n| !self.overlay.contains_key(*n))))
+
+        overlay.chain(repo.filter(move |p| !self.overlay.contains_key(p.name())))
     }
 }
 
@@ -714,9 +720,12 @@ mod tests {
         db.insert(entry("localpkg", "1.0"));
 
         assert!(db.has_package("localpkg"));
-        let all = db.get_all("localpkg").collect::<Vec<_>>();
-        assert_eq!(all.len(), 1);
-        assert_eq!(all[0].version.as_deref(), Some("1.0"));
+        let pkg = db.package("localpkg").unwrap();
+        assert_eq!(pkg.version_count(), 1);
+        assert_eq!(
+            pkg.candidate().unwrap().entry.version.as_deref(),
+            Some("1.0")
+        );
 
         // Versions inserted without a source have an empty source list.
         let versions = db.versions("localpkg");
@@ -729,8 +738,7 @@ mod tests {
         let mut db = AptDb::from_entries("", vec![entry("localpkg", "1.0")]);
         db.insert(entry("localpkg", "2.0"));
 
-        let all = db.get_all("localpkg").collect::<Vec<_>>();
-        assert_eq!(all.len(), 2);
+        assert_eq!(db.package("localpkg").unwrap().version_count(), 2);
     }
 
     #[test]
@@ -748,12 +756,12 @@ mod tests {
             .resolve_queries(vec!["fish".into(), "nosuchpkg".into()])
             .unwrap();
 
-        assert_eq!(resolution.groups.len(), 1);
-        let versions = &resolution.groups[0];
+        assert_eq!(resolution.resolved.len(), 1);
+        let versions = &resolution.resolved[0].versions;
         assert_eq!(versions.len(), 2);
         assert!(versions.iter().all(|v| v.entry.package == "fish"));
         // two distinct versions (3.6, 3.7)
-        assert_eq!(resolution.version_counts, vec![2]);
+        assert_eq!(resolution.resolved[0].pkg.version_count(), 2);
         assert_eq!(resolution.no_match, vec!["nosuchpkg"]);
     }
 
@@ -771,13 +779,13 @@ mod tests {
             .unwrap();
 
         assert!(resolution.no_match.is_empty());
-        assert_eq!(resolution.groups.len(), 1);
-        let versions = &resolution.groups[0];
+        assert_eq!(resolution.resolved.len(), 1);
+        let versions = &resolution.resolved[0].versions;
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].entry.package, "hello");
         assert_eq!(versions[0].entry.version.as_deref(), Some("2.10-2"));
         // only the local `.deb` version exists in the database
-        assert_eq!(resolution.version_counts, vec![1]);
+        assert_eq!(resolution.resolved[0].pkg.version_count(), 1);
 
         // The local `.deb` carries a `file:` URI source.
         assert_eq!(versions[0].sources.len(), 1);
@@ -806,8 +814,8 @@ mod tests {
             .resolve_queries(vec![deb_path.to_string_lossy().into_owned()])
             .unwrap();
 
-        assert_eq!(resolution.groups.len(), 1);
-        let versions = &resolution.groups[0];
+        assert_eq!(resolution.resolved.len(), 1);
+        let versions = &resolution.resolved[0].versions;
         // repo (same version) + local `.deb` merge into one version whose
         // source list carries both the `stable` and `file:` entries.
         assert_eq!(versions.len(), 1);
@@ -815,24 +823,7 @@ mod tests {
         assert_eq!(versions[0].sources[0].suite, "stable");
         assert!(versions[0].sources[1].base_url.starts_with("file:"));
         // repo 2.10-2 + local 2.10-2 dedupe to one distinct version
-        assert_eq!(resolution.version_counts, vec![1]);
-    }
-
-    #[test]
-    fn test_distinct_version_count() {
-        let db = AptDb::from_entries(
-            "",
-            vec![
-                entry("fish", "3.6"),
-                entry("fish", "3.7"),
-                entry("fish", "3.7"), // same version from another source
-                entry("apt", "2.5"),
-            ],
-        );
-
-        assert_eq!(db.distinct_version_count("fish"), 2);
-        assert_eq!(db.distinct_version_count("apt"), 1);
-        assert_eq!(db.distinct_version_count("nosuchpkg"), 0);
+        assert_eq!(resolution.resolved[0].pkg.version_count(), 1);
     }
 
     fn stable_source() -> IndexSource {
@@ -938,7 +929,7 @@ mod tests {
         assert_eq!(merged[0].sources.len(), 2);
         assert!(merged[0].sources.iter().any(|s| s.suite == "stable"));
         assert!(merged[0].sources.iter().any(|s| s.suite == "local-deb"));
-        assert_eq!(db.distinct_version_count("hello"), 1);
+        assert_eq!(db.package("hello").unwrap().version_count(), 1);
     }
 
     /// `resolve_queries` works against a memory-mapped repo, matching a
@@ -968,11 +959,61 @@ mod tests {
             .resolve_queries(vec!["fish".into(), "nosuchpkg".into()])
             .unwrap();
 
-        assert_eq!(resolution.groups.len(), 1);
-        let versions = &resolution.groups[0];
+        assert_eq!(resolution.resolved.len(), 1);
+        let versions = &resolution.resolved[0].versions;
         assert_eq!(versions.len(), 2);
         assert!(versions.iter().all(|v| v.entry.package == "fish"));
-        assert_eq!(resolution.version_counts, vec![2]);
+        assert_eq!(resolution.resolved[0].pkg.version_count(), 2);
         assert_eq!(resolution.no_match, vec!["nosuchpkg"]);
+    }
+
+    /// The [`Package`] view works against a memory-mapped repo, exercising
+    /// the owned-deserialize (rkyv) path of `package()`/`packages_iter()`
+    /// and the `Package` accessors.
+    #[test]
+    fn test_package_on_archived_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("oma-aptdb.bincode");
+
+        let data = AptDbData {
+            entries: build_map(
+                vec![
+                    entry("fish", "3.6"),
+                    entry("fish", "3.7"),
+                    entry("apt", "2.5.4"),
+                ],
+                vec![stable_source(), stable_source(), stable_source()],
+            ),
+            native_arch: "amd64".to_string(),
+            files: Vec::new(),
+        };
+        save_aptdb(&path, &data).unwrap();
+
+        let db = AptDb {
+            repo: Repo::Archived(ArchivedAptDb::open(&path).unwrap()),
+            overlay: HashMap::new(),
+            native_arch: "amd64".to_string(),
+        };
+
+        let fish = db.package("fish").expect("fish present");
+        assert_eq!(fish.name(), "fish");
+        assert_eq!(fish.version_count(), 2);
+        assert_eq!(
+            fish.candidate().unwrap().entry.version.as_deref(),
+            Some("3.7")
+        );
+        assert_eq!(
+            fish.get_version("3.6").unwrap().entry.version.as_deref(),
+            Some("3.6")
+        );
+        assert_eq!(fish.fullname(true), "fish");
+        assert!(db.package("nosuchpkg").is_none());
+
+        let mut names = db
+            .packages_iter()
+            .map(|p| p.name().to_string())
+            .collect::<Vec<_>>();
+        names.sort();
+        assert_eq!(names, vec!["apt", "fish"]);
     }
 }

--- a/oma-apt-pkg/src/dpkg_state.rs
+++ b/oma-apt-pkg/src/dpkg_state.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use deb822_fast::{Deb822, FromDeb822Paragraph};
 
@@ -14,7 +15,8 @@ use crate::dpkg::{DpkgPackage, parse_dpkg_status};
 /// every installed package (e.g. search). [`Self::from_file_lazy`] only
 /// records the path and answers [`Self::is_installed`] by scanning until the
 /// queried package is found, so a single-package consumer like `oma show`
-/// never parses the whole status file.
+/// never parses the whole status file. Installed-version lookups in lazy
+/// mode scan the file once on first use (cached afterwards).
 #[derive(Debug, Clone)]
 pub struct DpkgState {
     /// Set of installed package names (eager mode).
@@ -26,6 +28,29 @@ pub struct DpkgState {
     /// Lazily-answered `is_installed` results (name → installed), filled by
     /// partial scans. Only ever consulted in lazy mode.
     lazy_answers: RefCell<HashMap<String, bool>>,
+    /// Installed-version map for lazy mode, filled by a single full scan on
+    /// the first version lookup (lazy mode otherwise scans incrementally for
+    /// `is_installed` only, and a version cannot be borrowed from a partial
+    /// cache).
+    lazy_versions: OnceLock<HashMap<String, String>>,
+}
+
+/// Build the installed name → version map from parsed status packages.
+fn installed_versions_map(packages: &[DpkgPackage]) -> HashMap<String, String> {
+    packages
+        .iter()
+        .filter(|p| p.selection_state().is_installed())
+        .map(|p| (p.name.clone(), p.version.clone().unwrap_or_default()))
+        .collect()
+}
+
+/// Full-scan the status file into an installed-version map. Infallible, like
+/// lazy mode: an unreadable or unparsable file yields an empty map.
+fn load_installed_versions(path: &Path) -> HashMap<String, String> {
+    match parse_dpkg_status(path) {
+        Ok(packages) => installed_versions_map(&packages),
+        Err(_) => HashMap::new(),
+    }
 }
 
 impl DpkgState {
@@ -34,33 +59,33 @@ impl DpkgState {
         let dpkg_packages = parse_dpkg_status(path)?;
 
         let mut installed = HashSet::new();
-        let mut installed_versions = HashMap::new();
-
         for p in &dpkg_packages {
             if p.selection_state().is_installed() {
                 installed.insert(p.name.clone());
-                installed_versions.insert(p.name.clone(), p.version.clone().unwrap_or_default());
             }
         }
 
         Ok(Self {
             installed,
-            installed_versions,
+            installed_versions: installed_versions_map(&dpkg_packages),
             lazy_path: None,
             lazy_answers: RefCell::new(HashMap::new()),
+            lazy_versions: OnceLock::new(),
         })
     }
 
     /// Record the status file path without parsing it; [`Self::is_installed`]
-    /// then scans only until the queried package is found. Infallible — an
-    /// unreadable status file simply reports nothing as installed. Version
-    /// lookups are not supported in this mode.
+    /// then scans only until the queried package is found, and
+    /// [`Self::installed_version`] scans the file once on first use.
+    /// Infallible — an unreadable status file simply reports nothing as
+    /// installed.
     pub fn from_file_lazy(path: impl AsRef<Path>) -> Self {
         Self {
             installed: HashSet::new(),
             installed_versions: HashMap::new(),
             lazy_path: Some(path.as_ref().to_path_buf()),
             lazy_answers: RefCell::new(HashMap::new()),
+            lazy_versions: OnceLock::new(),
         }
     }
 
@@ -105,8 +130,19 @@ impl DpkgState {
     }
 
     /// The installed version of a package, if any.
+    ///
+    /// In lazy mode this scans the status file once on the first call and
+    /// caches the result, so callers get the same answer as eager mode
+    /// instead of a silent `None`.
     pub fn installed_version(&self, name: &str) -> Option<&str> {
-        self.installed_versions.get(name).map(|s| s.as_str())
+        if let Some(path) = &self.lazy_path {
+            let versions = self
+                .lazy_versions
+                .get_or_init(|| load_installed_versions(path));
+            versions.get(name).map(|s| s.as_str())
+        } else {
+            self.installed_versions.get(name).map(|s| s.as_str())
+        }
     }
 }
 
@@ -156,6 +192,26 @@ Status: install ok installed
             assert_eq!(
                 lazy.is_installed(name),
                 eager.is_installed(name),
+                "mismatch for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn lazy_installed_version_matches_eager() {
+        let dir = write_status();
+        let path = dir.path().join("status");
+
+        let eager = DpkgState::from_file(&path).unwrap();
+        let lazy = DpkgState::from_file_lazy(&path);
+
+        // Lazy mode must answer version lookups like eager mode — a silent
+        // `None` would make `is_upgradable` report every installed package
+        // as not upgradable.
+        for name in ["bash", "zsh", "fish", "notinstalled", "nosuchpkg"] {
+            assert_eq!(
+                lazy.installed_version(name),
+                eager.installed_version(name),
                 "mismatch for {name}"
             );
         }

--- a/oma-apt-pkg/src/lib.rs
+++ b/oma-apt-pkg/src/lib.rs
@@ -15,6 +15,8 @@ pub use package_matcher::*;
 mod apt_lists;
 #[cfg(feature = "apt-sources")]
 pub mod apt_sources;
+#[cfg(feature = "apt-lists")]
+pub mod package;
 pub use apt_config::*;
 #[cfg(feature = "apt-config")]
 pub(crate) mod config_parser;
@@ -40,6 +42,8 @@ pub use apt_lists::*;
 pub use dpkg::*;
 pub use dpkg_state::*;
 pub use error::*;
+#[cfg(feature = "apt-lists")]
+pub use package::*;
 
 #[cfg(feature = "filename")]
 pub use filename::{AptListFilename, FilenameError, FilenameResult};

--- a/oma-apt-pkg/src/package.rs
+++ b/oma-apt-pkg/src/package.rs
@@ -1,0 +1,369 @@
+//! Package-level view over the APT package database — one [`Package`] per
+//! package name, mirroring apt's `pkgCache::PkgIterator` / rust-apt's
+//! `Package` parent.
+//!
+//! A [`Package`] is the "parent" of the versions in the database: it borrows
+//! the [`AptDb`] and a package name, and exposes package-level information —
+//! name, installed state, candidate version, display fields — without the
+//! caller having to reach into a specific [`PackageVersion`] first. Version
+//! access still goes through [`Package::versions`] /
+//! [`Package::candidate`].
+//!
+//! Since `AptDb`, `DpkgState` and `AptExtendedStates` are separate objects
+//! (unlike apt's `Cache`, which bakes dpkg state in), the state methods take
+//! `&DpkgState` / `&AptExtendedStates` as arguments.
+
+use std::borrow::Cow;
+use std::str::FromStr;
+
+use crate::{AptDb, AptExtendedStates, DpkgState, PackageEntry, PackageVersion};
+
+/// A package in the database: the per-name parent of its versions.
+///
+/// Construct via [`AptDb::package`] (one named package) or
+/// [`AptDb::packages_iter`] (all packages).
+#[derive(Debug)]
+pub struct Package<'a> {
+    apt_db: &'a AptDb,
+    name: Cow<'a, str>,
+}
+
+impl<'a> Package<'a> {
+    /// Build a package view. The name is borrowed when `name` already lives
+    /// `'a` (e.g. a database map key) and owned otherwise — so iterating
+    /// [`AptDb::packages_iter`] never allocates.
+    pub(crate) fn new(apt_db: &'a AptDb, name: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            apt_db,
+            name: name.into(),
+        }
+    }
+
+    /// The package name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The display name, `name:arch` — the pretty form omits the `:arch`
+    /// qualifier for the native architecture and `all` (see
+    /// [`PackageEntry::fullname`]).
+    pub fn fullname(&self, pretty: bool) -> Cow<'_, str> {
+        match self.representative() {
+            Some(Cow::Borrowed(version)) => self.apt_db.fullname(&version.entry, pretty),
+            Some(Cow::Owned(version)) => self
+                .apt_db
+                .fullname(&version.entry, pretty)
+                .into_owned()
+                .into(),
+            None => Cow::Borrowed(self.name.as_ref()),
+        }
+    }
+
+    /// Number of distinct versions in the database (a version shared by
+    /// several sources counts once).
+    pub fn version_count(&self) -> usize {
+        self.apt_db.version_count(&self.name)
+    }
+
+    /// All versions of this package.
+    pub fn versions(&self) -> Cow<'a, [PackageVersion]> {
+        self.apt_db.versions(&self.name)
+    }
+
+    /// The candidate version (highest version), like apt's
+    /// `PkgIterator::CandidateVer`.
+    pub fn candidate(&self) -> Option<Cow<'a, PackageVersion>> {
+        match self.versions() {
+            Cow::Borrowed(versions) => versions
+                .iter()
+                .max_by_key(|v| v.parsed_version())
+                .map(Cow::Borrowed),
+            Cow::Owned(versions) => versions
+                .iter()
+                .max_by_key(|v| v.parsed_version())
+                .map(|v| Cow::Owned(v.clone())),
+        }
+    }
+
+    /// The version matching `version` exactly, if present.
+    pub fn get_version(&self, version: &str) -> Option<Cow<'a, PackageVersion>> {
+        match self.versions() {
+            Cow::Borrowed(versions) => versions
+                .iter()
+                .find(|v| v.entry.version.as_deref() == Some(version))
+                .map(Cow::Borrowed),
+            Cow::Owned(versions) => versions
+                .into_iter()
+                .find(|v| v.entry.version.as_deref() == Some(version))
+                .map(Cow::Owned),
+        }
+    }
+
+    /// Whether the package is currently installed.
+    pub fn is_installed(&self, dpkg: &DpkgState) -> bool {
+        dpkg.is_installed(&self.name)
+    }
+
+    /// The installed version string, if any.
+    pub fn installed_version<'b>(&self, dpkg: &'b DpkgState) -> Option<&'b str> {
+        dpkg.installed_version(&self.name)
+    }
+
+    /// Whether the package was installed automatically as a dependency.
+    pub fn is_auto_installed(&self, dpkg: &DpkgState, ext: &AptExtendedStates) -> bool {
+        dpkg.is_installed(&self.name) && ext.is_auto_installed(&self.name)
+    }
+
+    /// Whether a newer version than the installed one is available in the
+    /// database. Uses proper Debian version comparison (epochs, `~`, ...),
+    /// falling back to string comparison when a version fails to parse.
+    pub fn is_upgradable(&self, dpkg: &DpkgState) -> bool {
+        let Some(installed) = dpkg.installed_version(&self.name) else {
+            return false;
+        };
+        let Some(candidate) = self.candidate() else {
+            return false;
+        };
+        let Some(cand) = candidate.entry.version.as_deref() else {
+            return false;
+        };
+        match (
+            debversion::Version::from_str(cand),
+            debversion::Version::from_str(installed),
+        ) {
+            (Ok(cand), Ok(installed)) => cand > installed,
+            _ => cand != installed,
+        }
+    }
+
+    /// The architecture of the package (from the candidate version, falling
+    /// back to the first version).
+    pub fn arch(&self) -> Option<Cow<'a, str>> {
+        self.version_field(|e| e.architecture.as_deref())
+    }
+
+    /// The section of the package (from the candidate version, falling back
+    /// to the first version).
+    pub fn section(&self) -> Option<Cow<'a, str>> {
+        self.version_field(|e| e.section.as_deref())
+    }
+
+    /// The priority of the package (from the candidate version, falling back
+    /// to the first version).
+    pub fn priority(&self) -> Option<Cow<'a, str>> {
+        self.version_field(|e| e.priority.as_deref())
+    }
+
+    /// The one-line summary (first line of the description), like apt's
+    /// `Summary()`. From the candidate version, falling back to the first
+    /// version.
+    pub fn short_description(&self) -> Option<Cow<'a, str>> {
+        self.version_field(|e| {
+            e.description
+                .as_deref()
+                .map(|d| d.lines().next().unwrap_or(d))
+        })
+    }
+
+    /// The candidate version, or the first version when there is no
+    /// candidate — the "representative" version display fields are read
+    /// from, mirroring apt's package-level convenience accessors.
+    fn representative(&self) -> Option<Cow<'a, PackageVersion>> {
+        match self.candidate() {
+            Some(candidate) => Some(candidate),
+            None => match self.versions() {
+                Cow::Borrowed(versions) => versions.first().map(Cow::Borrowed),
+                Cow::Owned(versions) => versions.into_iter().next().map(Cow::Owned),
+            },
+        }
+    }
+
+    /// Read a package-level field from the representative version, borrowing
+    /// when the database is owned and owning when it comes from the
+    /// memory-mapped archive.
+    fn version_field(
+        &self,
+        pick: impl for<'x> Fn(&'x PackageEntry) -> Option<&'x str>,
+    ) -> Option<Cow<'a, str>> {
+        match self.representative()? {
+            Cow::Borrowed(version) => pick(&version.entry).map(Cow::Borrowed),
+            Cow::Owned(version) => pick(&version.entry).map(|s| Cow::Owned(s.to_owned())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const STATUS: &str = "\
+Package: fish
+Version: 3.6
+Architecture: amd64
+Status: install ok installed
+
+Package: apt
+Version: 2.4
+Architecture: amd64
+Status: install ok installed
+
+Package: zsh
+Version: 5.9
+Architecture: amd64
+Status: install ok installed
+";
+
+    const EXTENDED: &str = "\
+Package: fish
+Architecture: amd64
+Auto-Installed: 1
+";
+
+    fn entry(name: &str, version: &str) -> PackageEntry {
+        PackageEntry {
+            package: name.to_string(),
+            version: Some(version.to_string()),
+            architecture: Some("amd64".to_string()),
+            section: Some("utils".to_string()),
+            priority: Some("optional".to_string()),
+            description: Some("A test package.\nLonger description.".to_string()),
+            ..PackageEntry {
+                package: String::new(),
+                version: None,
+                architecture: None,
+                description: None,
+                description_md5: None,
+                maintainer: None,
+                installed_size: None,
+                depends: None,
+                pre_depends: None,
+                recommends: None,
+                suggests: None,
+                breaks: None,
+                conflicts: None,
+                replaces: None,
+                provides: None,
+                section: None,
+                priority: None,
+                homepage: None,
+                multi_arch: None,
+                filename: None,
+                size: None,
+                sha256: None,
+            }
+        }
+    }
+
+    fn db() -> AptDb {
+        AptDb::from_entries(
+            "amd64",
+            vec![
+                entry("fish", "3.6"),
+                entry("fish", "3.7"),
+                entry("apt", "2.5"),
+                entry("zsh", "5.9"),
+                entry("vim", "9.0"),
+            ],
+        )
+    }
+
+    fn write_status() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::File::create(dir.path().join("status"))
+            .unwrap()
+            .write_all(STATUS.as_bytes())
+            .unwrap();
+        std::fs::File::create(dir.path().join("extended_states"))
+            .unwrap()
+            .write_all(EXTENDED.as_bytes())
+            .unwrap();
+        dir
+    }
+
+    #[test]
+    fn package_lookup() {
+        let db = db();
+        let fish = db.package("fish").unwrap();
+        assert_eq!(fish.name(), "fish");
+        assert!(db.package("nosuchpkg").is_none());
+    }
+
+    #[test]
+    fn packages_iter_yields_all_names() {
+        let db = db();
+        let mut names = db
+            .packages_iter()
+            .map(|p| p.name().to_string())
+            .collect::<Vec<_>>();
+        names.sort();
+        assert_eq!(names, vec!["apt", "fish", "vim", "zsh"]);
+    }
+
+    #[test]
+    fn versions_and_candidate() {
+        let db = db();
+        let fish = db.package("fish").unwrap();
+        assert_eq!(fish.version_count(), 2);
+        assert_eq!(
+            fish.candidate().unwrap().entry.version.as_deref(),
+            Some("3.7")
+        );
+        assert_eq!(
+            fish.get_version("3.6").unwrap().entry.version.as_deref(),
+            Some("3.6")
+        );
+        assert!(fish.get_version("9.9").is_none());
+    }
+
+    #[test]
+    fn fullname_pretty_and_plain() {
+        let db = db();
+        let fish = db.package("fish").unwrap();
+        assert_eq!(fish.fullname(true), "fish");
+        assert_eq!(fish.fullname(false), "fish:amd64");
+    }
+
+    #[test]
+    fn display_fields_from_candidate() {
+        let db = db();
+        let fish = db.package("fish").unwrap();
+        assert_eq!(fish.arch().as_deref(), Some("amd64"));
+        assert_eq!(fish.section().as_deref(), Some("utils"));
+        assert_eq!(fish.priority().as_deref(), Some("optional"));
+        assert_eq!(fish.short_description().as_deref(), Some("A test package."));
+    }
+
+    #[test]
+    fn installed_state_and_upgradable() {
+        let dir = write_status();
+        let dpkg = DpkgState::from_file(dir.path().join("status")).unwrap();
+        let ext = AptExtendedStates::from_file_lazy(dir.path().join("extended_states"));
+
+        let db = db();
+
+        // fish: installed 3.6, candidate 3.7, auto-installed.
+        let fish = db.package("fish").unwrap();
+        assert!(fish.is_installed(&dpkg));
+        assert_eq!(fish.installed_version(&dpkg), Some("3.6"));
+        assert!(fish.is_auto_installed(&dpkg, &ext));
+        assert!(fish.is_upgradable(&dpkg));
+
+        // apt: installed 2.4, candidate 2.5, manually installed.
+        let apt = db.package("apt").unwrap();
+        assert!(apt.is_installed(&dpkg));
+        assert!(!apt.is_auto_installed(&dpkg, &ext));
+        assert!(apt.is_upgradable(&dpkg));
+
+        // zsh: installed 5.9, candidate 5.9 → not upgradable.
+        let zsh = db.package("zsh").unwrap();
+        assert!(zsh.is_installed(&dpkg));
+        assert!(!zsh.is_upgradable(&dpkg));
+
+        // vim: not in dpkg status → not installed, not upgradable.
+        let vim = db.package("vim").unwrap();
+        assert!(!vim.is_installed(&dpkg));
+        assert_eq!(vim.installed_version(&dpkg), None);
+        assert!(!vim.is_upgradable(&dpkg));
+    }
+}

--- a/oma-apt-pkg/src/package.rs
+++ b/oma-apt-pkg/src/package.rs
@@ -44,9 +44,11 @@ impl<'a> Package<'a> {
         &self.name
     }
 
-    /// The display name, `name:arch` — the pretty form omits the `:arch`
-    /// qualifier for the native architecture and `all` (see
-    /// [`PackageEntry::fullname`]).
+    /// The display name of the representative (candidate) version,
+    /// `name:arch` — the pretty form omits the `:arch` qualifier for the
+    /// native architecture and `all` (see [`PackageEntry::fullname`]). To
+    /// name a specific version (e.g. the one a query filtered to), use
+    /// [`Self::fullname_of`].
     pub fn fullname(&self, pretty: bool) -> Cow<'_, str> {
         match self.representative() {
             Some(Cow::Borrowed(version)) => self.apt_db.fullname(&version.entry, pretty),
@@ -57,6 +59,15 @@ impl<'a> Package<'a> {
                 .into(),
             None => Cow::Borrowed(self.name.as_ref()),
         }
+    }
+
+    /// The display name of a specific version, `name:arch` — uses the
+    /// version's own architecture, unlike [`Self::fullname`] which takes
+    /// the package-wide candidate's. Lets an architecture-filtered query
+    /// (e.g. `foo:i386`) or an `--all` listing label every displayed block
+    /// with the architecture that block actually shows.
+    pub fn fullname_of<'b>(&self, version: &'b PackageVersion, pretty: bool) -> Cow<'b, str> {
+        self.apt_db.fullname(&version.entry, pretty)
     }
 
     /// Number of distinct versions in the database (a version shared by

--- a/oma-apt-pkg/src/package.rs
+++ b/oma-apt-pkg/src/package.rs
@@ -376,5 +376,17 @@ Auto-Installed: 1
         assert!(!vim.is_installed(&dpkg));
         assert_eq!(vim.installed_version(&dpkg), None);
         assert!(!vim.is_upgradable(&dpkg));
+
+        // The lazy status reader (used by single-package consumers like
+        // `oma show`) must report the same installed versions and upgrade
+        // status, not a silent "not upgradable" for every package.
+        let lazy = DpkgState::from_file_lazy(dir.path().join("status"));
+        let fish = db.package("fish").unwrap();
+        assert!(fish.is_installed(&lazy));
+        assert_eq!(fish.installed_version(&lazy), Some("3.6"));
+        assert!(fish.is_upgradable(&lazy));
+        let vim = db.package("vim").unwrap();
+        assert_eq!(vim.installed_version(&lazy), None);
+        assert!(!vim.is_upgradable(&lazy));
     }
 }

--- a/oma-apt-pkg/src/package.rs
+++ b/oma-apt-pkg/src/package.rs
@@ -49,6 +49,14 @@ impl<'a> Package<'a> {
     /// native architecture and `all` (see [`PackageEntry::fullname`]). To
     /// name a specific version (e.g. the one a query filtered to), use
     /// [`Self::fullname_of`].
+    ///
+    /// `fullname()` takes parameter `pretty` (boolean):
+    ///
+    /// * When `true`: Take into account whether the package is built for
+    ///   our "native" architecture (e.g., amd64 on amd64), and display
+    ///   `pkgname` on native, and `pkgname:arch` on foreign (e.g., loong64
+    ///   on loongarch64).
+    /// * When `false`: Display `pkgname:arch` unconditionally.
     pub fn fullname(&self, pretty: bool) -> Cow<'_, str> {
         match self.representative() {
             Some(Cow::Borrowed(version)) => self.apt_db.fullname(&version.entry, pretty),

--- a/oma-apt-pkg/src/package.rs
+++ b/oma-apt-pkg/src/package.rs
@@ -127,7 +127,8 @@ impl<'a> Package<'a> {
 
     /// Whether a newer version than the installed one is available in the
     /// database. Uses proper Debian version comparison (epochs, `~`, ...),
-    /// falling back to string comparison when a version fails to parse.
+    /// falling back to a directional string comparison (`cand > installed`)
+    /// when a version fails to parse.
     pub fn is_upgradable(&self, dpkg: &DpkgState) -> bool {
         let Some(installed) = dpkg.installed_version(&self.name) else {
             return false;
@@ -143,7 +144,9 @@ impl<'a> Package<'a> {
             debversion::Version::from_str(installed),
         ) {
             (Ok(cand), Ok(installed)) => cand > installed,
-            _ => cand != installed,
+            // Directional string fallback: only an unparsable candidate
+            // that sorts above the installed string counts as an upgrade.
+            _ => cand > installed,
         }
     }
 
@@ -388,5 +391,28 @@ Auto-Installed: 1
         let vim = db.package("vim").unwrap();
         assert_eq!(vim.installed_version(&lazy), None);
         assert!(!vim.is_upgradable(&lazy));
+    }
+
+    #[test]
+    fn is_upgradable_falls_back_directionally() {
+        let dir = tempfile::tempdir().unwrap();
+        let status = dir.path().join("status");
+        std::fs::write(
+            &status,
+            "Package: weird\nVersion: 5.0\nArchitecture: amd64\nStatus: install ok installed\n\n",
+        )
+        .unwrap();
+        let dpkg = DpkgState::from_file(&status).unwrap();
+
+        // A malformed candidate (`!` is not a valid Debian version char)
+        // that sorts below the installed version is not an upgrade: the
+        // string-comparison fallback is directional, not mere inequality.
+        let db = AptDb::from_entries("amd64", vec![entry("weird", "1.0!")]);
+        assert!(!db.package("weird").unwrap().is_upgradable(&dpkg));
+
+        // A malformed candidate that sorts above the installed version is
+        // still reported as an upgrade by the string fallback.
+        let db = AptDb::from_entries("amd64", vec![entry("weird", "5.0!")]);
+        assert!(db.package("weird").unwrap().is_upgradable(&dpkg));
     }
 }

--- a/oma-apt-pkg/src/package_matcher.rs
+++ b/oma-apt-pkg/src/package_matcher.rs
@@ -129,8 +129,12 @@ impl<'a> PackageMatcher<'a> {
                     .collect(),
             );
         } else {
-            for name in self.index.packages().filter(|p| glob_match(glob, p)) {
-                res.push(self.versions_of(name).collect());
+            for pkg in self
+                .index
+                .packages_iter()
+                .filter(|p| glob_match(glob, p.name()))
+            {
+                res.push(self.versions_of(pkg.name()).collect());
             }
         }
 

--- a/oma-apt-pkg/src/search.rs
+++ b/oma-apt-pkg/src/search.rs
@@ -567,8 +567,9 @@ fn is_upgradable(candidate_version: Option<&str>, installed_version: Option<&str
             let inst_ver = debversion::Version::from_str(inst);
             match (cand_ver, inst_ver) {
                 (Ok(cv), Ok(iv)) => cv > iv,
-                // Fall back to string comparison if parsing fails
-                _ => cand != inst,
+                // Directional string fallback: only an unparsable candidate
+                // that sorts above the installed string counts as an upgrade.
+                _ => cand > inst,
             }
         }
         (Some(_), None) => false, // not installed
@@ -856,6 +857,18 @@ mod tests {
     #[test]
     fn test_is_upgradable_no_candidate() {
         assert!(!is_upgradable(None, Some("1.0")));
+    }
+
+    #[test]
+    fn test_is_upgradable_malformed_fallback_is_directional() {
+        // An unparsable candidate that sorts below the installed version is
+        // not an upgrade: the string fallback compares directionally instead
+        // of reporting any unequal pair as an upgrade.
+        assert!(!is_upgradable(Some("1.0!"), Some("5.0")));
+        // An unparsable candidate that sorts above → upgradable.
+        assert!(is_upgradable(Some("5.0!"), Some("1.0")));
+        // Identical unparsable strings → not upgradable.
+        assert!(!is_upgradable(Some("1.0!"), Some("1.0!")));
     }
 
     #[test]

--- a/oma-apt-pkg/src/search.rs
+++ b/oma-apt-pkg/src/search.rs
@@ -628,8 +628,8 @@ impl OmaSearch for StrSimSearch<'_> {
         let mut results: Vec<SearchResult> = scored
             .into_iter()
             .map(|(name, _, installed, upgradable)| {
-                let entry = self.apt_db.get_candidate(&name);
-                let (old_version, new_version) = if let Some(e) = entry.as_ref() {
+                let cand = self.apt_db.package(&name).and_then(|p| p.candidate());
+                let (old_version, new_version) = if let Some(cand) = cand.as_ref() {
                     extract_versions(
                         if upgradable {
                             PackageStatus::Upgrade
@@ -640,22 +640,23 @@ impl OmaSearch for StrSimSearch<'_> {
                         },
                         &self.dpkg.installed_versions,
                         &name,
-                        &e.version,
+                        &cand.entry.version,
                     )
                 } else {
                     (None, "Unknown".to_string())
                 };
 
-                let desc = entry
+                let desc = cand
                     .as_ref()
-                    .and_then(|e| {
-                        e.description
+                    .and_then(|cand| {
+                        cand.entry
+                            .description
                             .as_deref()
                             .map(|d| d.lines().next().unwrap_or(d).to_string())
                     })
                     .unwrap_or_else(|| "No description".to_string());
 
-                let has_dbg = entry
+                let has_dbg = cand
                     .as_ref()
                     .is_some_and(|_| self.apt_db.has_package(&format!("{name}-dbg")));
 

--- a/src/subcommand/show.rs
+++ b/src/subcommand/show.rs
@@ -202,10 +202,12 @@ fn display_version(
     apt_cfg: &AptConfig,
 ) {
     for (label, field) in DISPLAY_FIELDS {
-        // The package name is the fullname (`name:arch`, omitting the
-        // native arch), like apt's `apt show` and old oma.
+        // The package name is this version's fullname (`name:arch`,
+        // omitting the native arch), like apt's `apt show` — taken from
+        // the displayed version so an arch-filtered query (`foo:i386`) or
+        // `--all` labels each block with its own architecture.
         let value = if *field == "Package" {
-            Some(resolved.pkg.fullname(true))
+            Some(resolved.pkg.fullname_of(version, true))
         } else {
             field_value(&version.entry, field)
         };

--- a/src/subcommand/show.rs
+++ b/src/subcommand/show.rs
@@ -8,6 +8,7 @@ use dialoguer::console::{StyledObject, style};
 use oma_apt_pkg::apt_sources::{IndexTargetTemplates, substitute};
 use oma_apt_pkg::{
     AptConfig, AptDb, AptExtendedStates, DpkgState, IndexSource, PackageEntry, PackageVersion,
+    ResolvedPackage,
 };
 use oma_console::indicatif::HumanBytes;
 use serde::Serialize;
@@ -77,10 +78,10 @@ impl CliExecuter for Show {
 
         let mut stdout = stdout();
 
-        for (i, versions) in resolution.groups.iter().enumerate() {
+        for (i, resolved) in resolution.resolved.iter().enumerate() {
             display_group(
                 &mut stdout,
-                versions,
+                resolved,
                 &dpkg,
                 &ext_states,
                 all,
@@ -88,23 +89,18 @@ impl CliExecuter for Show {
                 apt_cfg,
             )?;
 
-            if i != resolution.groups.len() - 1 {
+            if i != resolution.resolved.len() - 1 {
                 writeln!(stdout).ok();
             }
 
             // Show "N additional versions" hint for a single package without
-            // --all. Use the distinct version count resolved from the whole
-            // database (not entries of the displayed group): a query may be
-            // version-filtered (a local `.deb` resolves to `pkg=<version>`),
-            // yet the hint reports every other available version, matching
-            // `apt` and old oma (`pkg.versions().count() - 1`).
-            let additional = if !all && !json && resolution.groups.len() == 1 {
-                resolution
-                    .version_counts
-                    .first()
-                    .copied()
-                    .unwrap_or(0)
-                    .saturating_sub(1)
+            // --all. The version count comes from the whole database (not the
+            // displayed group): a query may be version-filtered (a local
+            // `.deb` resolves to `pkg=<version>`), yet the hint reports every
+            // other available version, matching `apt` and old oma
+            // (`pkg.versions().count() - 1`).
+            let additional = if !all && !json && resolution.resolved.len() == 1 {
+                resolved.pkg.version_count().saturating_sub(1)
             } else {
                 0
             };
@@ -118,11 +114,10 @@ impl CliExecuter for Show {
     }
 }
 
-/// Display one resolved group, honoring the JSON flag.
-#[allow(clippy::too_many_arguments)]
+/// Display one resolved query, honoring the JSON flag.
 fn display_group(
     stdout: &mut impl Write,
-    versions: &[Cow<'_, PackageVersion>],
+    resolved: &ResolvedPackage<'_>,
     dpkg: &DpkgState,
     ext_states: &AptExtendedStates,
     all: bool,
@@ -130,16 +125,16 @@ fn display_group(
     apt_cfg: &AptConfig,
 ) -> Result<(), OutputError> {
     if json {
-        display_versions_to_json(stdout, versions, dpkg, apt_cfg)?;
+        display_versions_to_json(stdout, &resolved.versions, dpkg, apt_cfg)?;
     } else {
-        display_versions(stdout, versions, dpkg, ext_states, all, apt_cfg);
+        display_versions(stdout, resolved, dpkg, ext_states, all, apt_cfg);
     }
     Ok(())
 }
 
 fn display_versions(
     stdout: &mut impl Write,
-    versions: &[Cow<'_, PackageVersion>],
+    resolved: &ResolvedPackage<'_>,
     dpkg: &DpkgState,
     ext_states: &AptExtendedStates,
     show_all: bool,
@@ -148,8 +143,9 @@ fn display_versions(
     // Just the highest version without `--all`: a linear scan over the
     // already-parsed versions (the `OnceCell` cache) instead of sorting
     // them all just to keep the last.
-    if !show_all && let Some(version) = versions.iter().max_by_key(|v| v.parsed_version()) {
-        display_version(stdout, version, dpkg, ext_states, apt_cfg);
+    if !show_all && let Some(version) = resolved.versions.iter().max_by_key(|v| v.parsed_version())
+    {
+        display_version(stdout, resolved, version, dpkg, ext_states, apt_cfg);
         return;
     }
 
@@ -157,7 +153,7 @@ fn display_versions(
     // versions instead of re-parsing each version string. Unstable is fine:
     // ties only occur between versions that compare equal (e.g. unparsable
     // version strings), whose display order is meaningless.
-    let mut shown: Vec<&Cow<'_, PackageVersion>> = versions.iter().collect();
+    let mut shown: Vec<&Cow<'_, PackageVersion>> = resolved.versions.iter().collect();
     shown.sort_unstable_by_key(|a| a.parsed_version());
 
     for (idx, version) in shown.iter().enumerate() {
@@ -165,7 +161,7 @@ fn display_versions(
             writeln!(stdout).ok();
         }
 
-        display_version(stdout, version, dpkg, ext_states, apt_cfg);
+        display_version(stdout, resolved, version, dpkg, ext_states, apt_cfg);
     }
 }
 
@@ -195,16 +191,25 @@ fn field_value<'a>(entry: &'a PackageEntry, field: &str) -> Option<Cow<'a, str>>
 }
 
 /// Display one version as a single block, listing every source it is
-/// available from.
+/// available from. The package-level fields (name, installed state) come
+/// from the [`Package`] view, the rest from this specific version.
 fn display_version(
     stdout: &mut impl Write,
+    resolved: &ResolvedPackage<'_>,
     version: &PackageVersion,
     dpkg: &DpkgState,
     ext_states: &AptExtendedStates,
     apt_cfg: &AptConfig,
 ) {
     for (label, field) in DISPLAY_FIELDS {
-        let Some(value) = field_value(&version.entry, field) else {
+        // The package name is the fullname (`name:arch`, omitting the
+        // native arch), like apt's `apt show` and old oma.
+        let value = if *field == "Package" {
+            Some(resolved.pkg.fullname(true))
+        } else {
+            field_value(&version.entry, field)
+        };
+        let Some(value) = value else {
             continue;
         };
         writeln!(stdout, "{} {value}", key_style(Cow::Borrowed(label))).ok();
@@ -229,14 +234,14 @@ fn display_version(
     }
 
     // APT-Manual-Installed: check dpkg status and auto-installed flag.
-    if version.entry.is_installed(dpkg) {
+    if resolved.pkg.is_installed(dpkg) {
         write!(
             stdout,
             "{}",
             key_style(Cow::Borrowed("APT-Manual-Installed: "))
         )
         .ok();
-        if version.entry.is_auto_installed(dpkg, ext_states) {
+        if resolved.pkg.is_auto_installed(dpkg, ext_states) {
             writeln!(stdout, "no").ok();
         } else {
             writeln!(stdout, "yes").ok();


### PR DESCRIPTION
## Description

This branch introduces a `Package` view to `oma-apt-pkg` — a per-name parent over the package database mirroring apt's `pkgCache::PkgIterator` / rust-apt's `Package` — and ports `oma show` onto it.

`Package` borrows the `AptDb` and a package name and exposes package-level information without reaching into a specific version: the name and pretty fullname, the number of versions, installed state (`is_installed`/`installed_version`/`is_auto_installed`/`is_upgradable` via `DpkgState`/`AptExtendedStates`), version access (`versions`/`candidate`/`get_version`) and display fields (`arch`/`section`/`priority`/`short_description`). Since `AptDb`, `DpkgState` and `AptExtendedStates` are separate objects, the state methods take them as arguments.

On the database side, `AptDb` gains `package()` and `packages_iter()` (the package name is borrowed from the database's map key via `Cow`, so iterating never allocates), a `version_count()` that reads the rkyv vector length directly without deserializing, and a `canonical_name()` helper. `resolve_queries` now returns `ResolvedPackage { pkg, versions }` bundles instead of parallel version groups, so display code can use package-level info without re-borrowing the database. The superseded per-name lookups are dropped (`get`, `get_all`, `get_candidate`, `packages`, `distinct_version_count`; `fullname` downgraded to `pub(crate)`), with `search` and the package matcher migrating to the `Package` view, and `debversion` moved into the `apt-lists` feature.

`oma show` consumes the resolved packages: the Package field uses `Package::fullname` (restoring `name:arch` for foreign architectures, like apt's `apt show`), the "N additional versions" hint uses `Package::version_count`, and `APT-Manual-Installed` uses `Package::is_installed`/`is_auto_installed`. The display chain threads `&ResolvedPackage` instead of separate package + versions arguments.

## About AI

This PR draws inspiration from and modifies the Deepseek V4 flash. I have reviewed and amended some of the code, and updated some of the comments.

- Model: Deepseek v4 flash
- Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)