### PR TITLE
refactor(oma-refresh): replace date_hack with apt-aligned date parser

### DIFF
--- a/oma-refresh/Cargo.toml
+++ b/oma-refresh/Cargo.toml
@@ -52,7 +52,3 @@ default = ["aosc", "sequoia-nettle-backend", "rustls"]
 flume = { workspace = true }
 oma-utils = { workspace = true, features = ["dpkg"] }
 rustls = { workspace = true }
-
-[[example]]
-name = "update"
-required-features = ["apt"]

--- a/oma-refresh/src/date.rs
+++ b/oma-refresh/src/date.rs
@@ -95,8 +95,9 @@ fn parse_comma_date(rest: &str, format: &str) -> Result<Timestamp, ParseDateErro
 /// sensitive comparison apt accepts exactly:
 ///
 ///   - the named zones `GMT`, `UTC` and `Z` (strutl.cc line ~1099), or
-///   - any zone whose integer value is 0 and is fully consumed, i.e.
-///     `+0000`, `-0000`, `0000`, `0`, ... (strutl.cc lines ~1100-1111;
+///   - any zone whose integer value is 0 and is fully consumed, i.e. any
+///     all-zero token with or without a sign — `+0000`, `-0000`, `0000`,
+///     `+0`, `-0`, `+000`, `0`, ... (strutl.cc lines ~1100-1111;
 ///     see also the note in apt-pkg/contrib/strutl.h lines ~61-79).
 ///
 /// We deliberately extend this (as oma's previous rfc2822-based parser did):
@@ -127,6 +128,16 @@ fn parse_zone(token: &str) -> Result<jiff::tz::Offset, ParseDateError> {
             };
         }
     };
