### PR TITLE
`oma-refresh` compression fallback logic refactor

### DIFF
--- a/oma-apt-pkg/src/apt_config.rs
+++ b/oma-apt-pkg/src/apt_config.rs
@@ -125,6 +125,17 @@ impl AptConfig {
         self.set("Acquire::AllowWeakRepositories", "false");
         self.set("Acquire::AllowDowngradeToInsecureRepositories", "false");
         self.set("Acquire::cdrom::mount", "/media/cdrom/");
+        // apt's built-in compression-method map (`Acquire::CompressionTypes`),
+        // from apt-pkg/aptconfiguration.cc `setDefaultConfigurationForCompressors`.
+        // `Acquire::CompressionTypes::Order` (a priority list) is intentionally
+        // not set here: oma-refresh seeds the AOSC default, and this tree's
+        // iteration order is apt's fallback when no Order is configured.
+        self.set("Acquire::CompressionTypes::xz", "xz");
+        self.set("Acquire::CompressionTypes::bz2", "bzip2");
+        self.set("Acquire::CompressionTypes::lzma", "lzma");
+        self.set("Acquire::CompressionTypes::gz", "gzip");
+        self.set("Acquire::CompressionTypes::lz4", "lz4");
+        self.set("Acquire::CompressionTypes::zst", "zstd");
         self.set("APT::Sandbox::User", "_apt");
         // apt's built-in index targets (deb Packages / Translations,
         // deb-src Sources), from apt-pkg/init.cc:181-197 (pkgInitConfig).

--- a/oma-fetch/examples/downloads.rs
+++ b/oma-fetch/examples/downloads.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use oma_fetch::{
-    DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType, Event, checksum::Checksum,
+    CompressType, DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType, Event,
+    checksum::Checksum,
 };
 use reqwest::ClientBuilder;
 
@@ -14,6 +15,7 @@ async fn main() {
     let source_1 = DownloadSource {
         url: "https://mirrors.jlu.edu.cn/anthon/aosc-os/os-amd64/base/aosc-os_base_20260312_amd64.squashfs".to_string(),
         source_type: DownloadSourceType::Http,
+        file_type: CompressType::None,
     };
 
     let file_1 = DownloadEntry::builder()
@@ -33,6 +35,7 @@ async fn main() {
     let source_2 = DownloadSource {
         url: "https://mirrors.jlu.edu.cn/anthon/oma/pool/beige/main/o/oma_1.27.0~rc.1-1_amd64-deepin23.deb".to_string(),
         source_type: DownloadSourceType::Http,
+        file_type: CompressType::None,
     };
 
     let file_2 = DownloadEntry::builder()

--- a/oma-fetch/src/download.rs
+++ b/oma-fetch/src/download.rs
@@ -539,7 +539,7 @@ impl SingleDownloader {
                 reported = read;
             }
 
-            if self.entry.file_type != CompressType::None {
+            if source.file_type != CompressType::None {
                 downloaded_size = 0;
             }
         }
@@ -582,7 +582,7 @@ impl SingleDownloader {
         } else {
             true
         } {
-            if !allow_resume || self.entry.file_type != CompressType::None {
+            if !allow_resume || source.file_type != CompressType::None {
                 // restart download if resume is disallowed
                 downloaded_size = 0;
             }
@@ -702,7 +702,7 @@ impl SingleDownloader {
 
             // seek to expected location
             if downloaded_size != old_downloaded_size {
-                assert!(downloaded_size == 0 || self.entry.file_type == CompressType::None);
+                assert!(downloaded_size == 0 || source.file_type == CompressType::None);
                 debug!("moving writer from {old_downloaded_size} to {downloaded_size}");
                 if let Err(e) = dest.seek(SeekFrom::Start(0)).await {
                     callback(Event::ProgressDone(self.download_list_index)).await;
@@ -801,7 +801,7 @@ impl SingleDownloader {
             let mut stream = BufReader::new(stream);
 
             // initialize decompressor
-            let reader: &mut (dyn AsyncRead + Unpin + Send) = match self.entry.file_type {
+            let reader: &mut (dyn AsyncRead + Unpin + Send) = match source.file_type {
                 CompressType::Xz => &mut XzDecoder::new(&mut stream),
                 CompressType::Gzip => &mut GzipDecoder::new(&mut stream),
                 CompressType::Bz2 => &mut BzDecoder::new(&mut stream),
@@ -971,7 +971,7 @@ impl SingleDownloader {
             .await
             .context(CreateSnafu)?;
 
-        let reader: &mut (dyn AsyncRead + Unpin + Send) = match self.entry.file_type {
+        let reader: &mut (dyn AsyncRead + Unpin + Send) = match source.file_type {
             CompressType::Xz => &mut XzDecoder::new(BufReader::new(from)),
             CompressType::Gzip => &mut GzipDecoder::new(BufReader::new(from)),
             CompressType::Bz2 => &mut BzDecoder::new(BufReader::new(from)),

--- a/oma-fetch/src/lib.rs
+++ b/oma-fetch/src/lib.rs
@@ -32,8 +32,6 @@ pub struct DownloadEntry {
     /// different mirror.
     #[builder(default)]
     by_hash_fallback: bool,
-    #[builder(default)]
-    file_type: CompressType,
 }
 
 impl Debug for DownloadEntry {
@@ -46,7 +44,6 @@ impl Debug for DownloadEntry {
             .field("allow_resume", &self.allow_resume)
             .field("msg", &self.msg)
             .field("by_hash_fallback", &self.by_hash_fallback)
-            .field("file_type", &self.file_type)
             .finish()
     }
 }
@@ -79,6 +76,12 @@ impl From<&str> for CompressType {
 pub struct DownloadSource {
     pub url: String,
     pub source_type: DownloadSourceType,
+    /// The compression format of the file this source points to. Used to
+    /// decompress the downloaded file. This is per-source so that a single
+    /// [`DownloadEntry`] can fall back between different compression formats
+    /// (e.g. `Packages.zst` → `Packages.xz` → `Packages.gz`), matching apt's
+    /// `Acquire::CompressionTypes::Order` behavior.
+    pub file_type: CompressType,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/oma-fetch/tests/bar_lifecycle.rs
+++ b/oma-fetch/tests/bar_lifecycle.rs
@@ -1,6 +1,8 @@
 use std::{path::PathBuf, time::Duration};
 
-use oma_fetch::{DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType, Event};
+use oma_fetch::{
+    CompressType, DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType, Event,
+};
 use reqwest::ClientBuilder;
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
@@ -38,6 +40,7 @@ async fn every_bar_is_closed_on_request_timeout() {
     let source = DownloadSource {
         url: format!("http://127.0.0.1:{port}/pkg.deb"),
         source_type: DownloadSourceType::Http,
+        file_type: CompressType::None,
     };
     let entry = DownloadEntry::builder()
         .source(vec![source])

--- a/oma-pm/src/download.rs
+++ b/oma-pm/src/download.rs
@@ -2,8 +2,8 @@ use std::{path::Path, sync::Arc};
 
 use flume::Sender;
 use oma_fetch::{
-    DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType, Event, Summary,
-    checksum::Checksum,
+    CompressType, DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType, Event,
+    Summary, checksum::Checksum,
 };
 use oma_pm_operation_type::InstallEntry;
 use oma_utils::url_no_escape::url_no_escape_times;
@@ -61,7 +61,11 @@ pub async fn download_pkgs(
                     (DownloadSourceType::Http, x.download_url.clone())
                 };
 
-                DownloadSource { url, source_type }
+                DownloadSource {
+                    url,
+                    source_type,
+                    file_type: CompressType::None,
+                }
             })
             .collect::<Vec<_>>();
 

--- a/oma-refresh/src/config.rs
+++ b/oma-refresh/src/config.rs
@@ -9,9 +9,11 @@ use spdlog::debug;
 
 use crate::{db::RefreshError, inrelease::ChecksumItem};
 
-/// All compression formats oma can decode, in the default download order
-/// (mirrors apt's built-in `Acquire::CompressionTypes::Order`).
-pub(crate) const DEFAULT_COMPRESSION_ORDER: [&str; 6] =
+/// All compression formats oma can decode, in oma's preferred order (`zst`
+/// first). Used to complete a configured `Acquire::CompressionTypes::Order`
+/// so every compressed variant ranks ahead of the uncompressed fallback, and
+/// as the default order applied on AOSC builds.
+pub(crate) const SUPPORTED_COMPRESSION_FORMATS: [&str; 6] =
     ["zst", "xz", "bz2", "lzma", "gz", "lz4"];
 
 /// IndexTarget config — stores only the enabled target keys and reads
@@ -39,12 +41,12 @@ impl<'a> IndexTargetConfig<'a> {
             .map(str::to_owned)
             .collect();
         // `Acquire::CompressionTypes::Order` is a priority order, not a
-        // whitelist: append every supported format (configured ones stay
+        // whitelist: append every format oma can decode (configured ones stay
         // first, the rest follow in the default order) so any available
         // compressed variant ranks ahead of the uncompressed fallback.
         // Without this, a partial config such as `{"gz";}` would rank the
         // plain `Packages` file before `Packages.xz`.
-        for c in DEFAULT_COMPRESSION_ORDER {
+        for c in SUPPORTED_COMPRESSION_FORMATS {
             if !compression_order.iter().any(|x| x == c) {
                 compression_order.push(c.to_string());
             }
@@ -335,8 +337,7 @@ fn test_compression_rank_partial_config_keeps_compressed_first() {
     );
     for f in ["gz", "xz", "zst", "bz2", "lzma", "lz4"] {
         assert!(
-            config.compression_rank(&format!("Packages.{f}"))
-                < config.compression_rank("Packages"),
+            config.compression_rank(&format!("Packages.{f}")) < config.compression_rank("Packages"),
             "{f} must rank before the uncompressed fallback"
         );
     }

--- a/oma-refresh/src/config.rs
+++ b/oma-refresh/src/config.rs
@@ -1,86 +1,18 @@
-use std::{cmp::Ordering, collections::HashSet, path::Path};
+use std::{collections::HashSet, path::Path};
 
 use ahash::AHashMap;
 use oma_apt_pkg::AptConfig;
 use oma_apt_pkg::apt_sources::{
     IndexTargetTemplates, find_matching_combinations, strip_compression_ext, substitute,
 };
-use oma_fetch::CompressType;
-use once_cell::sync::OnceCell;
 use spdlog::debug;
 
 use crate::{db::RefreshError, inrelease::ChecksumItem};
 
-static COMPRESSION_ORDER: OnceCell<Vec<CompressFileWrapper>> = OnceCell::new();
-
-#[derive(Debug, Eq, PartialEq)]
-struct CompressFileWrapper {
-    compress_file: CompressType,
-}
-
-impl From<&str> for CompressFileWrapper {
-    fn from(value: &str) -> Self {
-        match value {
-            "xz" => CompressFileWrapper {
-                compress_file: CompressType::Xz,
-            },
-            "bz2" => CompressFileWrapper {
-                compress_file: CompressType::Bz2,
-            },
-            "lzma" => CompressFileWrapper {
-                compress_file: CompressType::Lzma,
-            },
-            "gz" => CompressFileWrapper {
-                compress_file: CompressType::Gzip,
-            },
-            "lz4" => CompressFileWrapper {
-                compress_file: CompressType::Lz4,
-            },
-            "zst" => CompressFileWrapper {
-                compress_file: CompressType::Zstd,
-            },
-            x => {
-                if !x.is_ascii() {
-                    debug!("{x} format is not compress format");
-                }
-
-                CompressFileWrapper {
-                    compress_file: CompressType::None,
-                }
-            }
-        }
-    }
-}
-
-impl PartialOrd for CompressFileWrapper {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for CompressFileWrapper {
-    fn cmp(&self, other: &Self) -> Ordering {
-        let t = COMPRESSION_ORDER.get_or_init(|| {
-            vec!["zst", "xz", "bz2", "lzma", "gz", "lz4", "uncompressed"]
-                .into_iter()
-                .map(CompressFileWrapper::from)
-                .collect()
-        });
-
-        let self_pos = t.iter().position(|x| x == self).unwrap();
-        let other_pos = t.iter().position(|x| x == other).unwrap();
-
-        other_pos.cmp(&self_pos)
-    }
-}
-
-impl From<CompressType> for CompressFileWrapper {
-    fn from(value: CompressType) -> Self {
-        Self {
-            compress_file: value,
-        }
-    }
-}
+/// All compression formats oma can decode, in the default download order
+/// (mirrors apt's built-in `Acquire::CompressionTypes::Order`).
+pub(crate) const DEFAULT_COMPRESSION_ORDER: [&str; 6] =
+    ["zst", "xz", "bz2", "lzma", "gz", "lz4"];
 
 /// IndexTarget config — stores only the enabled target keys and reads
 /// properties directly from [`AptConfig`] on demand.
@@ -90,6 +22,10 @@ pub struct IndexTargetConfig<'a> {
     deb_src_keys: Vec<String>,
     native_arch: &'a str,
     langs: Vec<String>,
+    /// Compression types to try in order, read from
+    /// `Acquire::CompressionTypes::Order`. The uncompressed format (`""`) is
+    /// always appended last, like apt's `pkgAcqIndex`.
+    compression_order: Vec<String>,
 }
 
 impl<'a> IndexTargetConfig<'a> {
@@ -98,12 +34,31 @@ impl<'a> IndexTargetConfig<'a> {
         let locales = sys_locale::get_locales();
         let langs = get_matches_language(locales);
 
+        let mut compression_order: Vec<String> = apt_cfg
+            .keys_under("Acquire::CompressionTypes::Order")
+            .map(str::to_owned)
+            .collect();
+        // `Acquire::CompressionTypes::Order` is a priority order, not a
+        // whitelist: append every supported format (configured ones stay
+        // first, the rest follow in the default order) so any available
+        // compressed variant ranks ahead of the uncompressed fallback.
+        // Without this, a partial config such as `{"gz";}` would rank the
+        // plain `Packages` file before `Packages.xz`.
+        for c in DEFAULT_COMPRESSION_ORDER {
+            if !compression_order.iter().any(|x| x == c) {
+                compression_order.push(c.to_string());
+            }
+        }
+        // apt always tries the uncompressed file last.
+        compression_order.push(String::new());
+
         Self {
             cfg: apt_cfg,
             deb_keys: templates.get_enabled_keys("Acquire::IndexTargets::deb"),
             deb_src_keys: templates.get_enabled_keys("Acquire::IndexTargets::deb-src"),
             native_arch,
             langs,
+            compression_order,
         }
     }
 
@@ -119,7 +74,10 @@ impl<'a> IndexTargetConfig<'a> {
         supported_archs: Option<&[&str]>,
     ) -> Result<Vec<ChecksumDownloadEntry>, RefreshError> {
         let meta_key = if is_flat { "flatMetaKey" } else { "MetaKey" };
-        let mut res_map: AHashMap<String, Vec<ChecksumDownloadEntry>> = AHashMap::new();
+        // Group every compression variant of the same index file together;
+        // each group becomes one `ChecksumDownloadEntry` whose `items` holds
+        // all variants so the downloader can fall back between them.
+        let mut res_map: AHashMap<String, ChecksumDownloadEntry> = AHashMap::new();
         let tree = if is_source {
             &self.deb_src_keys
         } else {
@@ -154,15 +112,12 @@ impl<'a> IndexTargetConfig<'a> {
                     .resolve_targets(name, release, &archs, "", "", "", true)
                     .map_err(|e| RefreshError::InvalidUrl(e.to_string()))?;
                 for m in &matches {
-                    res_map
-                        .entry(name.to_string())
-                        .or_default()
-                        .push(to_download_entry(
-                            c,
-                            self.cfg,
-                            &m.config_key,
-                            &m.description,
-                        ));
+                    let entry = res_map.entry(name.to_string()).or_insert_with(|| {
+                        to_download_entry(self.cfg, &m.config_key, &m.description)
+                    });
+                    if !entry.items.iter().any(|x| x.name == c.name) {
+                        entry.items.push(c.to_owned());
+                    }
                 }
             } else {
                 let comps: Vec<&str> = components.iter().map(|s| s.as_str()).collect();
@@ -195,28 +150,47 @@ impl<'a> IndexTargetConfig<'a> {
                                 self.native_arch,
                             )
                         };
-                        res_map
+                        let entry = res_map
                             .entry(name.to_string())
-                            .or_default()
-                            .push(to_download_entry(c, self.cfg, config_key, &desc));
+                            .or_insert_with(|| to_download_entry(self.cfg, config_key, &desc));
+                        if !entry.items.iter().any(|x| x.name == c.name) {
+                            entry.items.push(c.to_owned());
+                        }
                     }
                 }
             }
         }
 
-        let mut sort_res = vec![];
+        let mut result = vec![];
 
-        for (_, v) in &mut res_map {
-            v.sort_unstable_by(|a, b| {
-                compress_file(&a.item.name).cmp(&compress_file(&b.item.name))
-            });
-            if v[0].item.size == 0 {
+        for (_, mut entry) in res_map {
+            // Sort variants by the configured compression order
+            // (`Acquire::CompressionTypes::Order`), preferred format first:
+            // `Packages.zst` → `Packages.xz` → `Packages.gz`, matching apt.
+            entry
+                .items
+                .sort_unstable_by_key(|a| self.compression_rank(&a.name));
+            if entry.items[0].size == 0 {
                 continue;
             }
-            sort_res.push(v.last().unwrap().to_owned());
+            result.push(entry);
         }
 
-        Ok(fallback_of_filter(sort_res))
+        Ok(fallback_of_filter(result))
+    }
+
+    /// Position of `name`'s compression type in the configured download
+    /// order; smaller means higher priority (tried first). Unknown types sort
+    /// after everything else.
+    fn compression_rank(&self, name: &str) -> usize {
+        let ext = Path::new(name)
+            .extension()
+            .map(|x| x.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        self.compression_order
+            .iter()
+            .position(|x| *x == ext)
+            .unwrap_or(self.compression_order.len())
     }
 }
 
@@ -244,14 +218,9 @@ fn fallback_of_filter(res: Vec<ChecksumDownloadEntry>) -> Vec<ChecksumDownloadEn
         .collect()
 }
 
-fn to_download_entry(
-    c: &ChecksumItem,
-    cfg: &AptConfig,
-    config_key: &str,
-    msg: &str,
-) -> ChecksumDownloadEntry {
+fn to_download_entry(cfg: &AptConfig, config_key: &str, msg: &str) -> ChecksumDownloadEntry {
     ChecksumDownloadEntry {
-        item: c.to_owned(),
+        items: vec![],
         keep_compress: cfg
             .get(&format!("{config_key}::KeepCompressed"), "")
             .parse::<bool>()
@@ -276,7 +245,12 @@ fn to_download_entry(
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChecksumDownloadEntry {
-    pub item: ChecksumItem,
+    /// Every compression variant of the index file, ordered best-first.
+    /// `items[0]` is the preferred (highest-priority) compression format; the
+    /// rest are fallbacks tried in order when it is unavailable, e.g.
+    /// `Packages.zst` → `Packages.xz` → `Packages.gz`, matching apt's
+    /// `Acquire::CompressionTypes::Order` behavior.
+    pub items: Vec<ChecksumItem>,
     pub keep_compress: bool,
     pub msg: String,
     pub optional: bool,
@@ -310,54 +284,8 @@ fn get_matches_language(locales: impl IntoIterator<Item = String>) -> Vec<String
     langs
 }
 
-fn compress_file(name: &str) -> CompressFileWrapper {
-    CompressFileWrapper {
-        compress_file: CompressType::from(
-            Path::new(name)
-                .extension()
-                .map(|x| x.to_string_lossy())
-                .unwrap_or_default()
-                .to_string()
-                .as_str(),
-        ),
-    }
-}
-
 #[test]
 fn test_apt_config() {
-    // Test that compression ordering is correct
-    let mut types: Vec<CompressFileWrapper> = vec![
-        CompressType::None,
-        CompressType::Xz,
-        CompressType::Zstd,
-        CompressType::Gzip,
-        CompressType::Bz2,
-        CompressType::Lz4,
-        CompressType::Lzma,
-    ]
-    .into_iter()
-    .map(|x| x.into())
-    .collect();
-
-    types.sort_unstable();
-    types.reverse();
-
-    assert_eq!(
-        types,
-        vec![
-            CompressType::Zstd,
-            CompressType::Xz,
-            CompressType::Bz2,
-            CompressType::Lzma,
-            CompressType::Gzip,
-            CompressType::Lz4,
-            CompressType::None,
-        ]
-        .into_iter()
-        .map(|x| x.into())
-        .collect::<Vec<CompressFileWrapper>>()
-    );
-
     // Test that IndexTarget tree is correctly parsed from AptConfig
     let mut cfg = AptConfig::new();
     cfg.init_defaults().unwrap();
@@ -365,6 +293,53 @@ fn test_apt_config() {
     let t = templates.get_enabled_keys("Acquire::IndexTargets::deb");
     assert!(t.iter().any(|x| x.contains("::deb::")));
     assert!(t.iter().all(|x| !x.contains("::deb-src::")));
+}
+
+#[test]
+fn test_compression_rank_reads_apt_config() {
+    let mut cfg = AptConfig::new();
+    cfg.init_defaults().unwrap();
+    for c in &["xz", "gz", "zst"] {
+        cfg.set_list("Acquire::CompressionTypes::Order", c);
+    }
+    let config = IndexTargetConfig::new_from_apt_config(&cfg, "amd64");
+
+    // Order read from config: xz first, then gz, then zst, uncompressed last.
+    assert!(config.compression_rank("Packages.xz") < config.compression_rank("Packages.gz"));
+    assert!(config.compression_rank("Packages.gz") < config.compression_rank("Packages.zst"));
+    assert!(
+        config.compression_rank("Packages") > config.compression_rank("Packages.zst"),
+        "uncompressed must sort last"
+    );
+    // Unknown compression types sort after everything else.
+    assert!(
+        config.compression_rank("Packages.unknown") > config.compression_rank("Packages"),
+        "unknown type must sort after uncompressed"
+    );
+}
+
+#[test]
+fn test_compression_rank_partial_config_keeps_compressed_first() {
+    // Only `gz` is configured; the remaining supported formats must still
+    // rank ahead of the uncompressed fallback, otherwise a mirror without
+    // gzip would download the large plain `Packages` before trying `xz`.
+    let mut cfg = AptConfig::new();
+    cfg.init_defaults().unwrap();
+    cfg.set_list("Acquire::CompressionTypes::Order", "gz");
+    let config = IndexTargetConfig::new_from_apt_config(&cfg, "amd64");
+
+    assert_eq!(
+        config.compression_rank("Packages.gz"),
+        0,
+        "configured format is tried first"
+    );
+    for f in ["gz", "xz", "zst", "bz2", "lzma", "lz4"] {
+        assert!(
+            config.compression_rank(&format!("Packages.{f}"))
+                < config.compression_rank("Packages"),
+            "{f} must rank before the uncompressed fallback"
+        );
+    }
 }
 
 #[test]
@@ -384,11 +359,11 @@ fn test_get_matches_language() {
 fn test_fallback_of_filter() {
     let entries = vec![
         ChecksumDownloadEntry {
-            item: ChecksumItem {
+            items: vec![ChecksumItem {
                 name: "file1".to_string(),
                 size: 100,
                 checksum: "abc".to_string(),
-            },
+            }],
             keep_compress: false,
             msg: "msg1".to_string(),
             optional: false,
@@ -396,11 +371,11 @@ fn test_fallback_of_filter() {
             fallback_of: None,
         },
         ChecksumDownloadEntry {
-            item: ChecksumItem {
+            items: vec![ChecksumItem {
                 name: "file2".to_string(),
                 size: 100,
                 checksum: "def".to_string(),
-            },
+            }],
             keep_compress: false,
             msg: "msg2".to_string(),
             optional: false,
@@ -408,11 +383,11 @@ fn test_fallback_of_filter() {
             fallback_of: Some("key1".to_string()),
         },
         ChecksumDownloadEntry {
-            item: ChecksumItem {
+            items: vec![ChecksumItem {
                 name: "file3".to_string(),
                 size: 100,
                 checksum: "ghi".to_string(),
-            },
+            }],
             keep_compress: false,
             msg: "msg3".to_string(),
             optional: false,

--- a/oma-refresh/src/config.rs
+++ b/oma-refresh/src/config.rs
@@ -9,11 +9,11 @@ use spdlog::debug;
 
 use crate::{db::RefreshError, inrelease::ChecksumItem};
 
-/// All compression formats oma can decode, in oma's preferred order (`zst`
-/// first). Used to complete a configured `Acquire::CompressionTypes::Order`
-/// so every compressed variant ranks ahead of the uncompressed fallback, and
-/// as the default order applied on AOSC builds.
-pub(crate) const SUPPORTED_COMPRESSION_FORMATS: [&str; 6] =
+/// Compression formats oma can decode, in oma's preferred order (`zst` first).
+/// Seeds the AOSC default `Acquire::CompressionTypes::Order`, and filters the
+/// `Acquire::CompressionTypes` tree when no Order is configured (like apt
+/// filters by available decompression methods).
+pub(crate) const DECODABLE_COMPRESSION_FORMATS: [&str; 6] =
     ["zst", "xz", "bz2", "lzma", "gz", "lz4"];
 
 /// IndexTarget config — stores only the enabled target keys and reads
@@ -40,15 +40,19 @@ impl<'a> IndexTargetConfig<'a> {
             .keys_under("Acquire::CompressionTypes::Order")
             .map(str::to_owned)
             .collect();
-        // `Acquire::CompressionTypes::Order` is a priority order, not a
-        // whitelist: append every format oma can decode (configured ones stay
-        // first, the rest follow in the default order) so any available
-        // compressed variant ranks ahead of the uncompressed fallback.
-        // Without this, a partial config such as `{"gz";}` would rank the
-        // plain `Packages` file before `Packages.xz`.
-        for c in SUPPORTED_COMPRESSION_FORMATS {
-            if !compression_order.iter().any(|x| x == c) {
-                compression_order.push(c.to_string());
+
+        // 显式配置了 `Acquire::CompressionTypes::Order` 就直接使用；为空时才
+        // 遍历整个 `Acquire::CompressionTypes` 树取默认顺序（与 apt 的
+        // `getCompressionTypes` 一致），且只保留 oma 能解码的格式。
+        if compression_order.is_empty() {
+            for ext in apt_cfg.keys_under("Acquire::CompressionTypes") {
+                if ext == "Order" {
+                    continue;
+                }
+                if !DECODABLE_COMPRESSION_FORMATS.contains(&ext) {
+                    continue;
+                }
+                compression_order.push(ext.to_string());
             }
         }
         // apt always tries the uncompressed file last.
@@ -321,26 +325,35 @@ fn test_compression_rank_reads_apt_config() {
 }
 
 #[test]
-fn test_compression_rank_partial_config_keeps_compressed_first() {
-    // Only `gz` is configured; the remaining supported formats must still
-    // rank ahead of the uncompressed fallback, otherwise a mirror without
-    // gzip would download the large plain `Packages` before trying `xz`.
+fn test_compression_rank_default_from_config_tree() {
+    // No Order configured: the default order comes from the
+    // `Acquire::CompressionTypes` tree, uncompressed last.
     let mut cfg = AptConfig::new();
     cfg.init_defaults().unwrap();
-    cfg.set_list("Acquire::CompressionTypes::Order", "gz");
     let config = IndexTargetConfig::new_from_apt_config(&cfg, "amd64");
 
-    assert_eq!(
-        config.compression_rank("Packages.gz"),
-        0,
-        "configured format is tried first"
-    );
-    for f in ["gz", "xz", "zst", "bz2", "lzma", "lz4"] {
+    for f in ["xz", "bz2", "lzma", "gz", "lz4", "zst"] {
         assert!(
             config.compression_rank(&format!("Packages.{f}")) < config.compression_rank("Packages"),
             "{f} must rank before the uncompressed fallback"
         );
     }
+}
+
+#[test]
+fn test_compression_rank_partial_config_is_authoritative() {
+    // An explicitly configured Order is used as-is: only the configured
+    // formats rank ahead of the uncompressed fallback.
+    let mut cfg = AptConfig::new();
+    cfg.init_defaults().unwrap();
+    cfg.set_list("Acquire::CompressionTypes::Order", "gz");
+    let config = IndexTargetConfig::new_from_apt_config(&cfg, "amd64");
+
+    assert_eq!(config.compression_rank("Packages.gz"), 0);
+    assert_eq!(config.compression_rank("Packages"), 1);
+    // Not-configured formats sort after the uncompressed fallback.
+    assert!(config.compression_rank("Packages.xz") > config.compression_rank("Packages"));
+    assert!(config.compression_rank("Packages.zst") > config.compression_rank("Packages"));
 }
 
 #[test]

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -111,6 +111,10 @@ pub struct OmaRefresh {
     #[cfg(feature = "aosc")]
     topic_msg: Cow<'static, str>,
     sources_lists_paths: Option<Vec<PathBuf>>,
+    /// An externally-supplied APT configuration, shared via [`Arc`]. When
+    /// omitted, a fresh one is built from the system defaults inside
+    /// [`OmaRefresh`].
+    apt_config: Option<Arc<AptConfig>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -125,7 +129,10 @@ pub enum Event {
 }
 
 impl OmaRefresh {
-    pub fn start(self, mut callback: impl FnMut(Event) + 'static) -> Result<Vec<SuccessSummary>> {
+    pub fn start(
+        mut self,
+        mut callback: impl FnMut(Event) + 'static,
+    ) -> Result<Vec<SuccessSummary>> {
         if self.threads == 0 || self.threads > 255 {
             return Err(RefreshError::WrongThreadCount(self.threads));
         }
@@ -252,24 +259,35 @@ impl OmaRefresh {
         Ok(res.success)
     }
 
-    fn init_apt_config(&self) -> AptConfig {
-        let mut cfg = AptConfig::new();
-        cfg.init_defaults()
-            .expect("failed to initialize APT configuration");
-        let _ = cfg.load_system();
+    fn init_apt_config(&mut self) -> AptConfig {
+        // 调用方传入的 Arc 配置在需要写入（Dir、压缩顺序）时按写时复制 clone
+        // 一份，调用方本身无需深拷贝；未传入时新建一份并初始化默认值与系统配置。
+        let mut cfg = match self.apt_config.take() {
+            Some(arc) => Arc::unwrap_or_clone(arc),
+            None => {
+                let mut cfg = AptConfig::new();
+                cfg.init_defaults()
+                    .expect("failed to initialize APT configuration");
+                let _ = cfg.load_system();
+                cfg
+            }
+        };
 
         if !is_termux() {
             cfg.set("Dir", &self.source.to_string_lossy());
         }
 
-        // Set default compression order if not configured
-        let has_order = cfg
-            .keys_under("Acquire::CompressionTypes::Order")
-            .next()
-            .is_some();
-        if !has_order {
-            for c in crate::config::DEFAULT_COMPRESSION_ORDER {
-                cfg.set_list("Acquire::CompressionTypes::Order", c);
+        // AOSC 仓库默认优先 zst；非 aosc 构建沿用系统配置，不强加默认顺序。
+        #[cfg(feature = "aosc")]
+        {
+            let has_order = cfg
+                .keys_under("Acquire::CompressionTypes::Order")
+                .next()
+                .is_some();
+            if !has_order {
+                for c in crate::config::SUPPORTED_COMPRESSION_FORMATS {
+                    cfg.set_list("Acquire::CompressionTypes::Order", c);
+                }
             }
         }
 

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -285,7 +285,7 @@ impl OmaRefresh {
                 .next()
                 .is_some();
             if !has_order {
-                for c in crate::config::SUPPORTED_COMPRESSION_FORMATS {
+                for c in crate::config::DECODABLE_COMPRESSION_FORMATS {
                     cfg.set_list("Acquire::CompressionTypes::Order", c);
                 }
             }

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -268,7 +268,7 @@ impl OmaRefresh {
             .next()
             .is_some();
         if !has_order {
-            for c in &["zst", "xz", "bz2", "lzma", "gz", "lz4"] {
+            for c in crate::config::DEFAULT_COMPRESSION_ORDER {
                 cfg.set_list("Acquire::CompressionTypes::Order", c);
             }
         }
@@ -660,11 +660,17 @@ fn get_all_need_db_from_config(
             continue;
         }
 
+        // Only the preferred (first) compression variant will actually be
+        // downloaded; the rest are fallbacks tried on failure. Count only its
+        // size toward the total so the progress bar reflects the expected
+        // download size.
+        let item = &i.items[0];
+
         if i.keep_compress {
-            *total += i.item.size;
+            *total += item.size;
         } else {
-            let size = if file_is_compress(&i.item.name) {
-                let (_, name_without_compress) = split_ext_and_filename(&i.item.name);
+            let size = if file_is_compress(&item.name) {
+                let (_, name_without_compress) = split_ext_and_filename(&item.name);
 
                 checksums
                     .iter()
@@ -675,9 +681,9 @@ fn get_all_need_db_from_config(
                             None
                         }
                     })
-                    .unwrap_or(i.item.size)
+                    .unwrap_or(item.size)
             } else {
-                i.item.size
+                item.size
             };
 
             *total += size;
@@ -735,6 +741,7 @@ fn collect_flat_repo_no_release(
     let sources = vec![DownloadSource {
         url: download_url.clone(),
         source_type: from,
+        file_type: CompressType::None,
     }];
 
     let task = DownloadEntry::builder()
@@ -743,7 +750,6 @@ fn collect_flat_repo_no_release(
         .dir(download_dir.to_path_buf())
         .allow_resume(false)
         .msg(msg.into())
-        .file_type(CompressType::None)
         .build();
 
     tasks.push(task);
@@ -759,6 +765,11 @@ fn collect_download_task(
     release: &Release,
     optional_set: &mut HashSet<String>,
 ) -> Result<()> {
+    // The preferred (first) compression variant drives the message, filename,
+    // checksum and primary file type; the remaining variants are fallbacks
+    // tried in order if the preferred one is unavailable.
+    let item = &c.items[0];
+
     let file_type = &c.msg;
 
     let msg = mirror_source.get_human_download_message(Some(file_type))?;
@@ -767,19 +778,19 @@ fn collect_download_task(
         OmaSourceEntryFrom::Http => DownloadSourceType::Http,
         OmaSourceEntryFrom::Local => DownloadSourceType::Local(
             mirror_source.is_flat()
-                && (!file_is_compress(&c.item.name)
-                    || (file_is_compress(&c.item.name) && c.keep_compress)),
+                && (!file_is_compress(&item.name)
+                    || (file_is_compress(&item.name) && c.keep_compress)),
         ),
     };
 
-    let not_compress_filename_before = if file_is_compress(&c.item.name) {
-        Cow::Owned(split_ext_and_filename(&c.item.name).1)
+    let not_compress_filename_before = if file_is_compress(&item.name) {
+        Cow::Owned(split_ext_and_filename(&item.name).1)
     } else {
-        Cow::Borrowed(&c.item.name)
+        Cow::Borrowed(&item.name)
     };
 
     let checksum = if c.keep_compress {
-        Some(&c.item.checksum)
+        Some(&item.checksum)
     } else {
         release
             .checksum_type_and_list()
@@ -790,36 +801,66 @@ fn collect_download_task(
             .map(|c| &c.checksum)
     };
 
-    // When `Acquire-By-Hash: yes` is set, prefer the by-hash path, but fall
-    // back to the traditional by-name path if the by-hash file is missing
-    // (e.g. HTTP 404). The download manager tries the sources in order and
-    // moves on to the next one if the current one fails.
+    // Build one source per compression variant, ordered best-first. The
+    // download manager tries the sources in order and falls back to the next
+    // one on failure (e.g. HTTP 404), matching apt's
+    // `Acquire::CompressionTypes::Order` behavior. Each source carries its own
+    // `file_type` so the correct decompressor is used for whichever variant
+    // actually succeeds.
+    //
+    // When `keep_compress` is set the stored filename embeds the compression
+    // extension and the checksum is that of the compressed file, so a
+    // transparent fallback to a different compression format is impossible;
+    // in that case only the preferred variant is tried.
+    let variants: &[ChecksumItem] = if c.keep_compress {
+        &c.items[..1]
+    } else {
+        &c.items
+    };
+
     let mut sources = vec![];
 
-    if release.acquire_by_hash() {
-        let path = Path::new(&c.item.name);
-        let parent = path.parent().unwrap_or(path);
-        let dir = match release.checksum_type_and_list().0 {
-            InReleaseChecksum::Sha256 => "SHA256",
-            InReleaseChecksum::Sha512 => "SHA512",
-            InReleaseChecksum::Md5 => "MD5Sum",
+    for variant in variants {
+        // KeepCompressed means the downloaded bytes must be stored as-is.
+        // The checksum in that mode is for the compressed variant, so passing
+        // its decompressor here would both corrupt the stored file and make
+        // checksum verification fail.
+        let variant_file_type = if c.keep_compress {
+            CompressType::None
+        } else {
+            compress_type_of(&variant.name)
         };
 
-        let path = parent.join("by-hash").join(dir).join(&c.item.checksum);
+        // When `Acquire-By-Hash: yes` is set, prefer the by-hash path, but
+        // fall back to the traditional by-name path if the by-hash file is
+        // missing (e.g. HTTP 404).
+        if release.acquire_by_hash() {
+            let path = Path::new(&variant.name);
+            let parent = path.parent().unwrap_or(path);
+            let dir = match release.checksum_type_and_list().0 {
+                InReleaseChecksum::Sha256 => "SHA256",
+                InReleaseChecksum::Sha512 => "SHA512",
+                InReleaseChecksum::Md5 => "MD5Sum",
+            };
+
+            let path = parent.join("by-hash").join(dir).join(&variant.checksum);
+
+            sources.push(DownloadSource {
+                url: mirror_source.get_download_url(&path.display().to_string()),
+                source_type: from.clone(),
+                file_type: variant_file_type,
+            });
+        }
 
         sources.push(DownloadSource {
-            url: mirror_source.get_download_url(&path.display().to_string()),
+            url: mirror_source.get_download_url(&variant.name),
             source_type: from.clone(),
+            file_type: variant_file_type,
         });
     }
 
-    sources.push(DownloadSource {
-        url: mirror_source.get_download_url(&c.item.name),
-        source_type: from,
-    });
-
     let file_name = if c.keep_compress {
-        mirror_source.get_download_file_name(Some(&c.item.name))?
+        mirror_source.get_download_file_name(Some(&item.name))?
     } else {
         mirror_source.get_download_file_name(Some(&not_compress_filename_before))?
     };
@@ -836,21 +877,6 @@ fn collect_download_task(
         .msg(msg.into())
         .final_dir(download_dir.to_path_buf())
         .by_hash_fallback(release.acquire_by_hash())
-        .file_type({
-            if c.keep_compress {
-                CompressType::None
-            } else {
-                match Path::new(&c.item.name).extension().and_then(|x| x.to_str()) {
-                    Some("gz") => CompressType::Gzip,
-                    Some("xz") => CompressType::Xz,
-                    Some("bz2") => CompressType::Bz2,
-                    Some("zst") => CompressType::Zstd,
-                    Some("lzma") => CompressType::Lzma,
-                    Some("lz4") => CompressType::Lz4,
-                    _ => CompressType::None,
-                }
-            }
-        })
         .maybe_hash(if let Some(checksum) = checksum {
             match release.checksum_type_and_list().0 {
                 InReleaseChecksum::Sha256 => Some(Checksum::from_sha256_str(checksum)?),
@@ -865,6 +891,20 @@ fn collect_download_task(
     tasks.push(task);
 
     Ok(())
+}
+
+/// Map a file name to its [`CompressType`], used to pick the correct
+/// decompressor for a downloaded source.
+fn compress_type_of(name: &str) -> CompressType {
+    match Path::new(name).extension().and_then(|x| x.to_str()) {
+        Some("gz") => CompressType::Gzip,
+        Some("xz") => CompressType::Xz,
+        Some("bz2") => CompressType::Bz2,
+        Some("zst") => CompressType::Zstd,
+        Some("lzma") => CompressType::Lzma,
+        Some("lz4") => CompressType::Lz4,
+        _ => CompressType::None,
+    }
 }
 
 fn run_task_with_pump<Fut, T>(

--- a/oma-refresh/src/inrelease.rs
+++ b/oma-refresh/src/inrelease.rs
@@ -56,7 +56,7 @@ pub enum InReleaseChecksum {
     Md5,
 }
 
-const COMPRESS: &[&str] = &[".gz", ".xz", ".zst", ".bz2"];
+const COMPRESS: &[&str] = &[".gz", ".xz", ".zst", ".bz2", ".lzma", ".lz4"];
 
 pub struct Release {
     pub source: InReleaseEntry,
@@ -387,6 +387,35 @@ fn test_split_name_and_ext() {
     let example2 = "main/i18n/Translation-bg";
     let res = split_ext_and_filename(&example2);
     assert_eq!(res, ("".into(), "main/i18n/Translation-bg".to_string()));
+}
+
+#[test]
+fn test_file_is_compress() {
+    for name in [
+        "main/binary/Packages.gz",
+        "main/binary/Packages.xz",
+        "main/binary/Packages.zst",
+        "main/binary/Packages.bz2",
+        "main/binary/Packages.lzma",
+        "main/binary/Packages.lz4",
+    ] {
+        assert!(
+            file_is_compress(name),
+            "expected compressed filename: {name}"
+        );
+    }
+
+    for name in [
+        "main/binary/Packages",
+        "main/binary/Packages.gz.bak",
+        "main/binary/Packages.GZ",
+        "main/binary/Packages.zip",
+    ] {
+        assert!(
+            !file_is_compress(name),
+            "expected uncompressed filename: {name}"
+        );
+    }
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,6 +261,14 @@ impl OmaConfig {
             .expect("AptConfig not initialized — call init_apt_config first")
     }
 
+    /// The initialized [`AptConfig`] as a shared [`Arc`], so callers can hand
+    /// it to long-lived workers (e.g. `OmaRefresh`) without deep-cloning it.
+    pub fn apt_config_arc(&self) -> &Arc<AptConfig> {
+        self.apt_config
+            .get()
+            .expect("AptConfig not initialized — call init_apt_config first")
+    }
+
     fn init_tls_config(&self) {
         self.rustls_crypto_provider.get_or_init(|| {
             #[cfg(feature = "rustls")]

--- a/src/core/refresh.rs
+++ b/src/core/refresh.rs
@@ -33,7 +33,11 @@ impl Refresh<'_> {
             .source(sysroot.clone())
             .threads(config.download_threads)
             .arch(arch)
-            .client(config.http_client()?.clone());
+            .client(config.http_client()?.clone())
+            // 传入 oma 已初始化的 APT 配置（含 sysroot 的 Dir、apt_options、
+            // 二进制缓存路径等），OmaRefresh 不再自己从系统默认值新建一份。
+            // `Arc::clone` 只是引用计数 +1，不深拷贝配置树。
+            .apt_config(config.apt_config_arc().clone());
 
         #[cfg(feature = "aosc")]
         let msg = fl!("do-not-edit-topic-sources-list");


### PR DESCRIPTION
## Description

- **oma-fetch**: Move file_type from DownloadEntry to DownloadSource so each source carries its own compression format. The downloader now decompresses with source.file_type, which lets a single DownloadEntry fall back between different compression formats (e.g. `Packages.zst` → `Packages.xz` → `Packages.gz`) via the existing source-list fallback, matching apt's `Acquire::CompressionTypes::Order` behavior. This is a breaking API change: DownloadSource gains a required file_type field and DownloadEntry.file_type is removed.

- **oma-refresh**: Group every compression variant of an index file into one ChecksumDownloadEntry (item → `items`), ordered by `Acquire::CompressionTypes::Order` read from apt config (the uncompressed format is always appended last, like apt's `pkgAcqIndex`; the previously hardcoded order is removed). collect_download_task now builds a DownloadEntry with one source per variant — plus the by-hash path when `Acquire-By-Hash` is set — so oma-fetch tries them in order and falls back when the preferred format is missing. When keep_compress is set, only the preferred variant is tried, since the stored filename embeds the compression extension and the checksum is per-variant.

## About AI

This PR was written in collaboration with Deepseek V4 Flash in a VS Code agent session. I have reviewed and amended the code, tested it thoroughly, and updated the comments.

• Model: Deepseek v4 flash
• Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)