+
+    // Like apt (`stoi(zone) == 0` with full consumption), any all-zero token
+    // — signed or not (`+0`, `-0`, `+000`, `+000000`, ...) — is UTC, even
+    // though it does not match the `HH`/`HHMM`/`HH:MM` shapes below. The sign
+    // is discarded, so this is always a zero offset. A lone sign (`+`/`-`)
+    // has no digits to consume and falls through to the shapes to be
+    // rejected, like apt's `stoi("+")` which throws.
+    if !digits.is_empty() && digits.iter().all(|b| *b == b'0') {
+        return Ok(jiff::tz::Offset::UTC);
+    }
 
     // Accept `HH`, `HHMM` and `HH:MM`.
     let (hh, mm) = match digits {
@@ -237,8 +248,8 @@ fn test_whitespace_tolerance() {
 fn test_zone_and_year_edges() {
     // Timezone tokens. apt's accepted set (case-sensitive) is exactly
     // {GMT, UTC, Z} plus anything `stoi`-ing to 0 (`+0000`, `-0000`, `0000`,
-    // `0`, ...). We additionally accept `UT`, lowercase `z` and non-zero
-    // offsets (converted correctly) — see parse_zone.
+    // `0`, `+0`, `+000`, ...). We additionally accept `UT`, lowercase `z`
+    // and non-zero offsets (converted correctly) — see parse_zone.
     let accepted = [
         ("Sun, 06 Nov 1994 08:49:37 GMT", "1994-11-06T08:49:37Z"),
         ("Sun, 06 Nov 1994 08:49:37 UTC", "1994-11-06T08:49:37Z"),
@@ -249,6 +260,13 @@ fn test_zone_and_year_edges() {
         ("Sun, 06 Nov 1994 08:49:37 -0000", "1994-11-06T08:49:37Z"),
         ("Sun, 06 Nov 1994 08:49:37 0000", "1994-11-06T08:49:37Z"),
         ("Sun, 06 Nov 1994 08:49:37 0", "1994-11-06T08:49:37Z"),
+        // Signed all-zero tokens: apt accepts any fully-consumed integer
+        // zero regardless of shape (`stoi("+0") == 0`), so must we.
+        ("Sun, 06 Nov 1994 08:49:37 +0", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 -0", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 +000", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 -000", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 +000000", "1994-11-06T08:49:37Z"),
         // Deliberate extensions over apt: non-zero offsets are converted.
         ("Sun, 06 Nov 1994 08:49:37 +0530", "1994-11-06T03:19:37Z"),
         ("Sun, 06 Nov 1994 08:49:37 -0500", "1994-11-06T13:49:37Z"),
@@ -269,6 +287,9 @@ fn test_zone_and_year_edges() {
         "Sun, 06 Nov 1994 08:49:37 ut",
         "Sun, 06 Nov 1994 08:49:37 PST",
         "Sun, 06 Nov 1994 08:49:37 0530",
+        // A lone sign has no digits to consume; apt's `stoi("+")` throws.
+        "Sun, 06 Nov 1994 08:49:37 +",
+        "Sun, 06 Nov 1994 08:49:37 -",
     ];
     for input in rejected {
         assert!(parse_date(input).is_err(), "should reject: {input}");

--- a/oma-refresh/src/date.rs
+++ b/oma-refresh/src/date.rs
@@ -1,10 +1,10 @@
 //! Parsing of the date/time strings found in Debian `Release`/`InRelease`
 //! files (the `Date:` and `Valid-Until:` fields).
 //!
-//! The parser mirrors apt's `RFC1123StrToTime`
-//! (apt-pkg/contrib/strutl.cc on master, lines ~1038-1132), which accepts the
-//! RFC 1123, RFC 850 and asctime layouts. jiff does the actual calendar, clock
-//! and offset validation.
+//! The parser mirrors APT's `RFC1123StrToTime` (apt-pkg/contrib/strutl.cc @
+//! d8f548e00ca4, lines ~1067-1161), which accepts the RFC 1123, RFC 850, and
+//! asctime layouts. jiff does the actual calendar, clock and offset
+//! validation.
 
 use jiff::Timestamp;
 use thiserror::Error;
@@ -15,31 +15,35 @@ pub(crate) enum ParseDateError {
     ParseError(#[from] jiff::Error),
     // Raised for structural problems across all three accepted layouts, e.g.
     // a missing weekday, a localized weekday, or a wrongly placed comma.
-    #[error("Invalid date: expected RFC 1123, RFC 850 or asctime format")]
+    #[error("Invalid date: expected RFC 1123, RFC 850, or asctime format")]
     BadDate,
     #[error("Unknown timezone `{0}`")]
     BadZone(String),
 }
 
 pub(crate) fn parse_date(date: &str) -> Result<Timestamp, ParseDateError> {
-    // Mirror of apt's `RFC1123StrToTime` (apt-pkg/contrib/strutl.cc on master,
-    // lines ~1038-1132), which accepts RFC 1123, RFC 850 and asctime forms.
-    // Weekday validation and layout selection mirror lines ~1048-1097,
-    // timezone handling lines ~1097-1127, and the final strict parse lines
-    // ~1127-1132. The only deliberate divergence is accepting non-UTC numeric
-    // offsets (see parse_zone) instead of rejecting them. jiff does the actual
-    // calendar, clock and offset validation.
+    // Mirror of APT's `RFC1123StrToTime` (apt-pkg/contrib/strutl.cc @
+    // d8f548e00ca4 (lines ~1067-1161), which accepts RFC 1123, RFC 850, and
+    // asctime forms. Weekday validation and layout selection mirror lines
+    // ~1084-1130, timezone handling at lines ~1135-1146, and the final strict
+    // parse at lines ~1155-1160.
     //
-    // Collapse any whitespace so fields are predictable, mirroring apt's
+    // The only deliberate divergence is accepting non-UTC numeric offsets (see
+    // `parse_zone`) instead of rejecting them. jiff does the actual calendar,
+    // clock and offset validation.
+    //
+    // Collapse any whitespace so fields are predictable, mirroring APT's
     // `operator>>` which skips arbitrary whitespace between fields.
     let date = date.split_ascii_whitespace().collect::<Vec<_>>().join(" ");
 
     let (weekday, rest) = date.split_once(' ').ok_or(ParseDateError::BadDate)?;
 
-    // Like apt (strutl.cc lines ~1052-1059), only the first three letters are
-    // checked to reject localized weekdays; the *length* of the token then
-    // selects the date layout (strutl.cc lines ~1060-1097). This is as lenient
-    // as apt: a typo like `Thursdayyyyy,` still routes to RFC 850.
+    // Like APT, only the first three letters are checked to reject localized
+    // weekdays; the *length* of the token then selects the date layout (see
+    // `switch (weekday.length())`.
+    //
+    // This is as lenient as APT: a typo like `Thursdayyyyy,` still routes to
+    // RFC 850.
     let wd = weekday
         .get(..weekday.len().min(3))
         .ok_or(ParseDateError::BadDate)?;
@@ -70,13 +74,13 @@ pub(crate) fn parse_date(date: &str) -> Result<Timestamp, ParseDateError> {
     }
 }
 
-/// Parse the fields after `Weekday,` — date + time + trailing timezone token —
+/// Parse the fields after `Weekday,` - date + time + trailing timezone token -
 /// for the RFC 1123 (`dd Mon yyyy`) and RFC 850 (`dd-Mon-yy`) layouts.
 ///
-/// Mirrors apt's RFC1123StrToTime (strutl.cc lines ~1062-1097): the date/time
-/// fields and the trailing zone token are read separately, then the datetime
-/// is parsed strictly (equivalent to apt's `strptime("%Y-%m-%d %H:%M:%S")` at
-/// lines ~1127-1132).
+/// Mirrors APT's RFC1123StrToTime: the date/time fields and the trailing zone
+/// token are read separately, then the datetime is parsed strictly (mirroring
+/// APT's `strptime(datetime.c_str(), "%Y-%m-%d %H:%M:%S", &Tm)` at line 1157
+/// (commit d8f548e00ca4).
 fn parse_comma_date(rest: &str, format: &str) -> Result<Timestamp, ParseDateError> {
     let (date_part, zone) = rest
         .rsplit_once(' ')
@@ -90,15 +94,16 @@ fn parse_comma_date(rest: &str, format: &str) -> Result<Timestamp, ParseDateErro
 /// Resolve the trailing timezone token of an RFC 1123/850 date to a fixed UTC
 /// offset.
 ///
-/// Mirrors apt's RFC1123StrToTime (strutl.cc lines ~1097-1113), which resolves
-/// the zone by hand (strptime's `%Z` is a no-op on glibc). With a case
-/// sensitive comparison apt accepts exactly:
+/// Mirrors APT's RFC1123StrToTime, which resolves the zone by hand (strptime's
+/// `%Z` is a no-op on glibc). With a case sensitive comparison apt accepts
+/// exactly:
 ///
 ///   - the named zones `GMT`, `UTC` and `Z` (strutl.cc line ~1099), or
 ///   - any zone whose integer value is 0 and is fully consumed, i.e. any
 ///     all-zero token with or without a sign — `+0000`, `-0000`, `0000`,
-///     `+0`, `-0`, `+000`, `0`, ... (strutl.cc lines ~1100-1111;
-///     see also the note in apt-pkg/contrib/strutl.h lines ~61-79).
+///     `+0`, `-0`, `+000`, `0`, ... (see `TimeRFC1123` and lines ~1135-1146,
+///     and notes in apt-pkg/contrib/strutl.h lines ~61-79 regarding "parses
+///     time as needed by HTTP/1.1 and Debian files.")
 ///
 /// We deliberately extend this (as oma's previous rfc2822-based parser did):
 ///
@@ -163,7 +168,7 @@ fn pair_to_num(a: u8, b: u8, token: &str) -> Result<i32, ParseDateError> {
 
 #[test]
 fn test_apt_date_parser() {
-    // These are the three date layouts handled by apt's RFC1123StrToTime.
+    // These are the three date layouts handled by APT's RFC1123StrToTime.
     let cases = [
         ("Thu, 02 May 2024 09:58:03 +0000", "2024-05-02T09:58:03Z"),
         ("Thursday, 02-May-24 09:58:03 +0000", "2024-05-02T09:58:03Z"),
@@ -174,7 +179,7 @@ fn test_apt_date_parser() {
         assert_eq!(parse_date(input).unwrap().to_string(), expected);
     }
 
-    // Apt's parser is permissive about whitespace between fields.
+    // APT's parser is permissive about whitespace between fields.
     assert!(parse_date("Thu, 02 May 2024  09:58:03 +0000").is_ok());
 
     // RFC 1123 specifies GMT as the zone; apt additionally accepts UTC (a
@@ -227,7 +232,7 @@ fn test_apt_date_parser() {
 
 #[test]
 fn test_whitespace_tolerance() {
-    // Like apt's `operator>>`, any ASCII whitespace may separate fields.
+    // Like APT's `operator>>`, any ASCII whitespace may separate fields.
     let cases = [
         "Sun,\t06 Nov 1994 08:49:37 UTC",
         "  Sun, 06 Nov 1994 08:49:37 UTC",
@@ -246,7 +251,7 @@ fn test_whitespace_tolerance() {
 
 #[test]
 fn test_zone_and_year_edges() {
-    // Timezone tokens. apt's accepted set (case-sensitive) is exactly
+    // Timezone tokens. APT's accepted set (case-sensitive) is exactly
     // {GMT, UTC, Z} plus anything `stoi`-ing to 0 (`+0000`, `-0000`, `0000`,
     // `0`, `+0`, `+000`, ...). We additionally accept `UT`, lowercase `z`
     // and non-zero offsets (converted correctly) — see parse_zone.
@@ -325,7 +330,7 @@ fn test_zone_and_year_edges() {
 
 #[test]
 fn test_apt_suite_cases() {
-    // Accepted by apt's own test suite (test/libapt/strutil_test.cc).
+    // Accepted by APT's own test suite (test/libapt/strutil_test.cc).
     let cases = [
         ("Sun, 06 Nov 1994 08:49:37 GMT", "1994-11-06T08:49:37Z"),
         ("Sun, 6 Nov 1994 08:49:37 UTC", "1994-11-06T08:49:37Z"),
@@ -344,7 +349,7 @@ fn test_apt_suite_cases() {
         assert_eq!(parse_date(input).unwrap().to_string(), expected);
     }
 
-    // Rejected by apt's own test suite.
+    // Rejected by APT's own test suite.
     let rejected = [
         "So, 06 Nov 1994 08:49:37 UTC",
         ", 06 Nov 1994 08:49:37 UTC",

--- a/oma-refresh/src/date.rs
+++ b/oma-refresh/src/date.rs
@@ -1,0 +1,345 @@
+//! Parsing of the date/time strings found in Debian `Release`/`InRelease`
+//! files (the `Date:` and `Valid-Until:` fields).
+//!
+//! The parser mirrors apt's `RFC1123StrToTime`
+//! (apt-pkg/contrib/strutl.cc on master, lines ~1038-1132), which accepts the
+//! RFC 1123, RFC 850 and asctime layouts. jiff does the actual calendar, clock
+//! and offset validation.
+
+use jiff::Timestamp;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum ParseDateError {
+    #[error(transparent)]
+    ParseError(#[from] jiff::Error),
+    // Raised for structural problems across all three accepted layouts, e.g.
+    // a missing weekday, a localized weekday, or a wrongly placed comma.
+    #[error("Invalid date: expected RFC 1123, RFC 850 or asctime format")]
+    BadDate,
+    #[error("Unknown timezone `{0}`")]
+    BadZone(String),
+}
+
+pub(crate) fn parse_date(date: &str) -> Result<Timestamp, ParseDateError> {
+    // Mirror of apt's `RFC1123StrToTime` (apt-pkg/contrib/strutl.cc on master,
+    // lines ~1038-1132), which accepts RFC 1123, RFC 850 and asctime forms.
+    // Weekday validation and layout selection mirror lines ~1048-1097,
+    // timezone handling lines ~1097-1127, and the final strict parse lines
+    // ~1127-1132. The only deliberate divergence is accepting non-UTC numeric
+    // offsets (see parse_zone) instead of rejecting them. jiff does the actual
+    // calendar, clock and offset validation.
+    //
+    // Collapse any whitespace so fields are predictable, mirroring apt's
+    // `operator>>` which skips arbitrary whitespace between fields.
+    let date = date.split_ascii_whitespace().collect::<Vec<_>>().join(" ");
+
+    let (weekday, rest) = date.split_once(' ').ok_or(ParseDateError::BadDate)?;
+
+    // Like apt (strutl.cc lines ~1052-1059), only the first three letters are
+    // checked to reject localized weekdays; the *length* of the token then
+    // selects the date layout (strutl.cc lines ~1060-1097). This is as lenient
+    // as apt: a typo like `Thursdayyyyy,` still routes to RFC 850.
+    let wd = weekday
+        .get(..weekday.len().min(3))
+        .ok_or(ParseDateError::BadDate)?;
+    if !matches!(
+        wd.to_ascii_lowercase().as_str(),
+        "sun" | "mon" | "tue" | "wed" | "thu" | "fri" | "sat"
+    ) {
+        return Err(ParseDateError::BadDate);
+    }
+
+    match weekday.len() {
+        // ANSI C asctime(): "Sun Nov  6 08:49:37 1994" — no timezone, UTC.
+        3 => {
+            let datetime = jiff::civil::DateTime::strptime("%b %e %H:%M:%S %Y", rest)?;
+            Ok(jiff::tz::Offset::UTC.to_timestamp(datetime)?)
+        }
+        // RFC 1123: "Sun, 06 Nov 1994 08:49:37 GMT"
+        4 if weekday.ends_with(',') => parse_comma_date(rest, "%d %b %Y %H:%M:%S"),
+        // RFC 850: "Sunday, 06-Nov-94 08:49:37 GMT"
+        //
+        // Two-digit year: jiff's `%y` follows the POSIX pivot (69-99 →
+        // 1969-1999, 00-68 → 2000-2068), while apt computes `1900 + yy`
+        // (strutl.cc line ~1086). They agree for 69-99 and diverge for 00-68,
+        // where we keep jiff's rule, which maps modern dates (e.g. "24" →
+        // 2024) correctly.
+        _ if weekday.ends_with(',') => parse_comma_date(rest, "%d-%b-%y %H:%M:%S"),
+        _ => Err(ParseDateError::BadDate),
+    }
+}
+
+/// Parse the fields after `Weekday,` — date + time + trailing timezone token —
+/// for the RFC 1123 (`dd Mon yyyy`) and RFC 850 (`dd-Mon-yy`) layouts.
+///
+/// Mirrors apt's RFC1123StrToTime (strutl.cc lines ~1062-1097): the date/time
+/// fields and the trailing zone token are read separately, then the datetime
+/// is parsed strictly (equivalent to apt's `strptime("%Y-%m-%d %H:%M:%S")` at
+/// lines ~1127-1132).
+fn parse_comma_date(rest: &str, format: &str) -> Result<Timestamp, ParseDateError> {
+    let (date_part, zone) = rest
+        .rsplit_once(' ')
+        .ok_or_else(|| ParseDateError::BadZone("missing timezone".to_string()))?;
+    let offset = parse_zone(zone)?;
+    let datetime = jiff::civil::DateTime::strptime(format, date_part)?;
+
+    Ok(offset.to_timestamp(datetime)?)
+}
+
+/// Resolve the trailing timezone token of an RFC 1123/850 date to a fixed UTC
+/// offset.
+///
+/// Mirrors apt's RFC1123StrToTime (strutl.cc lines ~1097-1113), which resolves
+/// the zone by hand (strptime's `%Z` is a no-op on glibc). With a case
+/// sensitive comparison apt accepts exactly:
+///
+///   - the named zones `GMT`, `UTC` and `Z` (strutl.cc line ~1099), or
+///   - any zone whose integer value is 0 and is fully consumed, i.e.
+///     `+0000`, `-0000`, `0000`, `0`, ... (strutl.cc lines ~1100-1111;
+///     see also the note in apt-pkg/contrib/strutl.h lines ~61-79).
+///
+/// We deliberately extend this (as oma's previous rfc2822-based parser did):
+///
+///   - `UT` (named by RFC 1123) and lowercase `z` are treated as UTC;
+///   - any other numeric offset (`+HH`, `+HHMM`, `+HH:MM`, including non-zero
+///     ones such as `+0530`/`-0500`) is accepted and converted correctly,
+///     where apt would reject the whole date.
+fn parse_zone(token: &str) -> Result<jiff::tz::Offset, ParseDateError> {
+    match token {
+        "UTC" | "GMT" | "UT" | "Z" | "z" => return Ok(jiff::tz::Offset::UTC),
+        _ => {}
+    }
+
+    let (sign, digits) = match token.as_bytes().split_first() {
+        Some((b'+', rest)) => (1i32, rest),
+        Some((b'-', rest)) => (-1i32, rest),
+        // Like apt (`stoi(zone) == 0`), a sign-less all-zero zone such as
+        // `0000` or `0` is also accepted; anything else is rejected.
+        _ => {
+            let z = token
+                .parse::<i32>()
+                .map_err(|_| ParseDateError::BadZone(token.to_string()))?;
+            return if z == 0 {
+                Ok(jiff::tz::Offset::UTC)
+            } else {
+                Err(ParseDateError::BadZone(token.to_string()))
+            };
+        }
+    };
+
+    // Accept `HH`, `HHMM` and `HH:MM`.
+    let (hh, mm) = match digits {
+        [a, b] => (pair_to_num(*a, *b, token)?, 0),
+        [a, b, c, d] => (pair_to_num(*a, *b, token)?, pair_to_num(*c, *d, token)?),
+        [a, b, b':', c, d] => (pair_to_num(*a, *b, token)?, pair_to_num(*c, *d, token)?),
+        _ => return Err(ParseDateError::BadZone(token.to_string())),
+    };
+
+    if hh > 23 || mm > 59 {
+        return Err(ParseDateError::BadZone(token.to_string()));
+    }
+
+    jiff::tz::Offset::from_seconds(sign * (hh * 3600 + mm * 60)).map_err(ParseDateError::from)
+}
+
+fn pair_to_num(a: u8, b: u8, token: &str) -> Result<i32, ParseDateError> {
+    if !a.is_ascii_digit() || !b.is_ascii_digit() {
+        return Err(ParseDateError::BadZone(token.to_string()));
+    }
+    Ok(((a - b'0') * 10 + (b - b'0')) as i32)
+}
+
+#[test]
+fn test_apt_date_parser() {
+    // These are the three date layouts handled by apt's RFC1123StrToTime.
+    let cases = [
+        ("Thu, 02 May 2024 09:58:03 +0000", "2024-05-02T09:58:03Z"),
+        ("Thursday, 02-May-24 09:58:03 +0000", "2024-05-02T09:58:03Z"),
+        ("Thu May 2 09:58:03 2024", "2024-05-02T09:58:03Z"),
+        ("Thu, 02 May 2024 09:58:03 +0530", "2024-05-02T04:28:03Z"),
+    ];
+    for (input, expected) in cases {
+        assert_eq!(parse_date(input).unwrap().to_string(), expected);
+    }
+
+    // Apt's parser is permissive about whitespace between fields.
+    assert!(parse_date("Thu, 02 May 2024  09:58:03 +0000").is_ok());
+
+    // RFC 1123 specifies GMT as the zone; apt additionally accepts UTC (a
+    // compatibility extension, and what Debian Release files actually emit)
+    // and Z. We also accept `UT` and lowercase `z`. Single-digit hours are
+    // tolerated like apt.
+    assert_eq!(
+        parse_date("Thu, 02 May 2024 09:58:03 UTC")
+            .unwrap()
+            .to_string(),
+        "2024-05-02T09:58:03Z"
+    );
+    assert_eq!(
+        parse_date("Thu, 02 May 2024 09:58:03 GMT")
+            .unwrap()
+            .to_string(),
+        "2024-05-02T09:58:03Z"
+    );
+    assert_eq!(
+        parse_date("Thu, 02 May 2024  9:58:03 UTC")
+            .unwrap()
+            .to_string(),
+        "2024-05-02T09:58:03Z"
+    );
+    assert_eq!(
+        parse_date("Thursday, 02-May-24 09:58:03 UTC")
+            .unwrap()
+            .to_string(),
+        "2024-05-02T09:58:03Z"
+    );
+
+    // Negative UTC offsets must not be mistaken for an RFC 850 date.
+    assert_eq!(
+        parse_date("Thu, 02 May 2024 09:58:03 -0500")
+            .unwrap()
+            .to_string(),
+        "2024-05-02T14:58:03Z"
+    );
+    assert_eq!(
+        parse_date("Thursday, 02-May-24 09:58:03 -0500")
+            .unwrap()
+            .to_string(),
+        "2024-05-02T14:58:03Z"
+    );
+
+    // Do not silently accept an unknown date layout or an unknown timezone.
+    assert!(parse_date("not a date").is_err());
+    assert!(parse_date("Thu, 02 May 2024 09:58:03 PST").is_err());
+}
+
+#[test]
+fn test_whitespace_tolerance() {
+    // Like apt's `operator>>`, any ASCII whitespace may separate fields.
+    let cases = [
+        "Sun,\t06 Nov 1994 08:49:37 UTC",
+        "  Sun, 06 Nov 1994 08:49:37 UTC",
+        "Sun, 06 Nov 1994 08:49:37\tUTC",
+        "Sun, 06 Nov 1994 08:49:37 UTC  ",
+        "Sun\tNov\t6\t08:49:37\t1994",
+    ];
+    for input in cases {
+        assert_eq!(
+            parse_date(input).unwrap().to_string(),
+            "1994-11-06T08:49:37Z",
+            "input: {input:?}"
+        );
+    }
+}
+
+#[test]
+fn test_zone_and_year_edges() {
+    // Timezone tokens. apt's accepted set (case-sensitive) is exactly
+    // {GMT, UTC, Z} plus anything `stoi`-ing to 0 (`+0000`, `-0000`, `0000`,
+    // `0`, ...). We additionally accept `UT`, lowercase `z` and non-zero
+    // offsets (converted correctly) — see parse_zone.
+    let accepted = [
+        ("Sun, 06 Nov 1994 08:49:37 GMT", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 UTC", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 Z", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 z", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 UT", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 +0000", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 -0000", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 0000", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 0", "1994-11-06T08:49:37Z"),
+        // Deliberate extensions over apt: non-zero offsets are converted.
+        ("Sun, 06 Nov 1994 08:49:37 +0530", "1994-11-06T03:19:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 -0500", "1994-11-06T13:49:37Z"),
+    ];
+    for (input, expected) in accepted {
+        assert_eq!(
+            parse_date(input).unwrap().to_string(),
+            expected,
+            "input: {input}"
+        );
+    }
+
+    // Zone comparison is case-sensitive like apt; non-zero without a sign is
+    // rejected (apt: `stoi("0530") == 530`).
+    let rejected = [
+        "Sun, 06 Nov 1994 08:49:37 gmt",
+        "Sun, 06 Nov 1994 08:49:37 utc",
+        "Sun, 06 Nov 1994 08:49:37 ut",
+        "Sun, 06 Nov 1994 08:49:37 PST",
+        "Sun, 06 Nov 1994 08:49:37 0530",
+    ];
+    for input in rejected {
+        assert!(parse_date(input).is_err(), "should reject: {input}");
+    }
+
+    // RFC 850 two-digit years: jiff follows the POSIX pivot (69-99 → 19xx,
+    // 00-68 → 20xx); apt computes `1900 + yy` (they agree for 69-99, diverge
+    // for 00-68 — we keep jiff's rule).
+    let years = [
+        ("Sunday, 06-Nov-68 08:49:37 GMT", "2068-11-06T08:49:37Z"),
+        ("Sunday, 06-Nov-69 08:49:37 GMT", "1969-11-06T08:49:37Z"),
+        ("Sunday, 06-Nov-70 08:49:37 GMT", "1970-11-06T08:49:37Z"),
+        ("Sunday, 06-Nov-94 08:49:37 GMT", "1994-11-06T08:49:37Z"),
+        ("Sunday, 06-Nov-99 08:49:37 GMT", "1999-11-06T08:49:37Z"),
+    ];
+    for (input, expected) in years {
+        assert_eq!(
+            parse_date(input).unwrap().to_string(),
+            expected,
+            "input: {input}"
+        );
+    }
+
+    // Like apt, only the first three letters of the weekday are checked, so a
+    // long weekday still routes to RFC 850.
+    assert_eq!(
+        parse_date("Thursdayyyyy, 02-May-24 09:58:03 +0000")
+            .unwrap()
+            .to_string(),
+        "2024-05-02T09:58:03Z"
+    );
+}
+
+#[test]
+fn test_apt_suite_cases() {
+    // Accepted by apt's own test suite (test/libapt/strutil_test.cc).
+    let cases = [
+        ("Sun, 06 Nov 1994 08:49:37 GMT", "1994-11-06T08:49:37Z"),
+        ("Sun, 6 Nov 1994 08:49:37 UTC", "1994-11-06T08:49:37Z"),
+        ("Sun,  6 Nov 1994 08:49:37 UTC", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994  8:49:37 UTC", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 -0000", "1994-11-06T08:49:37Z"),
+        ("Sun, 06 Nov 1994 08:49:37 +0000", "1994-11-06T08:49:37Z"),
+        ("Sunday, 06-Nov-94 08:49:37 GMT", "1994-11-06T08:49:37Z"),
+        ("Sunday,  6-Nov-94 08:49:37 GMT", "1994-11-06T08:49:37Z"),
+        ("Sunday, 06-Nov-94 8:49:37 GMT", "1994-11-06T08:49:37Z"),
+        ("Sun Nov  6 08:49:37 1994", "1994-11-06T08:49:37Z"),
+        ("Sun Nov 06 08:49:37 1994", "1994-11-06T08:49:37Z"),
+        ("Sun Nov  6  8:49:37 1994", "1994-11-06T08:49:37Z"),
+    ];
+    for (input, expected) in cases {
+        assert_eq!(parse_date(input).unwrap().to_string(), expected);
+    }
+
+    // Rejected by apt's own test suite.
+    let rejected = [
+        "So, 06 Nov 1994 08:49:37 UTC",
+        ", 06 Nov 1994 08:49:37 UTC",
+        "Son, 06 Nov 1994 08:49:37 UTC",
+        "Sun: 06 Nov 1994 08:49:37 UTC",
+        "Sun, 06 Nov 1994 08:49:37",
+        "Sun, 06 Nov 1994 08:49:37 GMT+1",
+        "Sunday, 06 Nov 1994 GMT",
+        "Sunday, 06 Nov 1994 08:49:37 GMT",
+        "Sun, 06-Nov-94 08:49:37 GMT",
+        "Sonntag, 06 Nov 1994 08:49:37 GMT",
+        "domingo Nov 6 08:49:37 1994",
+        "Sunday: 06-Nov-94 08:49:37 GMT",
+        "Sunday, 06-Nov-94 08:49:37 GMT+1",
+    ];
+    for input in rejected {
+        assert!(parse_date(input).is_err(), "should reject: {input}");
+    }
+}

--- a/oma-refresh/src/inrelease.rs
+++ b/oma-refresh/src/inrelease.rs
@@ -12,7 +12,8 @@ use std::{
     path::Path,
     str::FromStr,
 };
-use thiserror::Error;
+
+use crate::date::parse_date;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChecksumItem {
@@ -285,90 +286,6 @@ pub(crate) fn file_is_compress(name: &str) -> bool {
     }
 
     false
-}
-
-#[derive(Debug, Error)]
-enum ParseDateError {
-    #[error(transparent)]
-    ParseError(#[from] jiff::Error),
-    #[error("Could not parse date: {0}")]
-    BadDate(ParseIntError),
-}
-
-fn parse_date(date: &str) -> Result<Timestamp, ParseDateError> {
-    match jiff::fmt::rfc2822::parse(date) {
-        Ok(res) => Ok(res.timestamp()),
-        Err(e) => {
-            debug!("Failed to parse {}: {e}, trying to use date hack ...", date);
-            let hack_date = date_hack(date).map_err(ParseDateError::BadDate)?;
-            Ok(jiff::fmt::rfc2822::parse(&hack_date)?.timestamp())
-        }
-    }
-}
-
-/// Replace RFC 1123/822/2822 non-compliant "UTC" marker with RFC 2822-compliant "+0000" whilst parsing InRelease.
-/// and for non-standard X:YY:ZZ conversion to XX:YY:ZZ.
-///
-/// - Some third-party repositories (such as those generated with Aptly) uses "UTC" to denote the Coordinated Universal
-///   Time, which is not allowed in RFC 1123 or 822/2822 (all calls for "GMT" or "UT", 822 allows "Z", and 2822 allows
-///   "+0000").
-/// - This is used by many commercial software vendors, such as Google, Microsoft, and Spotify.
-/// - This is allowed in APT's RFC 1123 parser. However, as jiff requires full compliance with the
-///   aforementioned RFC documents, "UTC" is considered illegal.
-///
-/// Replace the "UTC" marker at the end of date strings to make it palatable to jiff.
-///
-/// and for non-standard X:YY:ZZ conversion to XX:YY:ZZ to make it palatable to jiff.
-fn date_hack(date: &str) -> Result<String, ParseIntError> {
-    let mut split_time = date
-        .split_ascii_whitespace()
-        .map(|x| x.to_string())
-        .collect::<Vec<_>>();
-
-    for c in split_time.iter_mut() {
-        if c.is_empty() || !c.contains(':') {
-            continue;
-        }
-
-        let mut time_split = c.split(':').map(|x| x.to_string()).collect::<Vec<_>>();
-
-        // X:YY:ZZ conversion to XX:YY:ZZ to make it palatable to jiff
-        for k in time_split.iter_mut() {
-            match k.parse::<u64>()? {
-                0..=9 if k.len() == 1 => {
-                    *k = "0".to_string() + k;
-                }
-                _ => continue,
-            }
-        }
-
-        *c = time_split.join(":");
-    }
-
-    let date = split_time.join(" ");
-
-    Ok(date.replace("UTC", "+0000"))
-}
-
-#[test]
-fn test_date_hack() {
-    let a = "Thu, 02 May 2024  9:58:03 UTC";
-    let hack = date_hack(&a).unwrap();
-    assert_eq!(hack, "Thu, 02 May 2024 09:58:03 +0000");
-    let b = jiff::fmt::rfc2822::parse(&hack);
-    assert!(b.is_ok());
-
-    let a = "Thu, 02 May 2024 09:58:03 +0000";
-    let hack = date_hack(&a).unwrap();
-    assert_eq!(hack, "Thu, 02 May 2024 09:58:03 +0000");
-    let b = jiff::fmt::rfc2822::parse(&hack);
-    assert!(b.is_ok());
-
-    let a = "Thu, 02 May 2024  0:58:03 +0000";
-    let hack = date_hack(&a).unwrap();
-    assert_eq!(hack, "Thu, 02 May 2024 00:58:03 +0000");
-    let b = jiff::fmt::rfc2822::parse(&hack);
-    assert!(b.is_ok());
 }
 
 #[test]

--- a/oma-refresh/src/inrelease.rs
+++ b/oma-refresh/src/inrelease.rs
@@ -291,18 +291,18 @@ pub(crate) fn file_is_compress(name: &str) -> bool {
 #[test]
 fn test_split_name_and_ext() {
     let example1 = "main/dep11/icons-128x128.tar.gz";
-    let res = split_ext_and_filename(&example1);
+    let res = split_ext_and_filename(example1);
     assert_eq!(
         res,
         ("gz".into(), "main/dep11/icons-128x128.tar".to_string())
     );
 
     let example2 = "main/i18n/Translation-bg.xz";
-    let res = split_ext_and_filename(&example2);
+    let res = split_ext_and_filename(example2);
     assert_eq!(res, ("xz".into(), "main/i18n/Translation-bg".to_string()));
 
     let example2 = "main/i18n/Translation-bg";
-    let res = split_ext_and_filename(&example2);
+    let res = split_ext_and_filename(example2);
     assert_eq!(res, ("".into(), "main/i18n/Translation-bg".to_string()));
 }
 

--- a/oma-refresh/src/lib.rs
+++ b/oma-refresh/src/lib.rs
@@ -1,4 +1,5 @@
 mod config;
+mod date;
 pub mod db;
 pub mod inrelease;
 mod sourceslist;


### PR DESCRIPTION
## Description

Move the parsing of Release Date/Valid-Until fields out of inrelease.rs into a dedicated `date` module that mirrors apt's RFC1123StrToTime (apt-pkg/contrib/strutl.cc), accepting the RFC 1123, RFC 850 and asctime layouts instead of the previous RFC 2822 + string-munging date_hack.

The new parser routes on the weekday token length like apt and rejects localized weekdays; it handles "UTC"/"GMT"/"Z" and zero offsets (+0000/-0000/0000) like apt, and additionally converts arbitrary numeric offsets correctly. Calendar, clock and offset validation is delegated to jiff instead of ad-hoc string rewrites. Tests cover apt's own strutil_test.cc cases plus whitespace, timezone and two-digit-year edge cases.

## About AI

This PR draws inspiration from and modifies the Deepseek V4 flash. I have reviewed and amended some of the code, and updated some of the comments.

- Model: Deepseek v4 flash
- Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)