### PR TITLE
Mirror protocol support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,6 +3656,7 @@ dependencies = [
  "serde",
  "spdlog-rs",
  "sys-locale",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "url",

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,11 @@
 [default.extend-words]
 ratatui = "ratatui"
 
+[default.extend-identifiers]
+# apt's methods/mirror.cc spells its mirror-list parser function
+# `MirrorListFileRecieved` (sic); keep the faithful reference.
+MirrorListFileRecieved = "MirrorListFileRecieved"
+
 [type.md]
 extend-glob = ["*.md"]
 check-file = false

--- a/oma-fetch/examples/downloads.rs
+++ b/oma-fetch/examples/downloads.rs
@@ -14,6 +14,7 @@ async fn main() {
     let source_1 = DownloadSource {
         url: "https://mirrors.jlu.edu.cn/anthon/aosc-os/os-amd64/base/aosc-os_base_20260312_amd64.squashfs".to_string(),
         source_type: DownloadSourceType::Http,
+        order: 0,
         priority: u64::MAX,
     };
 
@@ -34,6 +35,7 @@ async fn main() {
     let source_2 = DownloadSource {
         url: "https://mirrors.jlu.edu.cn/anthon/oma/pool/beige/main/o/oma_1.27.0~rc.1-1_amd64-deepin23.deb".to_string(),
         source_type: DownloadSourceType::Http,
+        order: 0,
         priority: u64::MAX,
     };
 

--- a/oma-fetch/examples/downloads.rs
+++ b/oma-fetch/examples/downloads.rs
@@ -14,6 +14,7 @@ async fn main() {
     let source_1 = DownloadSource {
         url: "https://mirrors.jlu.edu.cn/anthon/aosc-os/os-amd64/base/aosc-os_base_20260312_amd64.squashfs".to_string(),
         source_type: DownloadSourceType::Http,
+        priority: u64::MAX,
     };
 
     let file_1 = DownloadEntry::builder()
@@ -33,6 +34,7 @@ async fn main() {
     let source_2 = DownloadSource {
         url: "https://mirrors.jlu.edu.cn/anthon/oma/pool/beige/main/o/oma_1.27.0~rc.1-1_amd64-deepin23.deb".to_string(),
         source_type: DownloadSourceType::Http,
+        priority: u64::MAX,
     };
 
     let file_2 = DownloadEntry::builder()

--- a/oma-fetch/src/download.rs
+++ b/oma-fetch/src/download.rs
@@ -305,15 +305,17 @@ impl SingleDownloader {
         let mut sources = self.entry.source.clone();
         assert!(!sources.is_empty());
 
-        // Try higher-priority sources first: mirror sources carry their
-        // mirror-list `priority:`, and non-mirror local sources sort before
-        // HTTP ones. Among equal priorities keep the transport preference
-        // (local before HTTP) and, within that, the caller's given order —
-        // a stable sort keeps equal sources in their original relative
-        // order (primary first, fallbacks after it).
+        // Try the caller's alternate-URL groups in their given order first,
+        // then within each group higher-priority sources first: mirror
+        // sources carry their mirror-list `priority:`, and non-mirror local
+        // sources sort before HTTP ones. Among equal keys keep the
+        // transport preference (local before HTTP) and, within that, the
+        // caller's given order — a stable sort keeps equal sources in their
+        // original relative order (primary first, fallbacks after it).
         sources.sort_by(|a, b| {
-            a.priority
-                .cmp(&b.priority)
+            a.order
+                .cmp(&b.order)
+                .then_with(|| a.priority.cmp(&b.priority))
                 .then_with(|| b.source_type.cmp(&a.source_type))
         });
 

--- a/oma-fetch/src/download.rs
+++ b/oma-fetch/src/download.rs
@@ -305,9 +305,17 @@ impl SingleDownloader {
         let mut sources = self.entry.source.clone();
         assert!(!sources.is_empty());
 
-        // Use a stable sort so that sources with the same priority keep their
-        // given order: the primary source first, fallbacks after it.
-        sources.sort_by(|a, b| b.source_type.cmp(&a.source_type));
+        // Try higher-priority sources first: mirror sources carry their
+        // mirror-list `priority:`, and non-mirror local sources sort before
+        // HTTP ones. Among equal priorities keep the transport preference
+        // (local before HTTP) and, within that, the caller's given order —
+        // a stable sort keeps equal sources in their original relative
+        // order (primary first, fallbacks after it).
+        sources.sort_by(|a, b| {
+            a.priority
+                .cmp(&b.priority)
+                .then_with(|| b.source_type.cmp(&a.source_type))
+        });
 
         for (index, c) in sources.iter().enumerate() {
             let download_res = match &c.source_type {

--- a/oma-fetch/src/lib.rs
+++ b/oma-fetch/src/lib.rs
@@ -80,10 +80,16 @@ impl From<&str> for CompressType {
 pub struct DownloadSource {
     pub url: String,
     pub source_type: DownloadSourceType,
-    /// Sort priority: lower is tried first. Mirror sources carry their
-    /// mirror-list `priority:` so the mirror order survives the download
-    /// manager's transport-aware sort; non-mirror sources use `u64::MAX`
-    /// so their transport preference (local before HTTP) applies.
+    /// The alternate-URL group this source belongs to — e.g. the index of
+    /// the `PackageUrl` it was expanded from. Sources of the caller's
+    /// primary URL are tried before later alternates; mirror priority only
+    /// applies within the same group, since priorities from independent
+    /// mirror lists share no scale and must not be compared across groups.
+    pub order: usize,
+    /// Sort priority within the group: lower is tried first. Mirror sources
+    /// carry their mirror-list `priority:`; non-mirror local sources use `0`
+    /// and HTTP sources `u64::MAX`, so their transport preference (local
+    /// before HTTP) applies.
     pub priority: u64,
 }
 

--- a/oma-fetch/src/lib.rs
+++ b/oma-fetch/src/lib.rs
@@ -80,6 +80,11 @@ impl From<&str> for CompressType {
 pub struct DownloadSource {
     pub url: String,
     pub source_type: DownloadSourceType,
+    /// Sort priority: lower is tried first. Mirror sources carry their
+    /// mirror-list `priority:` so the mirror order survives the download
+    /// manager's transport-aware sort; non-mirror sources use `u64::MAX`
+    /// so their transport preference (local before HTTP) applies.
+    pub priority: u64,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/oma-fetch/src/lib.rs
+++ b/oma-fetch/src/lib.rs
@@ -13,6 +13,7 @@ use tokio::task::JoinSet;
 
 pub mod checksum;
 pub mod download;
+pub mod mirror;
 pub use crate::download::SingleDownloadError;
 
 pub use reqwest;

--- a/oma-fetch/src/mirror.rs
+++ b/oma-fetch/src/mirror.rs
@@ -1,0 +1,368 @@
+//! Resolving apt's `mirror://` protocol.
+//!
+//! Mirrors the behavior of apt's `methods/mirror.cc`: a `mirror://` (or
+//! `mirror+http(s)://` / `mirror+file://`) URI points at a *mirror list* file
+//! whose lines name the actual repository base URIs. The list is fetched over
+//! the network or read from a local file, parsed, filtered and sorted, and the
+//! result is the ordered set of concrete base URLs to use for downloads.
+//!
+//! Mirror list format (apt compatible), one entry per line:
+//!
+//! ```text
+//! http://mirror1.example.com/debian/        priority:1 release:stable
+//! http://mirror2.example.com/debian/        priority:2
+//! # comments and blank lines are ignored
+//! ```
+//!
+//! Entries are filtered by their tags (`arch:`, `release:`/`suite:`/`codename:`,
+//! `type:`, ...) and ordered by `priority` (lower first; entries without an
+//! explicit priority come last), like apt.
+
+use std::{collections::HashMap, io, path::PathBuf};
+
+use reqwest_middleware::ClientWithMiddleware;
+use snafu::{ResultExt, Snafu};
+
+use crate::{reqwest::Method, send_request_with_url_and_method};
+
+/// Where a mirror list lives and how to obtain it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MirrorListLocation {
+    /// Fetched over the network.
+    Http(String),
+    /// A local file.
+    File(PathBuf),
+}
+
+/// One entry of a mirror list file.
+#[derive(Debug, Clone)]
+pub struct MirrorEntry {
+    /// Base URI of the mirror (e.g. `http://mirror.example.com/debian`).
+    pub url: String,
+    /// Lower is preferred; mirrors without an explicit `priority:` sort last.
+    pub priority: u64,
+    /// Extra tags from the entry (`arch:`, `release:`, `type:`, ...).
+    pub tags: HashMap<Box<str>, Vec<Box<str>>>,
+}
+
+/// The transport used to reach a mirror base URI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MirrorSourceType {
+    Http,
+    File,
+}
+
+/// A mirror resolved to a concrete base URI and transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedMirror {
+    /// Base URI with any trailing `/` stripped.
+    pub url: String,
+    pub source_type: MirrorSourceType,
+}
+
+#[derive(Debug, Snafu)]
+pub enum MirrorError {
+    #[snafu(display("Unsupported mirror protocol: {uri}"))]
+    UnsupportedProtocol { uri: String },
+    #[snafu(display("Failed to read mirror list {path:?}: {source}"))]
+    ReadFile { path: PathBuf, source: io::Error },
+    #[snafu(display("Failed to fetch mirror list {url}: {source}"))]
+    Fetch {
+        url: String,
+        source: reqwest_middleware::Error,
+    },
+    #[snafu(display("Failed to read mirror list body from {url}: {source}"))]
+    ReadBody { url: String, source: reqwest::Error },
+    #[snafu(display("Mirror list {uri} is empty"))]
+    EmptyList { uri: String },
+}
+
+/// Interpret a mirror URI into the location of its mirror list.
+///
+/// * `mirror://host/path`    → list fetched from `http://host/path` (like apt)
+/// * `mirror+http(s)://...`  → list fetched from the given URL
+/// * `mirror+file:///path`   → list is the local file `/path`
+fn parse_mirror_uri(uri: &str) -> Result<MirrorListLocation, MirrorError> {
+    let location = if let Some(rest) = uri.strip_prefix("mirror+http:") {
+        MirrorListLocation::Http(format!("http:{rest}"))
+    } else if let Some(rest) = uri.strip_prefix("mirror+https:") {
+        MirrorListLocation::Http(format!("https:{rest}"))
+    } else if let Some(rest) = uri.strip_prefix("mirror+file:") {
+        let path = rest.strip_prefix("//").unwrap_or(rest);
+        MirrorListLocation::File(PathBuf::from(path))
+    } else if let Some(rest) = uri.strip_prefix("mirror:") {
+        // Bare `mirror://` fetches the list over http, mirroring apt.
+        MirrorListLocation::Http(format!("http:{rest}"))
+    } else {
+        return Err(MirrorError::UnsupportedProtocol {
+            uri: uri.to_string(),
+        });
+    };
+    Ok(location)
+}
+
+/// Parse a mirror list (apt's `MirrorListFileRecieved`).
+///
+/// Each line is either blank/comment or `<uri>[\t<tag> ...]`. When
+/// `from_network` is set — the list itself was fetched over the network —
+/// local `file:` mirrors are rejected, mirroring apt's security check
+/// (CVE-2018-0501).
+pub fn parse_mirror_list(text: &str, from_network: bool) -> Vec<MirrorEntry> {
+    let mut entries = vec![];
+
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let (url, tags) = match line.find('\t') {
+            Some(tab) => (&line[..tab], &line[tab + 1..]),
+            None => (line, ""),
+        };
+        let url = url.trim();
+        if url.is_empty() {
+            continue;
+        }
+
+        if from_network && url.starts_with("file:") {
+            continue;
+        }
+
+        let mut entry = MirrorEntry {
+            url: url.to_string(),
+            priority: u64::MAX,
+            tags: HashMap::new(),
+        };
+
+        for tag in tags.split_whitespace() {
+            let Some((name, value)) = tag.split_once(':') else {
+                continue;
+            };
+            if name.is_empty() {
+                continue;
+            }
+            match name {
+                "priority" => entry.priority = value.parse().unwrap_or(u64::MAX),
+                "arch" => entry
+                    .tags
+                    .entry("arch".into())
+                    .or_default()
+                    .push(value.into()),
+                "lang" => entry
+                    .tags
+                    .entry("lang".into())
+                    .or_default()
+                    .push(value.into()),
+                // `suite`/`codename` are matched against the release, like apt.
+                "suite" | "codename" | "release" => entry
+                    .tags
+                    .entry("release".into())
+                    .or_default()
+                    .push(value.into()),
+                other => entry
+                    .tags
+                    .entry(other.to_ascii_lowercase().into())
+                    .or_default()
+                    .push(value.into()),
+            }
+        }
+
+        entries.push(entry);
+    }
+
+    entries
+}
+
+/// Filter mirrors by the request's tags and order them by priority.
+///
+/// A mirror is kept when each of its tags matches the request attribute
+/// (`arch`, `suite`/`codename`/`release`, `type: deb`/`deb-src`); missing
+/// request attributes do not filter anything out.
+pub fn select_mirrors(
+    mut entries: Vec<MirrorEntry>,
+    arch: Option<&str>,
+    suite: Option<&str>,
+    is_source: bool,
+) -> Vec<ResolvedMirror> {
+    fn tag_matches(
+        tags: &HashMap<Box<str>, Vec<Box<str>>>,
+        key: &str,
+        value: Option<&str>,
+    ) -> bool {
+        match value {
+            None => true,
+            Some(value) => tags
+                .get(key)
+                .is_none_or(|values| values.iter().any(|x| x.as_ref() == value)),
+        }
+    }
+
+    entries.retain(|e| {
+        tag_matches(&e.tags, "arch", arch)
+            && tag_matches(&e.tags, "release", suite)
+            && tag_matches(
+                &e.tags,
+                "type",
+                Some(if is_source { "deb-src" } else { "deb" }),
+            )
+    });
+
+    entries.sort_by_key(|e| e.priority);
+
+    entries
+        .into_iter()
+        .map(|e| ResolvedMirror {
+            url: e.url.trim_end_matches('/').to_string(),
+            source_type: if e.url.starts_with("file:") {
+                MirrorSourceType::File
+            } else {
+                MirrorSourceType::Http
+            },
+        })
+        .collect()
+}
+
+/// Fetch (or read) and parse a mirror list, returning the resolved mirrors in
+/// priority order.
+pub async fn resolve_mirrors(
+    mirror_uri: &str,
+    client: &ClientWithMiddleware,
+    arch: Option<&str>,
+    suite: Option<&str>,
+    is_source: bool,
+) -> Result<Vec<ResolvedMirror>, MirrorError> {
+    let location = parse_mirror_uri(mirror_uri)?;
+
+    let (text, from_network) = match location {
+        MirrorListLocation::Http(url) => {
+            let resp = send_request_with_url_and_method(&url, client, Method::GET)
+                .await
+                .context(FetchSnafu { url: url.clone() })?;
+            let body = resp
+                .text()
+                .await
+                .context(ReadBodySnafu { url: url.clone() })?;
+            (body, true)
+        }
+        MirrorListLocation::File(path) => {
+            let text = tokio::fs::read_to_string(&path)
+                .await
+                .context(ReadFileSnafu { path })?;
+            (text, false)
+        }
+    };
+
+    let entries = parse_mirror_list(&text, from_network);
+    if entries.is_empty() {
+        return Err(MirrorError::EmptyList {
+            uri: mirror_uri.to_string(),
+        });
+    }
+
+    Ok(select_mirrors(entries, arch, suite, is_source))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_mirror_uri() {
+        assert_eq!(
+            parse_mirror_uri("mirror://mirrors.example.com/debian/").unwrap(),
+            MirrorListLocation::Http("http://mirrors.example.com/debian/".into())
+        );
+        assert_eq!(
+            parse_mirror_uri("mirror+http://host/list").unwrap(),
+            MirrorListLocation::Http("http://host/list".into())
+        );
+        assert_eq!(
+            parse_mirror_uri("mirror+https://host/list").unwrap(),
+            MirrorListLocation::Http("https://host/list".into())
+        );
+        assert_eq!(
+            parse_mirror_uri("mirror+file:///etc/apt/mirrors.list").unwrap(),
+            MirrorListLocation::File(PathBuf::from("/etc/apt/mirrors.list"))
+        );
+        assert_eq!(
+            parse_mirror_uri("mirror+file:/etc/apt/mirrors.list").unwrap(),
+            MirrorListLocation::File(PathBuf::from("/etc/apt/mirrors.list"))
+        );
+        assert!(parse_mirror_uri("http://plain.example.com/").is_err());
+        assert!(parse_mirror_uri("mirror+ftp://host/list").is_err());
+    }
+
+    #[test]
+    fn test_parse_mirror_list() {
+        // Tags are separated from the URI by a tab, like apt.
+        let text = "\
+# comment
+http://mirror1.example.com/debian/\tpriority:1\trelease:stable
+http://mirror2.example.com/debian/
+
+http://mirror3.example.com/debian/\tpriority:2\tarch:amd64
+file:///local/repo\tpriority:1
+";
+        let entries = parse_mirror_list(text, false);
+        assert_eq!(entries.len(), 4);
+        assert_eq!(entries[0].url, "http://mirror1.example.com/debian/");
+        assert_eq!(entries[0].priority, 1);
+        assert_eq!(entries[0].tags["release"], vec![Box::from("stable")]);
+        assert_eq!(entries[1].priority, u64::MAX);
+        assert_eq!(entries[2].priority, 2);
+        assert_eq!(entries[2].tags["arch"], vec![Box::from("amd64")]);
+        assert_eq!(entries[3].url, "file:///local/repo");
+    }
+
+    #[test]
+    fn test_parse_mirror_list_network_rejects_file() {
+        let text = "http://mirror1.example.com/\nfile:///local/repo\n";
+        let entries = parse_mirror_list(text, true);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].url, "http://mirror1.example.com/");
+    }
+
+    #[test]
+    fn test_select_mirrors() {
+        let text = "\
+http://m1.example.com/\tpriority:2
+http://m2.example.com/\tpriority:1
+http://m3.example.com/\tpriority:1\trelease:stable
+http://m4.example.com/\tpriority:1\trelease:unstable
+file:///local/repo\tpriority:0
+";
+        let entries = parse_mirror_list(text, false);
+
+        // suite filter + priority ordering (stable within equal priority)
+        let selected = select_mirrors(entries.clone(), None, Some("stable"), false);
+        assert_eq!(
+            selected,
+            vec![
+                ResolvedMirror {
+                    url: "file:///local/repo".into(),
+                    source_type: MirrorSourceType::File,
+                },
+                ResolvedMirror {
+                    url: "http://m2.example.com".into(),
+                    source_type: MirrorSourceType::Http,
+                },
+                ResolvedMirror {
+                    url: "http://m3.example.com".into(),
+                    source_type: MirrorSourceType::Http,
+                },
+                ResolvedMirror {
+                    url: "http://m1.example.com".into(),
+                    source_type: MirrorSourceType::Http,
+                },
+            ]
+        );
+
+        // arch filter
+        let text = "http://m1.example.com/\tarch:arm64\nhttp://m2.example.com/\n";
+        let entries = parse_mirror_list(text, false);
+        let selected = select_mirrors(entries, Some("amd64"), None, false);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].url, "http://m2.example.com");
+    }
+}

--- a/oma-fetch/src/mirror.rs
+++ b/oma-fetch/src/mirror.rs
@@ -182,10 +182,13 @@ pub fn parse_mirror_list(text: &str, from_network: bool) -> Vec<MirrorEntry> {
 ///
 /// A mirror is kept when each of its tags matches the request attribute
 /// (`arch`, `suite`/`codename`/`release`, `type: deb`/`deb-src`); missing
-/// request attributes do not filter anything out.
+/// request attributes do not filter anything out. `archs` holds every
+/// architecture the request will cover (a source's `[arch=...]` option, or
+/// the native plus any foreign architectures): an entry with an `arch:` tag
+/// is kept when it names any of them.
 pub fn select_mirrors(
     mut entries: Vec<MirrorEntry>,
-    arch: Option<&str>,
+    archs: &[&str],
     suite: Option<&str>,
     is_source: bool,
 ) -> Vec<ResolvedMirror> {
@@ -202,8 +205,21 @@ pub fn select_mirrors(
         }
     }
 
+    fn tag_matches_any(
+        tags: &HashMap<Box<str>, Vec<Box<str>>>,
+        key: &str,
+        values: &[&str],
+    ) -> bool {
+        if values.is_empty() {
+            return true;
+        }
+        tags.get(key).is_none_or(|tagged| {
+            tagged.iter().any(|x| values.iter().any(|v| x.as_ref() == *v))
+        })
+    }
+
     entries.retain(|e| {
-        tag_matches(&e.tags, "arch", arch)
+        tag_matches_any(&e.tags, "arch", archs)
             && tag_matches(&e.tags, "release", suite)
             && tag_matches(
                 &e.tags,
@@ -280,7 +296,11 @@ pub async fn resolve_mirrors(
     is_source: bool,
 ) -> Result<Vec<ResolvedMirror>, MirrorError> {
     let entries = fetch_mirror_list(mirror_uri, client).await?;
-    Ok(select_mirrors(entries, arch, suite, is_source))
+    let archs: &[&str] = match &arch {
+        Some(arch) => std::slice::from_ref(arch),
+        None => &[],
+    };
+    Ok(select_mirrors(entries, archs, suite, is_source))
 }
 
 #[cfg(test)]
@@ -355,7 +375,7 @@ file:///local/repo\tpriority:0
         let entries = parse_mirror_list(text, false);
 
         // suite filter + priority ordering (stable within equal priority)
-        let selected = select_mirrors(entries.clone(), None, Some("stable"), false);
+        let selected = select_mirrors(entries.clone(), &[], Some("stable"), false);
         assert_eq!(
             selected,
             vec![
@@ -385,8 +405,23 @@ file:///local/repo\tpriority:0
         // arch filter
         let text = "http://m1.example.com/\tarch:arm64\nhttp://m2.example.com/\n";
         let entries = parse_mirror_list(text, false);
-        let selected = select_mirrors(entries, Some("amd64"), None, false);
+        let selected = select_mirrors(entries, &["amd64"], None, false);
         assert_eq!(selected.len(), 1);
         assert_eq!(selected[0].url, "http://m2.example.com");
+
+        // A source requesting a foreign architecture keeps that arch's
+        // mirrors: `arch:arm64` is not discarded just because the host is
+        // amd64, and a multiarch request covers every needed architecture.
+        let text = "\
+http://amd.example.com/\tarch:amd64
+http://arm.example.com/\tarch:arm64
+http://any.example.com/
+";
+        let entries = parse_mirror_list(text, false);
+        let selected = select_mirrors(entries.clone(), &["arm64"], None, false);
+        assert_eq!(selected.len(), 2);
+        assert!(selected.iter().all(|m| m.url != "http://amd.example.com"));
+        let selected = select_mirrors(entries, &["amd64", "arm64"], None, false);
+        assert_eq!(selected.len(), 3);
     }
 }

--- a/oma-fetch/src/mirror.rs
+++ b/oma-fetch/src/mirror.rs
@@ -223,15 +223,17 @@ pub fn select_mirrors(
         .collect()
 }
 
-/// Fetch (or read) and parse a mirror list, returning the resolved mirrors in
-/// priority order.
-pub async fn resolve_mirrors(
+/// Fetch (or read) and parse a mirror list into its entries, without
+/// applying any per-request filtering.
+///
+/// The parsed list can be cached and [`select_mirrors`] applied once per
+/// source — the selection depends on the request's `suite` and
+/// `deb`/`deb-src` type, so a list shared by several suites or by both
+/// `deb` and `deb-src` must be filtered per source, not once.
+pub async fn fetch_mirror_list(
     mirror_uri: &str,
     client: &ClientWithMiddleware,
-    arch: Option<&str>,
-    suite: Option<&str>,
-    is_source: bool,
-) -> Result<Vec<ResolvedMirror>, MirrorError> {
+) -> Result<Vec<MirrorEntry>, MirrorError> {
     let location = parse_mirror_uri(mirror_uri)?;
 
     let (text, from_network) = match location {
@@ -260,6 +262,19 @@ pub async fn resolve_mirrors(
         });
     }
 
+    Ok(entries)
+}
+
+/// Fetch (or read) a mirror list and return the resolved mirrors for one
+/// request, filtered by `arch`/`suite`/`is_source` and in priority order.
+pub async fn resolve_mirrors(
+    mirror_uri: &str,
+    client: &ClientWithMiddleware,
+    arch: Option<&str>,
+    suite: Option<&str>,
+    is_source: bool,
+) -> Result<Vec<ResolvedMirror>, MirrorError> {
+    let entries = fetch_mirror_list(mirror_uri, client).await?;
     Ok(select_mirrors(entries, arch, suite, is_source))
 }
 

--- a/oma-fetch/src/mirror.rs
+++ b/oma-fetch/src/mirror.rs
@@ -58,6 +58,10 @@ pub struct ResolvedMirror {
     /// Base URI with any trailing `/` stripped.
     pub url: String,
     pub source_type: MirrorSourceType,
+    /// The mirror list `priority:` tag (lower is preferred; untagged
+    /// entries default to `u64::MAX`). Preserved so callers can keep the
+    /// priority ordering even when the sources are sorted later.
+    pub priority: u64,
 }
 
 #[derive(Debug, Snafu)]
@@ -219,6 +223,7 @@ pub fn select_mirrors(
             } else {
                 MirrorSourceType::Http
             },
+            priority: e.priority,
         })
         .collect()
 }
@@ -357,18 +362,22 @@ file:///local/repo\tpriority:0
                 ResolvedMirror {
                     url: "file:///local/repo".into(),
                     source_type: MirrorSourceType::File,
+                    priority: 0,
                 },
                 ResolvedMirror {
                     url: "http://m2.example.com".into(),
                     source_type: MirrorSourceType::Http,
+                    priority: 1,
                 },
                 ResolvedMirror {
                     url: "http://m3.example.com".into(),
                     source_type: MirrorSourceType::Http,
+                    priority: 1,
                 },
                 ResolvedMirror {
                     url: "http://m1.example.com".into(),
                     source_type: MirrorSourceType::Http,
+                    priority: 2,
                 },
             ]
         );

--- a/oma-fetch/tests/bar_lifecycle.rs
+++ b/oma-fetch/tests/bar_lifecycle.rs
@@ -38,6 +38,7 @@ async fn every_bar_is_closed_on_request_timeout() {
     let source = DownloadSource {
         url: format!("http://127.0.0.1:{port}/pkg.deb"),
         source_type: DownloadSourceType::Http,
+        order: 0,
         priority: u64::MAX,
     };
     let entry = DownloadEntry::builder()

--- a/oma-fetch/tests/bar_lifecycle.rs
+++ b/oma-fetch/tests/bar_lifecycle.rs
@@ -38,6 +38,7 @@ async fn every_bar_is_closed_on_request_timeout() {
     let source = DownloadSource {
         url: format!("http://127.0.0.1:{port}/pkg.deb"),
         source_type: DownloadSourceType::Http,
+        priority: u64::MAX,
     };
     let entry = DownloadEntry::builder()
         .source(vec![source])

--- a/oma-fetch/tests/source_order.rs
+++ b/oma-fetch/tests/source_order.rs
@@ -49,6 +49,7 @@ async fn higher_priority_http_mirror_wins_over_lower_priority_local() {
             DownloadSource {
                 url: format!("http://127.0.0.1:{port}/pkg.deb"),
                 source_type: DownloadSourceType::Http,
+                order: 0,
                 priority: 1,
             },
             // Fallback: local `file:` mirror with lower priority. A
@@ -56,6 +57,7 @@ async fn higher_priority_http_mirror_wins_over_lower_priority_local() {
             DownloadSource {
                 url: format!("file://{}", local_file.display()),
                 source_type: DownloadSourceType::Local(false),
+                order: 0,
                 priority: 2,
             },
         ])
@@ -126,11 +128,13 @@ async fn local_source_is_tried_before_http_at_equal_priority() {
             DownloadSource {
                 url: format!("http://127.0.0.1:{port}/pkg.deb"),
                 source_type: DownloadSourceType::Http,
+                order: 0,
                 priority: u64::MAX,
             },
             DownloadSource {
                 url: format!("file://{}", local_file.display()),
                 source_type: DownloadSourceType::Local(false),
+                order: 0,
                 priority: u64::MAX,
             },
         ])
@@ -169,5 +173,76 @@ async fn local_source_is_tried_before_http_at_equal_priority() {
     assert_eq!(
         std::fs::read(work.join("partial/pkg.deb")).unwrap(),
         b"from-local"
+    );
+}
+
+/// The caller's alternate-URL order is preserved: a primary normal HTTP URL
+/// (order 0) is tried before a `mirror://` fallback's expansions (order 1),
+/// even though the mirror's priority number is much smaller — mirror
+/// priority only applies among expansions of the same mirror list.
+#[tokio::test]
+async fn primary_alternate_url_wins_over_mirror_priority() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let port = http_server(b"from-http").await;
+    let work = std::env::temp_dir().join(format!(
+        "oma-fetch-source-order-alt-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&work);
+    tokio::fs::create_dir_all(&work).await.unwrap();
+
+    let local_file = work.join("mirror.deb");
+    std::fs::write(&local_file, b"from-mirror").unwrap();
+
+    let entry = DownloadEntry::builder()
+        .source(vec![
+            // Primary: normal HTTP repository URL.
+            DownloadSource {
+                url: format!("http://127.0.0.1:{port}/pkg.deb"),
+                source_type: DownloadSourceType::Http,
+                order: 0,
+                priority: u64::MAX,
+            },
+            // Fallback: a `mirror://` expansion. Its tiny priority number
+            // must not promote it over the primary alternate.
+            DownloadSource {
+                url: format!("file://{}", local_file.display()),
+                source_type: DownloadSourceType::Local(false),
+                order: 1,
+                priority: 1,
+            },
+        ])
+        .filename("pkg.deb".to_string())
+        .dir(work.join("partial"))
+        .allow_resume(true)
+        .build();
+
+    let client = ClientBuilder::new().user_agent("oma").build().unwrap();
+    let (tx, rx) = flume::unbounded();
+    let download_manager = DownloadManager::builder()
+        .client(client.into())
+        .download_list(Box::new([entry]))
+        .threads(1)
+        .timeout(Duration::from_secs(5))
+        .build();
+
+    let summary = download_manager
+        .start_download(move |event| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send_async(event).await;
+            }
+        })
+        .await
+        .unwrap();
+
+    drop(rx);
+
+    assert_eq!(summary.success.len(), 1, "the primary URL should win");
+    assert!(
+        summary.success[0].url.starts_with(&format!("http://127.0.0.1:{port}/")),
+        "expected the primary HTTP source to be used, got: {}",
+        summary.success[0].url
     );
 }

--- a/oma-fetch/tests/source_order.rs
+++ b/oma-fetch/tests/source_order.rs
@@ -1,0 +1,173 @@
+use std::time::Duration;
+
+use oma_fetch::{DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType};
+use reqwest::ClientBuilder;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// A minimal HTTP server that serves the same fixed body for any request.
+async fn http_server(body: &'static [u8]) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let body = body.to_vec();
+    tokio::spawn(async move {
+        while let Ok((mut socket, _)) = listener.accept().await {
+            let body = body.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                let _ = socket.read(&mut buf).await;
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = socket.write_all(head.as_bytes()).await;
+                let _ = socket.write_all(&body).await;
+            });
+        }
+    });
+    port
+}
+
+/// A higher-priority HTTP mirror must be tried before a lower-priority
+/// local `file:` fallback: the download manager sorts by the mirror-list
+/// priority, not by transport (which would promote the local source).
+#[tokio::test]
+async fn higher_priority_http_mirror_wins_over_lower_priority_local() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let port = http_server(b"from-http").await;
+    let work = std::env::temp_dir().join(format!("oma-fetch-source-order-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&work);
+    tokio::fs::create_dir_all(&work).await.unwrap();
+
+    let local_file = work.join("local.deb");
+    std::fs::write(&local_file, b"from-local").unwrap();
+
+    let entry = DownloadEntry::builder()
+        .source(vec![
+            // Primary: HTTP mirror with higher priority.
+            DownloadSource {
+                url: format!("http://127.0.0.1:{port}/pkg.deb"),
+                source_type: DownloadSourceType::Http,
+                priority: 1,
+            },
+            // Fallback: local `file:` mirror with lower priority. A
+            // transport sort would promote this one first; priority must not.
+            DownloadSource {
+                url: format!("file://{}", local_file.display()),
+                source_type: DownloadSourceType::Local(false),
+                priority: 2,
+            },
+        ])
+        .filename("pkg.deb".to_string())
+        .dir(work.join("partial"))
+        .allow_resume(true)
+        .build();
+
+    let client = ClientBuilder::new().user_agent("oma").build().unwrap();
+    let (tx, rx) = flume::unbounded();
+    let download_manager = DownloadManager::builder()
+        .client(client.into())
+        .download_list(Box::new([entry]))
+        .threads(1)
+        .timeout(Duration::from_secs(5))
+        .build();
+
+    let summary = download_manager
+        .start_download(move |event| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send_async(event).await;
+            }
+        })
+        .await
+        .unwrap();
+
+    // Drain events so the manager's channels do not block.
+    drop(rx);
+
+    assert_eq!(summary.success.len(), 1, "the HTTP source should win");
+    let won = &summary.success[0];
+    assert!(
+        won.url.starts_with(&format!("http://127.0.0.1:{port}/")),
+        "expected the HTTP source to be used, got: {}",
+        won.url
+    );
+    // The body proves the HTTP source's content was written, not the local
+    // fallback's (which a transport sort would have promoted).
+    assert_eq!(
+        std::fs::read(work.join("partial/pkg.deb")).unwrap(),
+        b"from-http"
+    );
+}
+
+/// Non-mirror sources keep the transport preference: at equal priority a
+/// local `file:` source is tried before an HTTP one, even when the HTTP
+/// source is listed first.
+#[tokio::test]
+async fn local_source_is_tried_before_http_at_equal_priority() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let port = http_server(b"from-http").await;
+    let work = std::env::temp_dir().join(format!(
+        "oma-fetch-source-order-local-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&work);
+    tokio::fs::create_dir_all(&work).await.unwrap();
+
+    let local_file = work.join("local.deb");
+    std::fs::write(&local_file, b"from-local").unwrap();
+
+    let entry = DownloadEntry::builder()
+        .source(vec![
+            // HTTP listed first, but the local source must win at equal
+            // priority (the download manager prefers local transports).
+            DownloadSource {
+                url: format!("http://127.0.0.1:{port}/pkg.deb"),
+                source_type: DownloadSourceType::Http,
+                priority: u64::MAX,
+            },
+            DownloadSource {
+                url: format!("file://{}", local_file.display()),
+                source_type: DownloadSourceType::Local(false),
+                priority: u64::MAX,
+            },
+        ])
+        .filename("pkg.deb".to_string())
+        .dir(work.join("partial"))
+        .allow_resume(true)
+        .build();
+
+    let client = ClientBuilder::new().user_agent("oma").build().unwrap();
+    let (tx, rx) = flume::unbounded();
+    let download_manager = DownloadManager::builder()
+        .client(client.into())
+        .download_list(Box::new([entry]))
+        .threads(1)
+        .timeout(Duration::from_secs(5))
+        .build();
+
+    let summary = download_manager
+        .start_download(move |event| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send_async(event).await;
+            }
+        })
+        .await
+        .unwrap();
+
+    drop(rx);
+
+    assert_eq!(summary.success.len(), 1, "the local source should win");
+    assert!(
+        summary.success[0].url.starts_with("file://"),
+        "expected the local source to be used, got: {}",
+        summary.success[0].url
+    );
+    assert_eq!(
+        std::fs::read(work.join("partial/pkg.deb")).unwrap(),
+        b"from-local"
+    );
+}

--- a/oma-pm/src/apt.rs
+++ b/oma-pm/src/apt.rs
@@ -172,6 +172,8 @@ pub enum OmaAptError {
     #[error("recv async event error")]
     RecvError,
     #[error(transparent)]
+    Mirror(#[from] oma_fetch::mirror::MirrorError),
+    #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
 }
 

--- a/oma-pm/src/download.rs
+++ b/oma-pm/src/download.rs
@@ -25,12 +25,15 @@ fn is_mirror_uri(uri: &str) -> bool {
 /// Expand a mirrored package URL (`download_url`) into one `DownloadSource`
 /// per resolved mirror. `index_url` is the source's base URI (`mirror://...`,
 /// with a trailing `/`), which `download_url` starts with; the remainder is
-/// the path inside the repository.
+/// the path inside the repository. All expansions share `order` — the index
+/// of this URL among the package's alternates — so mirror priority is only
+/// compared between mirrors of this same list.
 fn mirror_download_sources(
     download_url: &str,
     index_url: &str,
     mirrors: &[ResolvedMirror],
     download_only: bool,
+    order: usize,
 ) -> Vec<DownloadSource> {
     let suffix = download_url.strip_prefix(index_url).unwrap_or(download_url);
 
@@ -52,9 +55,11 @@ fn mirror_download_sources(
             DownloadSource {
                 url,
                 source_type,
+                order,
                 // Keep the mirror list's priority so the download manager
                 // tries higher-priority mirrors (even HTTP) before
-                // lower-priority ones (even local `file:` fallbacks).
+                // lower-priority ones (even local `file:` fallbacks) —
+                // among expansions of this same list only.
                 priority: m.priority,
             }
         })
@@ -103,7 +108,11 @@ pub async fn download_pkgs(
         let uris = entry.pkg_urls();
         let mut sources = vec![];
 
-        for x in uris.iter() {
+        // `uris` are the package's alternate URLs in the caller's order
+        // (primary first). Every source of one URL shares its `order`, so
+        // the alternates keep that order and mirror priority is only ever
+        // compared between expansions of the same mirror list.
+        for (order, x) in uris.iter().enumerate() {
             if is_mirror_uri(&x.download_url) {
                 // `index_url` is the source's base URI (e.g. `mirror://...`,
                 // with a trailing `/`); resolve the mirror list and expand
@@ -124,18 +133,21 @@ pub async fn download_pkgs(
                     &x.index_url,
                     &mirrors,
                     download_only,
+                    order,
                 ));
             } else if x.index_url.starts_with("file:") {
                 // Local sources are preferred over HTTP ones.
                 sources.push(DownloadSource {
                     url: url_no_escape_times(&x.download_url, 1),
                     source_type: DownloadSourceType::Local(!download_only),
+                    order,
                     priority: 0,
                 });
             } else {
                 sources.push(DownloadSource {
                     url: x.download_url.clone(),
                     source_type: DownloadSourceType::Http,
+                    order,
                     priority: u64::MAX,
                 });
             }
@@ -255,6 +267,7 @@ mod tests {
             "mirror+http://host/list/",
             &mirrors,
             false,
+            2,
         );
 
         assert_eq!(sources.len(), 2);
@@ -263,8 +276,10 @@ mod tests {
             "http://m1.example.com/debian/pool/main/a/apt_1_amd64.deb"
         );
         assert_eq!(sources[0].source_type, DownloadSourceType::Http);
-        // The mirror-list priority survives onto each source.
+        // The mirror-list priority survives onto each source, scoped to the
+        // caller's alternate-URL order.
         assert_eq!(sources[0].priority, 1);
+        assert_eq!(sources[0].order, 2);
         assert!(
             sources[1]
                 .url

--- a/oma-pm/src/download.rs
+++ b/oma-pm/src/download.rs
@@ -4,6 +4,7 @@ use flume::Sender;
 use oma_fetch::{
     DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType, Event, Summary,
     checksum::Checksum,
+    mirror::{MirrorSourceType, ResolvedMirror, resolve_mirrors},
 };
 use oma_pm_operation_type::InstallEntry;
 use oma_utils::url_no_escape::url_no_escape_times;
@@ -14,6 +15,44 @@ use crate::{
     CustomDownloadMessage,
     apt::{DownloadConfig, OmaAptError, OmaAptResult},
 };
+
+/// Whether a URL uses the apt `mirror://` protocol (mirror, mirror+http(s),
+/// mirror+file).
+fn is_mirror_uri(uri: &str) -> bool {
+    uri.starts_with("mirror:") || uri.starts_with("mirror+")
+}
+
+/// Expand a mirrored package URL (`download_url`) into one `DownloadSource`
+/// per resolved mirror. `index_url` is the source's base URI (`mirror://...`,
+/// with a trailing `/`), which `download_url` starts with; the remainder is
+/// the path inside the repository.
+fn mirror_download_sources(
+    download_url: &str,
+    index_url: &str,
+    mirrors: &[ResolvedMirror],
+    download_only: bool,
+) -> Vec<DownloadSource> {
+    let suffix = download_url.strip_prefix(index_url).unwrap_or(download_url);
+
+    mirrors
+        .iter()
+        .map(|m| {
+            let url = format!(
+                "{}/{}",
+                m.url.trim_end_matches('/'),
+                suffix.trim_start_matches('/')
+            );
+            let (source_type, url) = match m.source_type {
+                MirrorSourceType::Http => (DownloadSourceType::Http, url),
+                MirrorSourceType::File => (
+                    DownloadSourceType::Local(!download_only),
+                    url_no_escape_times(&url, 1),
+                ),
+            };
+            DownloadSource { url, source_type }
+        })
+        .collect()
+}
 
 /// Download packages (inner)
 pub async fn download_pkgs(
@@ -49,21 +88,34 @@ pub async fn download_pkgs(
 
     for entry in download_pkg_list.iter() {
         let uris = entry.pkg_urls();
-        let sources = uris
-            .iter()
-            .map(|x| {
-                let (source_type, url) = if x.index_url.starts_with("file:") {
-                    (
-                        DownloadSourceType::Local(!download_only),
-                        url_no_escape_times(&x.download_url, 1),
-                    )
-                } else {
-                    (DownloadSourceType::Http, x.download_url.clone())
-                };
+        let mut sources = vec![];
 
-                DownloadSource { url, source_type }
-            })
-            .collect::<Vec<_>>();
+        for x in uris.iter() {
+            if is_mirror_uri(&x.download_url) {
+                // `index_url` is the source's base URI (e.g. `mirror://...`,
+                // with a trailing `/`); resolve the mirror list and expand
+                // into one `DownloadSource` per mirror. The download manager
+                // tries the sources in order, so later mirrors are the
+                // fallbacks (apt's Alternate-URIs behavior).
+                let mirrors = resolve_mirrors(&x.index_url, &client, None, None, false).await?;
+                sources.extend(mirror_download_sources(
+                    &x.download_url,
+                    &x.index_url,
+                    &mirrors,
+                    download_only,
+                ));
+            } else if x.index_url.starts_with("file:") {
+                sources.push(DownloadSource {
+                    url: url_no_escape_times(&x.download_url, 1),
+                    source_type: DownloadSourceType::Local(!download_only),
+                });
+            } else {
+                sources.push(DownloadSource {
+                    url: x.download_url.clone(),
+                    source_type: DownloadSourceType::Http,
+                });
+            }
+        }
 
         debug!("Sources is: {:?}", sources);
 
@@ -140,4 +192,56 @@ fn apt_style_filename(entry: &InstallEntry) -> String {
     let version = version.replace(':', "%3a");
 
     format!("{package}_{version}_{arch}.deb").replace("%2b", "+")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_mirror_uri() {
+        assert!(is_mirror_uri("mirror://host/list"));
+        assert!(is_mirror_uri("mirror+http://host/list"));
+        assert!(is_mirror_uri("mirror+https://host/list"));
+        assert!(is_mirror_uri("mirror+file:///path"));
+        assert!(!is_mirror_uri("http://host"));
+        assert!(!is_mirror_uri("https://host"));
+        assert!(!is_mirror_uri("file:///path"));
+    }
+
+    #[test]
+    fn test_mirror_download_sources() {
+        let mirrors = vec![
+            ResolvedMirror {
+                url: "http://m1.example.com/debian/".into(),
+                source_type: MirrorSourceType::Http,
+            },
+            ResolvedMirror {
+                url: "file:///local/repo".into(),
+                source_type: MirrorSourceType::File,
+            },
+        ];
+
+        // `index_url` is the mirror base URI (with trailing `/`); the
+        // download URL is the same base plus the pool path.
+        let sources = mirror_download_sources(
+            "mirror+http://host/list/pool/main/a/apt_1_amd64.deb",
+            "mirror+http://host/list/",
+            &mirrors,
+            false,
+        );
+
+        assert_eq!(sources.len(), 2);
+        assert_eq!(
+            sources[0].url,
+            "http://m1.example.com/debian/pool/main/a/apt_1_amd64.deb"
+        );
+        assert_eq!(sources[0].source_type, DownloadSourceType::Http);
+        assert!(
+            sources[1]
+                .url
+                .starts_with("file:///local/repo/pool/main/a/apt_1_amd64.deb")
+        );
+        assert_eq!(sources[1].source_type, DownloadSourceType::Local(true));
+    }
 }

--- a/oma-pm/src/download.rs
+++ b/oma-pm/src/download.rs
@@ -49,7 +49,14 @@ fn mirror_download_sources(
                     url_no_escape_times(&url, 1),
                 ),
             };
-            DownloadSource { url, source_type }
+            DownloadSource {
+                url,
+                source_type,
+                // Keep the mirror list's priority so the download manager
+                // tries higher-priority mirrors (even HTTP) before
+                // lower-priority ones (even local `file:` fallbacks).
+                priority: m.priority,
+            }
         })
         .collect()
 }
@@ -119,14 +126,17 @@ pub async fn download_pkgs(
                     download_only,
                 ));
             } else if x.index_url.starts_with("file:") {
+                // Local sources are preferred over HTTP ones.
                 sources.push(DownloadSource {
                     url: url_no_escape_times(&x.download_url, 1),
                     source_type: DownloadSourceType::Local(!download_only),
+                    priority: 0,
                 });
             } else {
                 sources.push(DownloadSource {
                     url: x.download_url.clone(),
                     source_type: DownloadSourceType::Http,
+                    priority: u64::MAX,
                 });
             }
         }
@@ -229,10 +239,12 @@ mod tests {
             ResolvedMirror {
                 url: "http://m1.example.com/debian/".into(),
                 source_type: MirrorSourceType::Http,
+                priority: 1,
             },
             ResolvedMirror {
                 url: "file:///local/repo".into(),
                 source_type: MirrorSourceType::File,
+                priority: 2,
             },
         ];
 
@@ -251,11 +263,14 @@ mod tests {
             "http://m1.example.com/debian/pool/main/a/apt_1_amd64.deb"
         );
         assert_eq!(sources[0].source_type, DownloadSourceType::Http);
+        // The mirror-list priority survives onto each source.
+        assert_eq!(sources[0].priority, 1);
         assert!(
             sources[1]
                 .url
                 .starts_with("file:///local/repo/pool/main/a/apt_1_amd64.deb")
         );
         assert_eq!(sources[1].source_type, DownloadSourceType::Local(true));
+        assert_eq!(sources[1].priority, 2);
     }
 }

--- a/oma-pm/src/download.rs
+++ b/oma-pm/src/download.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use flume::Sender;
 use oma_fetch::{
@@ -86,6 +86,12 @@ pub async fn download_pkgs(
     let mut download_list = vec![];
     let mut total_size = 0;
 
+    // Resolve each distinct mirror list once and reuse it for every package
+    // from the same source: a large install/upgrade can otherwise fetch and
+    // parse the same `mirror://` list once per package, sequentially, and a
+    // single transient failure on a repeat would abort the whole download.
+    let mut resolved_mirrors: HashMap<String, Vec<ResolvedMirror>> = HashMap::new();
+
     for entry in download_pkg_list.iter() {
         let uris = entry.pkg_urls();
         let mut sources = vec![];
@@ -97,7 +103,15 @@ pub async fn download_pkgs(
                 // into one `DownloadSource` per mirror. The download manager
                 // tries the sources in order, so later mirrors are the
                 // fallbacks (apt's Alternate-URIs behavior).
-                let mirrors = resolve_mirrors(&x.index_url, &client, None, None, false).await?;
+                let mirrors = match resolved_mirrors.get(&x.index_url) {
+                    Some(mirrors) => mirrors.clone(),
+                    None => {
+                        let mirrors =
+                            resolve_mirrors(&x.index_url, &client, None, None, false).await?;
+                        resolved_mirrors.insert(x.index_url.clone(), mirrors.clone());
+                        mirrors
+                    }
+                };
                 sources.extend(mirror_download_sources(
                     &x.download_url,
                     &x.index_url,

--- a/oma-pm/src/download.rs
+++ b/oma-pm/src/download.rs
@@ -98,13 +98,26 @@ pub async fn download_pkgs(
     let mut download_list = vec![];
     let mut total_size = 0;
 
-    // Resolve each distinct mirror list once and reuse it for every package
-    // from the same source: a large install/upgrade can otherwise fetch and
-    // parse the same `mirror://` list once per package, sequentially, and a
-    // single transient failure on a repeat would abort the whole download.
-    let mut resolved_mirrors: HashMap<String, Vec<ResolvedMirror>> = HashMap::new();
+    // Resolve each distinct mirror list once per (URI, architecture) and
+    // reuse it for every package from the same source and arch: a large
+    // install/upgrade can otherwise fetch and parse the same `mirror://`
+    // list once per package, sequentially, and a single transient failure
+    // on a repeat would abort the whole download.
+    let mut resolved_mirrors: HashMap<(String, String), Vec<ResolvedMirror>> = HashMap::new();
 
     for entry in download_pkg_list.iter() {
+        let arch = entry.arch();
+        // Select mirrors for this package's architecture so `arch:`-tagged
+        // mirrors of other architectures are not tried first (an amd64
+        // package must not be attempted against a higher-priority
+        // `arch:arm64` mirror). `all`/`any` packages are served by any
+        // mirror, so they keep the unfiltered selection.
+        let arch_filter = if arch == "all" || arch == "any" {
+            None
+        } else {
+            Some(arch)
+        };
+
         let uris = entry.pkg_urls();
         let mut sources = vec![];
 
@@ -119,12 +132,13 @@ pub async fn download_pkgs(
                 // into one `DownloadSource` per mirror. The download manager
                 // tries the sources in order, so later mirrors are the
                 // fallbacks (apt's Alternate-URIs behavior).
-                let mirrors = match resolved_mirrors.get(&x.index_url) {
+                let key = (x.index_url.clone(), arch.to_string());
+                let mirrors = match resolved_mirrors.get(&key) {
                     Some(mirrors) => mirrors.clone(),
                     None => {
                         let mirrors =
-                            resolve_mirrors(&x.index_url, &client, None, None, false).await?;
-                        resolved_mirrors.insert(x.index_url.clone(), mirrors.clone());
+                            resolve_mirrors(&x.index_url, &client, arch_filter, None, false).await?;
+                        resolved_mirrors.insert(key, mirrors.clone());
                         mirrors
                     }
                 };

--- a/oma-refresh/Cargo.toml
+++ b/oma-refresh/Cargo.toml
@@ -52,6 +52,7 @@ default = ["aosc", "sequoia-nettle-backend", "rustls"]
 flume = { workspace = true }
 oma-utils = { workspace = true, features = ["dpkg"] }
 rustls = { workspace = true }
+tempfile = "3"
 
 [[example]]
 name = "update"

--- a/oma-refresh/Cargo.toml
+++ b/oma-refresh/Cargo.toml
@@ -53,6 +53,7 @@ flume = { workspace = true }
 oma-utils = { workspace = true, features = ["dpkg"] }
 rustls = { workspace = true }
 tempfile = "3"
+tokio = { workspace = true, features = ["net", "io-util"] }
 
 [[example]]
 name = "update"

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -387,8 +387,7 @@ impl OmaRefresh {
                 let entries = if let Some(cached) = parsed.get(&uri) {
                     cached.clone()
                 } else {
-                    let entries =
-                        oma_fetch::mirror::fetch_mirror_list(&uri, &self.client).await?;
+                    let entries = oma_fetch::mirror::fetch_mirror_list(&uri, &self.client).await?;
                     parsed.insert(uri, entries.clone());
                     entries
                 };

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -14,9 +14,10 @@ use flume::Sender;
 use oma_apt_pkg::AptConfig;
 use oma_apt_sources_lists::SourcesListError;
 use oma_fetch::{
-    CompressType, DownloadEntry, DownloadManager, DownloadSource, DownloadSourceType,
+    CompressType, DownloadEntry, DownloadManager,
     checksum::{Checksum, ChecksumError},
     download::{BuilderError, SuccessSummary},
+    mirror::ResolvedMirror,
     reqwest::{
         Response,
         header::{CONTENT_LENGTH, HeaderValue},
@@ -45,7 +46,7 @@ use crate::{
         ChecksumItem, InReleaseChecksum, InReleaseError, Release, file_is_compress,
         split_ext_and_filename, verify_inrelease,
     },
-    sourceslist::{OmaSourceEntry, OmaSourceEntryFrom},
+    sourceslist::OmaSourceEntry,
     util::url_to_list_filename,
 };
 
@@ -59,6 +60,8 @@ pub enum RefreshError {
     ScanSourceError(SourcesListError),
     #[error("Unsupported Protocol: {0}")]
     UnsupportedProtocol(String),
+    #[error(transparent)]
+    MirrorResolve(#[from] oma_fetch::mirror::MirrorError),
     #[error("Failed to download some metadata")]
     DownloadFailed(Option<SingleDownloadError>),
     #[cfg(feature = "aosc")]
@@ -361,11 +364,48 @@ impl OmaRefresh {
         }
     }
 
+    /// Resolve the mirror lists of all `mirror://` sources, once per source
+    /// URI, storing the ordered mirrors on each entry before any download
+    /// starts (so downstream code only ever sees concrete URLs).
+    async fn resolve_mirror_sources(&self, mirror_sources: &mut MirrorSources) -> Result<()> {
+        let mut resolved: AHashMap<String, Vec<ResolvedMirror>> = AHashMap::new();
+
+        for m in &mut mirror_sources.0 {
+            for source in &m.sources {
+                if !source.is_mirror() || source.mirrors().is_some() {
+                    continue;
+                }
+
+                let uri = source.url().to_string();
+                let mirrors = if let Some(cached) = resolved.get(&uri) {
+                    cached.clone()
+                } else {
+                    let mirrors = oma_fetch::mirror::resolve_mirrors(
+                        &uri,
+                        &self.client,
+                        Some(&self.arch),
+                        Some(source.suite()),
+                        source.is_source(),
+                    )
+                    .await?;
+                    resolved.insert(uri, mirrors.clone());
+                    mirrors
+                };
+
+                source.set_mirrors(mirrors);
+            }
+        }
+
+        Ok(())
+    }
+
     async fn download_releases(
         &self,
         mut mirror_sources: MirrorSources,
         sender: Sender<Event>,
     ) -> Result<(MirrorSources, Vec<Url>)> {
+        self.resolve_mirror_sources(&mut mirror_sources).await?;
+
         #[cfg(feature = "aosc")]
         let mut not_found = vec![];
 
@@ -724,18 +764,10 @@ fn collect_flat_repo_no_release(
 
     let dist_url = mirror_source.dist_path();
 
-    let from = match mirror_source.from()? {
-        OmaSourceEntryFrom::Http => DownloadSourceType::Http,
-        OmaSourceEntryFrom::Local => DownloadSourceType::Local(mirror_source.is_flat()),
-    };
-
     let download_url = format!("{dist_url}/Packages");
     let file_path = format!("{dist_url}Packages");
 
-    let sources = vec![DownloadSource {
-        url: download_url.clone(),
-        source_type: from,
-    }];
+    let sources = mirror_source.download_sources_for(&download_url, mirror_source.is_flat())?;
 
     let task = DownloadEntry::builder()
         .source(sources)
@@ -763,14 +795,8 @@ fn collect_download_task(
 
     let msg = mirror_source.get_human_download_message(Some(file_type))?;
 
-    let from = match mirror_source.from()? {
-        OmaSourceEntryFrom::Http => DownloadSourceType::Http,
-        OmaSourceEntryFrom::Local => DownloadSourceType::Local(
-            mirror_source.is_flat()
-                && (!file_is_compress(&c.item.name)
-                    || (file_is_compress(&c.item.name) && c.keep_compress)),
-        ),
-    };
+    let local_as_symlink = mirror_source.is_flat()
+        && (!file_is_compress(&c.item.name) || (file_is_compress(&c.item.name) && c.keep_compress));
 
     let not_compress_filename_before = if file_is_compress(&c.item.name) {
         Cow::Owned(split_ext_and_filename(&c.item.name).1)
@@ -807,16 +833,12 @@ fn collect_download_task(
 
         let path = parent.join("by-hash").join(dir).join(&c.item.checksum);
 
-        sources.push(DownloadSource {
-            url: mirror_source.get_download_url(&path.display().to_string()),
-            source_type: from.clone(),
-        });
+        let url = mirror_source.get_download_url(&path.display().to_string());
+        sources.extend(mirror_source.download_sources_for(&url, local_as_symlink)?);
     }
 
-    sources.push(DownloadSource {
-        url: mirror_source.get_download_url(&c.item.name),
-        source_type: from,
-    });
+    let url = mirror_source.get_download_url(&c.item.name);
+    sources.extend(mirror_source.download_sources_for(&url, local_as_symlink)?);
 
     let file_name = if c.keep_compress {
         mirror_source.get_download_file_name(Some(&c.item.name))?

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -549,6 +549,9 @@ impl OmaRefresh {
 
         let mut flat_repo_no_release = vec![];
         let mut optional_index_files = HashSet::with_hasher(ahash::RandomState::new());
+        // Flat repos without a release file: at most one task per
+        // destination file, so entries sharing a dist path cannot race.
+        let mut flat_emitted: HashSet<String> = HashSet::with_hasher(ahash::RandomState::new());
 
         for m in &mirror_sources.0 {
             if m.file_name().is_none() {
@@ -557,7 +560,12 @@ impl OmaRefresh {
         }
         for m in flat_repo_no_release {
             for source in &m.sources {
-                collect_flat_repo_no_release(source, &self.download_dir, &mut tasks)?;
+                collect_flat_repo_no_release(
+                    source,
+                    &self.download_dir,
+                    &mut tasks,
+                    &mut flat_emitted,
+                )?;
             }
         }
 
@@ -794,19 +802,33 @@ fn collect_flat_repo_no_release(
     source: &OmaSourceEntry,
     download_dir: &Path,
     tasks: &mut Vec<DownloadEntry>,
+    seen: &mut HashSet<String>,
 ) -> Result<()> {
-    let msg = source.get_human_download_url(Some("Packages"))?;
+    // A flat repo has no release file; its binary and source indexes live
+    // side by side (`Packages` vs `Sources`), so pick the index for this
+    // entry's type — a deb-src entry must fetch `Sources`, not `Packages`.
+    let index = if source.is_source() { "Sources" } else { "Packages" };
 
     let dist_url = source.dist_path();
+    let file_path = format!("{dist_url}{index}");
+    let filename = url_to_list_filename(&file_path)?;
 
-    let download_url = format!("{dist_url}/Packages");
-    let file_path = format!("{dist_url}Packages");
+    // Emit at most one task per destination: entries sharing a dist path
+    // (e.g. paired `deb` + `deb-src` lines) would otherwise queue two
+    // tasks for the same file and race while the download manager runs
+    // them concurrently.
+    if !seen.insert(filename.clone()) {
+        return Ok(());
+    }
+
+    let msg = source.get_human_download_url(Some(index))?;
+    let download_url = format!("{dist_url}/{index}");
 
     let sources = source.download_sources_for(&download_url, source.is_flat())?;
 
     let task = DownloadEntry::builder()
         .source(sources)
-        .filename(url_to_list_filename(&file_path)?)
+        .filename(filename)
         .dir(download_dir.to_path_buf())
         .allow_resume(false)
         .msg(msg.into())
@@ -947,4 +969,58 @@ where
     result_rx
         .recv()
         .map_err(|_| RefreshError::DownloadFailed(None))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oma_apt_sources_lists::SourceEntry;
+    use oma_fetch::mirror::{MirrorSourceType, ResolvedMirror};
+
+    use crate::sourceslist::OmaSourceEntry;
+
+    fn flat_source(entry: SourceEntry) -> OmaSourceEntry {
+        let ose = OmaSourceEntry::new(entry, Arc::from("amd64"));
+        ose.set_mirrors(vec![ResolvedMirror {
+            url: "http://m.example.com/repo".into(),
+            source_type: MirrorSourceType::Http,
+            priority: 1,
+        }]);
+        ose
+    }
+
+    #[test]
+    fn flat_repo_emits_distinct_tasks_per_type_and_dedups_destinations() {
+        let download_dir = tempfile::tempdir().unwrap();
+
+        let deb: SourceEntry = "deb mirror+file:///etc/apt/mirrors.test ./"
+            .parse()
+            .unwrap();
+        let deb_src: SourceEntry = "deb-src mirror+file:///etc/apt/mirrors.test ./"
+            .parse()
+            .unwrap();
+        let deb = flat_source(deb);
+        let deb_src = flat_source(deb_src);
+
+        let mut tasks = vec![];
+        let mut seen = HashSet::with_hasher(ahash::RandomState::new());
+        collect_flat_repo_no_release(&deb, download_dir.path(), &mut tasks, &mut seen).unwrap();
+        collect_flat_repo_no_release(&deb_src, download_dir.path(), &mut tasks, &mut seen).unwrap();
+
+        // One task per source type, with distinct destinations (`Packages`
+        // vs `Sources`) so the download manager cannot race on one file.
+        assert_eq!(tasks.len(), 2);
+        let mut names = tasks.iter().map(|t| t.filename.as_str()).collect::<Vec<_>>();
+        names.sort_unstable();
+        assert!(names[0].ends_with("Packages"), "got {names:?}");
+        assert!(names[1].ends_with("Sources"), "got {names:?}");
+        assert_ne!(names[0], names[1]);
+
+        // A duplicate entry must not queue a second task for the same file.
+        let mut tasks2 = vec![];
+        let mut seen2 = HashSet::with_hasher(ahash::RandomState::new());
+        collect_flat_repo_no_release(&deb, download_dir.path(), &mut tasks2, &mut seen2).unwrap();
+        collect_flat_repo_no_release(&deb, download_dir.path(), &mut tasks2, &mut seen2).unwrap();
+        assert_eq!(tasks2.len(), 1);
+    }
 }

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -17,7 +17,7 @@ use oma_fetch::{
     CompressType, DownloadEntry, DownloadManager,
     checksum::{Checksum, ChecksumError},
     download::{BuilderError, SuccessSummary},
-    mirror::ResolvedMirror,
+    mirror::{MirrorEntry, select_mirrors},
     reqwest::{
         Response,
         header::{CONTENT_LENGTH, HeaderValue},
@@ -364,11 +364,18 @@ impl OmaRefresh {
         }
     }
 
-    /// Resolve the mirror lists of all `mirror://` sources, once per source
-    /// URI, storing the ordered mirrors on each entry before any download
-    /// starts (so downstream code only ever sees concrete URLs).
+    /// Resolve the mirror lists of all `mirror://` sources, fetching each
+    /// list once per source URI and storing the ordered mirrors on each
+    /// entry before any download starts (so downstream code only ever sees
+    /// concrete URLs).
+    ///
+    /// The fetched/parsed list is cached per URI, but the mirrors are
+    /// *selected* per source: selection filters by the source's suite and
+    /// `deb`/`deb-src` type, so caching the already-selected mirrors by URI
+    /// would reuse the first source's filter for every later source sharing
+    /// the list.
     async fn resolve_mirror_sources(&self, mirror_sources: &mut MirrorSources) -> Result<()> {
-        let mut resolved: AHashMap<String, Vec<ResolvedMirror>> = AHashMap::new();
+        let mut parsed: AHashMap<String, Vec<MirrorEntry>> = AHashMap::new();
 
         for m in &mut mirror_sources.0 {
             for source in &m.sources {
@@ -377,21 +384,21 @@ impl OmaRefresh {
                 }
 
                 let uri = source.url().to_string();
-                let mirrors = if let Some(cached) = resolved.get(&uri) {
+                let entries = if let Some(cached) = parsed.get(&uri) {
                     cached.clone()
                 } else {
-                    let mirrors = oma_fetch::mirror::resolve_mirrors(
-                        &uri,
-                        &self.client,
-                        Some(&self.arch),
-                        Some(source.suite()),
-                        source.is_source(),
-                    )
-                    .await?;
-                    resolved.insert(uri, mirrors.clone());
-                    mirrors
+                    let entries =
+                        oma_fetch::mirror::fetch_mirror_list(&uri, &self.client).await?;
+                    parsed.insert(uri, entries.clone());
+                    entries
                 };
 
+                let mirrors = select_mirrors(
+                    entries,
+                    Some(&self.arch),
+                    Some(source.suite()),
+                    source.is_source(),
+                );
                 source.set_mirrors(mirrors);
             }
         }

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -376,6 +376,11 @@ impl OmaRefresh {
     /// the list.
     async fn resolve_mirror_sources(&self, mirror_sources: &mut MirrorSources) -> Result<()> {
         let mut parsed: AHashMap<String, Vec<MirrorEntry>> = AHashMap::new();
+        // Indexes are requested for a source's `[arch=...]` option, or for
+        // every locally-configured architecture; select mirrors for that
+        // whole set so `arch:`-tagged mirrors of a foreign architecture are
+        // not discarded just because the host is another arch.
+        let local_archs = local_archs(&self.arch);
 
         for m in &mut mirror_sources.0 {
             for source in &m.sources {
@@ -392,9 +397,17 @@ impl OmaRefresh {
                     entries
                 };
 
+                let archs: Vec<&str> = if let Some(archs) = source.archs()
+                    && !archs.is_empty()
+                {
+                    archs.iter().map(String::as_str).collect()
+                } else {
+                    local_archs.iter().map(String::as_str).collect()
+                };
+
                 let mirrors = select_mirrors(
                     entries,
-                    Some(&self.arch),
+                    &archs,
                     Some(source.suite()),
                     source.is_source(),
                 );
@@ -532,10 +545,7 @@ impl OmaRefresh {
 
         let index_target_config = IndexTargetConfig::new_from_apt_config(apt_cfg, &self.arch);
 
-        let archs_from_file = std::fs::read_to_string("/var/lib/dpkg/arch")
-            .ok()
-            .map(|file| file.lines().map(|x| x.to_string()).collect::<Vec<_>>())
-            .filter(|res| !res.is_empty());
+        let arch_from_local_configure = local_archs(&self.arch);
 
         let mut flat_repo_no_release = vec![];
         let mut optional_index_files = HashSet::with_hasher(ahash::RandomState::new());
@@ -593,18 +603,14 @@ impl OmaRefresh {
             // 仓库在 `Architectures:` 字段中声明的架构；若字段缺失则视为支持全部架构。
             let supported_archs = release.supported_architectures();
 
-            let arch_from_local_configure = if let Some(ref f) = archs_from_file {
-                f.iter().map(|x| x.as_str()).collect::<Vec<_>>()
-            } else {
-                vec![self.arch.as_str()]
-            };
-
             for ose in &m.sources {
                 let archs = if let Some(archs) = ose.archs()
                     && !archs.is_empty()
                 {
                     let archs = archs.iter().map(|x| x.as_str()).collect::<Vec<_>>();
-                    if arch_from_local_configure.iter().all(|x| !archs.contains(x))
+                    if arch_from_local_configure
+                        .iter()
+                        .all(|x| !archs.contains(&x.as_str()))
                         && !archs.contains(&"all")
                         && !archs.contains(&"any")
                     {
@@ -615,7 +621,7 @@ impl OmaRefresh {
                     }
                     archs
                 } else {
-                    arch_from_local_configure.clone()
+                    arch_from_local_configure.iter().map(String::as_str).collect()
                 };
 
                 let download_list = index_target_config.get_download_list(
@@ -661,6 +667,16 @@ pub fn content_length(resp: &Response) -> u64 {
         .ok()
         .and_then(|x| x.parse::<u64>().ok())
         .unwrap_or_default()
+}
+
+/// The architectures the local system is configured for: the native arch
+/// plus any foreign architectures listed in `/var/lib/dpkg/arch`.
+fn local_archs(host_arch: &str) -> Vec<String> {
+    std::fs::read_to_string("/var/lib/dpkg/arch")
+        .ok()
+        .map(|file| file.lines().map(|x| x.to_string()).collect::<Vec<_>>())
+        .filter(|res| !res.is_empty())
+        .unwrap_or_else(|| vec![host_arch.to_string()])
 }
 
 fn detect_duplicate_repositories(sourcelist: &[OmaSourceEntry]) -> Result<()> {

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -39,7 +39,7 @@ use url::Url;
 
 use oma_apt_pkg::apt_sources::{SourceLookup, scan_sources_list_paths};
 
-use crate::sourceslist::{MirrorSource, MirrorSources};
+use crate::sourceslist::MirrorSources;
 use crate::{
     config::{ChecksumDownloadEntry, IndexTargetConfig},
     inrelease::{
@@ -545,8 +545,10 @@ impl OmaRefresh {
                 flat_repo_no_release.push(m);
             }
         }
-        for i in flat_repo_no_release {
-            collect_flat_repo_no_release(i, &self.download_dir, &mut tasks)?;
+        for m in flat_repo_no_release {
+            for source in &m.sources {
+                collect_flat_repo_no_release(source, &self.download_dir, &mut tasks)?;
+            }
         }
 
         for m in &mirror_sources.0 {
@@ -625,18 +627,21 @@ impl OmaRefresh {
                     ose.components(),
                     supported_archs.as_deref(),
                 )?;
-                get_all_need_db_from_config(download_list, &mut total, checksums, &mut handle);
-            }
-
-            for c in &handle {
-                collect_download_task(
-                    c,
-                    m,
-                    &self.download_dir,
-                    &mut tasks,
-                    &release,
-                    &mut optional_index_files,
-                )?;
+                // Build each index task from the source that produced it:
+                // a group may hold both `deb` and `deb-src` entries whose
+                // mirror selections differ (`type:deb` / `type:deb-src`).
+                let new_entries =
+                    get_all_need_db_from_config(download_list, &mut total, checksums, &mut handle);
+                for c in &new_entries {
+                    collect_download_task(
+                        c,
+                        ose,
+                        &self.download_dir,
+                        &mut tasks,
+                        &release,
+                        &mut optional_index_files,
+                    )?;
+                }
             }
         }
 
@@ -695,12 +700,17 @@ fn detect_duplicate_repositories(sourcelist: &[OmaSourceEntry]) -> Result<()> {
     Ok(())
 }
 
+/// Deduplicate `filter_checksums` against `handle` (counting each new
+/// entry's size into `total`) and return the new entries, so callers can
+/// associate each one with the source it came from.
 fn get_all_need_db_from_config(
     filter_checksums: Vec<ChecksumDownloadEntry>,
     total: &mut u64,
     checksums: &[ChecksumItem],
     handle: &mut HashSet<ChecksumDownloadEntry>,
-) {
+) -> Vec<ChecksumDownloadEntry> {
+    let mut new_entries = vec![];
+
     for i in filter_checksums {
         if handle.contains(&i) {
             continue;
@@ -729,8 +739,11 @@ fn get_all_need_db_from_config(
             *total += size;
         }
 
-        handle.insert(i);
+        handle.insert(i.clone());
+        new_entries.push(i);
     }
+
+    new_entries
 }
 
 fn remove_unused_db(download_dir: &Path, download_list: HashSet<String>) -> Result<()> {
@@ -762,18 +775,18 @@ fn remove_unused_db(download_dir: &Path, download_list: HashSet<String>) -> Resu
 }
 
 fn collect_flat_repo_no_release(
-    mirror_source: &MirrorSource,
+    source: &OmaSourceEntry,
     download_dir: &Path,
     tasks: &mut Vec<DownloadEntry>,
 ) -> Result<()> {
-    let msg = mirror_source.get_human_download_message(Some("Packages"))?;
+    let msg = source.get_human_download_url(Some("Packages"))?;
 
-    let dist_url = mirror_source.dist_path();
+    let dist_url = source.dist_path();
 
     let download_url = format!("{dist_url}/Packages");
     let file_path = format!("{dist_url}Packages");
 
-    let sources = mirror_source.download_sources_for(&download_url, mirror_source.is_flat())?;
+    let sources = source.download_sources_for(&download_url, source.is_flat())?;
 
     let task = DownloadEntry::builder()
         .source(sources)
@@ -791,7 +804,7 @@ fn collect_flat_repo_no_release(
 
 fn collect_download_task(
     c: &ChecksumDownloadEntry,
-    mirror_source: &MirrorSource,
+    source: &OmaSourceEntry,
     download_dir: &Path,
     tasks: &mut Vec<DownloadEntry>,
     release: &Release,
@@ -799,9 +812,9 @@ fn collect_download_task(
 ) -> Result<()> {
     let file_type = &c.msg;
 
-    let msg = mirror_source.get_human_download_message(Some(file_type))?;
+    let msg = source.get_human_download_url(Some(file_type))?;
 
-    let local_as_symlink = mirror_source.is_flat()
+    let local_as_symlink = source.is_flat()
         && (!file_is_compress(&c.item.name) || (file_is_compress(&c.item.name) && c.keep_compress));
 
     let not_compress_filename_before = if file_is_compress(&c.item.name) {
@@ -839,17 +852,17 @@ fn collect_download_task(
 
         let path = parent.join("by-hash").join(dir).join(&c.item.checksum);
 
-        let url = mirror_source.get_download_url(&path.display().to_string());
-        sources.extend(mirror_source.download_sources_for(&url, local_as_symlink)?);
+        let url = source.get_download_url(&path.display().to_string());
+        sources.extend(source.download_sources_for(&url, local_as_symlink)?);
     }
 
-    let url = mirror_source.get_download_url(&c.item.name);
-    sources.extend(mirror_source.download_sources_for(&url, local_as_symlink)?);
+    let url = source.get_download_url(&c.item.name);
+    sources.extend(source.download_sources_for(&url, local_as_symlink)?);
 
     let file_name = if c.keep_compress {
-        mirror_source.get_download_file_name(Some(&c.item.name))?
+        source.get_download_file_name(Some(&c.item.name))?
     } else {
-        mirror_source.get_download_file_name(Some(&not_compress_filename_before))?
+        source.get_download_file_name(Some(&not_compress_filename_before))?
     };
 
     if c.optional {

--- a/oma-refresh/src/sourceslist.rs
+++ b/oma-refresh/src/sourceslist.rs
@@ -135,8 +135,9 @@ impl OmaSourceEntry {
     }
 
     /// Expand an original (mirror-based) full URL into concrete URLs — one per
-    /// resolved mirror — each with its transport. Non-mirror sources return
-    /// the URL unchanged.
+    /// resolved mirror — each with its transport and the mirror's priority
+    /// (lower is tried first). Non-mirror sources return the URL unchanged
+    /// with a default priority so their transport preference applies.
     ///
     /// `local_as_symlink` is used for `file:` mirrors, mirroring how plain
     /// local sources map to `DownloadSourceType::Local`.
@@ -144,13 +145,13 @@ impl OmaSourceEntry {
         &self,
         original_url: &str,
         local_as_symlink: bool,
-    ) -> Result<Vec<(String, DownloadSourceType)>, RefreshError> {
+    ) -> Result<Vec<(String, DownloadSourceType, u64)>, RefreshError> {
         if !self.is_mirror() {
             let source_type = match self.from()? {
                 OmaSourceEntryFrom::Http => DownloadSourceType::Http,
                 OmaSourceEntryFrom::Local => DownloadSourceType::Local(local_as_symlink),
             };
-            return Ok(vec![(original_url.to_string(), source_type)]);
+            return Ok(vec![(original_url.to_string(), source_type, u64::MAX)]);
         }
 
         let mirrors = self
@@ -169,7 +170,7 @@ impl OmaSourceEntry {
                     MirrorSourceType::Http => DownloadSourceType::Http,
                     MirrorSourceType::File => DownloadSourceType::Local(local_as_symlink),
                 };
-                (format!("{}{suffix}", m.url), source_type)
+                (format!("{}{suffix}", m.url), source_type, m.priority)
             })
             .collect())
     }
@@ -362,7 +363,7 @@ impl MirrorSource {
             .expand_mirror_url(&original, self.is_flat())
             .map(|v| {
                 v.into_iter()
-                    .map(|(url, source_type)| {
+                    .map(|(url, source_type, _priority)| {
                         let from = match source_type {
                             DownloadSourceType::Http => OmaSourceEntryFrom::Http,
                             DownloadSourceType::Local(_) => OmaSourceEntryFrom::Local,
@@ -387,7 +388,11 @@ impl MirrorSource {
             .expand_mirror_url(original_url, local_as_symlink)
             .map(|v| {
                 v.into_iter()
-                    .map(|(url, source_type)| DownloadSource { url, source_type })
+                    .map(|(url, source_type, priority)| DownloadSource {
+                        url,
+                        source_type,
+                        priority,
+                    })
                     .collect()
             })
     }
@@ -1375,10 +1380,12 @@ fn test_mirror_expansion() {
         ResolvedMirror {
             url: "http://m1.example.com/debian".into(),
             source_type: MirrorSourceType::Http,
+            priority: 1,
         },
         ResolvedMirror {
             url: "http://m2.example.com/debian".into(),
             source_type: MirrorSourceType::Http,
+            priority: 2,
         },
     ]);
 
@@ -1412,6 +1419,7 @@ fn test_mirror_expansion() {
     entry_file.set_mirrors(vec![ResolvedMirror {
         url: "file:///repo".into(),
         source_type: MirrorSourceType::File,
+        priority: 1,
     }]);
     let original = entry_file.get_download_url("InRelease");
     let expanded = entry_file.expand_mirror_url(&original, true).unwrap();
@@ -1478,10 +1486,12 @@ async fn test_fetch_mirror_release_atomic_pair() {
         ResolvedMirror {
             url: format!("file://{}", mirror_a.display()),
             source_type: MirrorSourceType::File,
+            priority: 1,
         },
         ResolvedMirror {
             url: format!("file://{}", mirror_b.display()),
             source_type: MirrorSourceType::File,
+            priority: 2,
         },
     ]);
 

--- a/oma-refresh/src/sourceslist.rs
+++ b/oma-refresh/src/sourceslist.rs
@@ -175,6 +175,30 @@ impl OmaSourceEntry {
             .collect())
     }
 
+    /// Expand a full original URL into `DownloadSource`s, one per mirror,
+    /// using *this* source's resolved mirrors. Tasks built from a specific
+    /// source must go through here rather than a group-level helper: `deb`
+    /// and `deb-src` entries sharing a mirror URI may have selected different
+    /// mirror sets (`type:deb` / `type:deb-src`), and expanding every task
+    /// with only the group's first entry would send one type's indexes to
+    /// the other type's mirrors.
+    pub fn download_sources_for(
+        &self,
+        original_url: &str,
+        local_as_symlink: bool,
+    ) -> Result<Vec<DownloadSource>, RefreshError> {
+        self.expand_mirror_url(original_url, local_as_symlink)
+            .map(|v| {
+                v.into_iter()
+                    .map(|(url, source_type, priority)| DownloadSource {
+                        url,
+                        source_type,
+                        priority,
+                    })
+                    .collect()
+            })
+    }
+
     pub fn components(&self) -> &[String] {
         &self.source.components
     }
@@ -369,29 +393,6 @@ impl MirrorSource {
                             DownloadSourceType::Local(_) => OmaSourceEntryFrom::Local,
                         };
                         (url, from)
-                    })
-                    .collect()
-            })
-    }
-
-    /// Expand a full original URL into `DownloadSource`s, one per mirror.
-    /// `local_as_symlink` is applied to `file:` mirrors (and to plain local
-    /// sources), matching `collect_download_task`'s existing logic.
-    pub fn download_sources_for(
-        &self,
-        original_url: &str,
-        local_as_symlink: bool,
-    ) -> Result<Vec<DownloadSource>, RefreshError> {
-        self.sources
-            .first()
-            .unwrap()
-            .expand_mirror_url(original_url, local_as_symlink)
-            .map(|v| {
-                v.into_iter()
-                    .map(|(url, source_type, priority)| DownloadSource {
-                        url,
-                        source_type,
-                        priority,
                     })
                     .collect()
             })
@@ -1363,6 +1364,53 @@ fn test_flat_repo_file_name_4() {
     let ose = OmaSourceEntry::new(entry, arch);
     let res = ose.get_download_file_name(Some("Packages")).unwrap();
     assert_eq!(res, "_debs___.___Packages");
+}
+
+#[test]
+fn per_source_mirror_selection_is_kept() {
+    // `deb` and `deb-src` entries sharing a mirror URI and suite group
+    // together, but each keeps its own resolved mirrors (`type:deb` vs
+    // `type:deb-src` selections): expanding an index URL must use the
+    // source's own mirrors, never the group's first entry.
+    let deb: SourceEntry = "deb mirror+file:///etc/apt/mirrors.test bookworm main"
+        .parse()
+        .unwrap();
+    let deb_src: SourceEntry = "deb-src mirror+file:///etc/apt/mirrors.test bookworm main"
+        .parse()
+        .unwrap();
+    let deb = OmaSourceEntry::new(deb, Arc::from("amd64"));
+    let deb_src = OmaSourceEntry::new(deb_src, Arc::from("amd64"));
+
+    deb.set_mirrors(vec![ResolvedMirror {
+        url: "http://deb.example.com/debian".into(),
+        source_type: MirrorSourceType::Http,
+        priority: 1,
+    }]);
+    deb_src.set_mirrors(vec![ResolvedMirror {
+        url: "http://src.example.com/debian".into(),
+        source_type: MirrorSourceType::Http,
+        priority: 1,
+    }]);
+
+    // They share a dist path, so they land in one `MirrorSource` group.
+    let grouped = MirrorSources::from_sourcelist(&[deb.clone(), deb_src.clone()]).unwrap();
+    assert_eq!(grouped.0.len(), 1);
+    assert_eq!(grouped.0[0].sources.len(), 2);
+
+    // Each source's index tasks expand to its own mirrors.
+    let deb_sources = deb
+        .download_sources_for(&deb.get_download_url("Packages"), false)
+        .unwrap();
+    assert_eq!(deb_sources.len(), 1);
+    assert!(deb_sources[0].url.starts_with("http://deb.example.com/debian/"));
+    assert!(deb_sources[0].url.ends_with("/Packages"));
+
+    let src_sources = deb_src
+        .download_sources_for(&deb_src.get_download_url("Sources"), false)
+        .unwrap();
+    assert_eq!(src_sources.len(), 1);
+    assert!(src_sources[0].url.starts_with("http://src.example.com/debian/"));
+    assert!(src_sources[0].url.ends_with("/Sources"));
 }
 
 #[test]

--- a/oma-refresh/src/sourceslist.rs
+++ b/oma-refresh/src/sourceslist.rs
@@ -193,6 +193,7 @@ impl OmaSourceEntry {
                     .map(|(url, source_type, priority)| DownloadSource {
                         url,
                         source_type,
+                        order: 0,
                         priority,
                     })
                     .collect()

--- a/oma-refresh/src/sourceslist.rs
+++ b/oma-refresh/src/sourceslist.rs
@@ -843,18 +843,33 @@ impl MirrorSource {
             OmaSourceEntryFrom::Http => {
                 match send_request_with_url_and_method(url, client, Method::GET).await {
                     Ok(resp) => {
-                        self.download_file(
-                            file_name,
-                            resp,
-                            index,
-                            total,
-                            tmp_dir,
-                            download_dir,
-                            tx.clone(),
-                        )
-                        .await
-                        .map_err(|e| RefreshError::DownloadFailed(Some(e)))?;
-                        true
+                        match self
+                            .download_file(
+                                file_name,
+                                resp,
+                                index,
+                                total,
+                                tmp_dir,
+                                download_dir,
+                                tx.clone(),
+                            )
+                            .await
+                        {
+                            Ok(()) => true,
+                            // The mirror returned headers but dropped the
+                            // response body mid-stream — a common transient
+                            // failure. Clean up the partial file and let the
+                            // caller try the next mirror, like a request
+                            // failure. Local disk errors still abort.
+                            Err(SingleDownloadError::ReqwestMiddlewareError { source }) => {
+                                debug!("Mirror dropped the response body: {source}");
+                                let _ = tokio::fs::remove_file(tmp_dir.join(file_name)).await;
+                                false
+                            }
+                            Err(e) => {
+                                return Err(RefreshError::DownloadFailed(Some(e)));
+                            }
+                        }
                     }
                     // Try the next mirror on any failure.
                     Err(_) => false,
@@ -1597,5 +1612,94 @@ async fn test_fetch_mirror_release_atomic_pair() {
     assert_eq!(
         std::fs::read_to_string(download_dir.path().join(&gpg_name)).unwrap(),
         "gpg-b"
+    );
+}
+
+/// A server that answers `200 OK` with a `Content-Length` larger than the
+/// body it sends, then closes the connection — the mirror drops the
+/// response body mid-stream.
+#[cfg(test)]
+async fn drop_body_server(body: &'static [u8]) -> u16 {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        while let Ok((mut socket, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                let _ = socket.read(&mut buf).await;
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len() + 100
+                );
+                let _ = socket.write_all(head.as_bytes()).await;
+                let _ = socket.write_all(body).await;
+                // Close without sending the promised bytes.
+            });
+        }
+    });
+    port
+}
+
+#[tokio::test]
+async fn test_fetch_mirror_release_falls_back_when_body_is_dropped() {
+    // The first mirror returns 200 headers but disconnects while streaming
+    // `InRelease`; the release fetch must fall back to the second (healthy)
+    // mirror instead of aborting the whole refresh.
+    let dir = tempfile::tempdir().unwrap();
+    let mirror_file = dir.path().join("file");
+    let download_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = tempfile::tempdir().unwrap();
+
+    let port = drop_body_server(b"partial-inrelease").await;
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = reqwest_middleware::ClientBuilder::new(oma_fetch::reqwest::Client::new()).build();
+
+    let entry: SourceEntry = "deb mirror+file:///etc/apt/mirrors.test bookworm main"
+        .parse()
+        .unwrap();
+    let ose = OmaSourceEntry::new(entry, Arc::from("amd64"));
+    ose.set_mirrors(vec![
+        ResolvedMirror {
+            url: format!("http://127.0.0.1:{port}"),
+            source_type: MirrorSourceType::Http,
+            priority: 1,
+        },
+        ResolvedMirror {
+            url: format!("file://{}", mirror_file.display()),
+            source_type: MirrorSourceType::File,
+            priority: 2,
+        },
+    ]);
+
+    // The file mirror carries a complete `InRelease`.
+    let inrelease_name = ose.get_download_file_name(Some("InRelease")).unwrap();
+    let urls = ose
+        .expand_mirror_url(&ose.get_download_url("InRelease"), false)
+        .unwrap();
+    assert_eq!(urls.len(), 2);
+    let file_inrelease = Path::new(urls[1].0.strip_prefix("file:").unwrap());
+    std::fs::create_dir_all(file_inrelease.parent().unwrap()).unwrap();
+    std::fs::write(file_inrelease, b"real-inrelease").unwrap();
+
+    let ms = MirrorSource {
+        sources: vec![ose],
+        release_file_name: OnceCell::new(),
+    };
+
+    let (tx, _rx) = flume::unbounded();
+    ms.fetch_mirror_release(&client, 0, 1, tmp_dir.path(), download_dir.path(), tx)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        ms.release_file_name.get().map(String::as_str),
+        Some(inrelease_name.as_str())
+    );
+    assert_eq!(
+        std::fs::read_to_string(download_dir.path().join(&inrelease_name)).unwrap(),
+        "real-inrelease"
     );
 }

--- a/oma-refresh/src/sourceslist.rs
+++ b/oma-refresh/src/sourceslist.rs
@@ -6,7 +6,8 @@ use flume::Sender;
 use oma_apt_pkg::AptConfig;
 use oma_apt_sources_lists::{Signature, SourceEntry};
 use oma_fetch::{
-    SingleDownloadError,
+    DownloadSource, DownloadSourceType, SingleDownloadError,
+    mirror::{MirrorSourceType, ResolvedMirror},
     reqwest::{Method, Response, StatusCode},
     send_request_with_url_and_method,
 };
@@ -35,6 +36,10 @@ pub struct OmaSourceEntry {
     suite: OnceCell<String>,
     dist_path: OnceCell<String>,
     from: OnceCell<OmaSourceEntryFrom>,
+    /// Resolved mirrors for `mirror://` sources (in priority order), set
+    /// during the pre-resolution step in `OmaRefresh`. `url()`/`dist_path()`
+    /// and the resulting list-file names keep the original `mirror://` URI.
+    mirrors: OnceCell<Vec<ResolvedMirror>>,
 }
 
 impl Debug for OmaSourceEntry {
@@ -80,11 +85,26 @@ impl OmaSourceEntry {
             suite: OnceCell::new(),
             dist_path: OnceCell::new(),
             from: OnceCell::new(),
+            mirrors: OnceCell::new(),
         }
     }
 
     pub fn from(&self) -> Result<&OmaSourceEntryFrom, RefreshError> {
         self.from.get_or_try_init(|| {
+            if self.is_mirror() {
+                // The primary mirror's transport decides how this source is
+                // fetched. Mirrors are resolved during `OmaRefresh`'s
+                // pre-resolution step, before any download begins.
+                let primary = self
+                    .mirrors()
+                    .and_then(|m| m.first())
+                    .ok_or_else(|| RefreshError::UnsupportedProtocol(self.url().to_string()))?;
+                return Ok(match primary.source_type {
+                    MirrorSourceType::Http => OmaSourceEntryFrom::Http,
+                    MirrorSourceType::File => OmaSourceEntryFrom::Local,
+                });
+            }
+
             let url = Url::parse(self.url())
                 .map_err(|_| RefreshError::InvalidUrl(self.url().to_string()))?;
 
@@ -94,6 +114,64 @@ impl OmaSourceEntry {
                 x => Err(RefreshError::UnsupportedProtocol(x.to_string())),
             }
         })
+    }
+
+    /// Whether this source uses the apt `mirror://` protocol.
+    pub fn is_mirror(&self) -> bool {
+        let url = self.url();
+        url.starts_with("mirror:") || url.starts_with("mirror+")
+    }
+
+    /// Store the resolved mirrors (priority order). Must be called before any
+    /// download; list-file naming keeps the original `mirror://` URI so files
+    /// are stored under stable names. Idempotent: re-resolving a source is a
+    /// no-op.
+    pub fn set_mirrors(&self, mirrors: Vec<ResolvedMirror>) {
+        let _ = self.mirrors.set(mirrors);
+    }
+
+    pub fn mirrors(&self) -> Option<&[ResolvedMirror]> {
+        self.mirrors.get().map(Vec::as_slice)
+    }
+
+    /// Expand an original (mirror-based) full URL into concrete URLs — one per
+    /// resolved mirror — each with its transport. Non-mirror sources return
+    /// the URL unchanged.
+    ///
+    /// `local_as_symlink` is used for `file:` mirrors, mirroring how plain
+    /// local sources map to `DownloadSourceType::Local`.
+    pub fn expand_mirror_url(
+        &self,
+        original_url: &str,
+        local_as_symlink: bool,
+    ) -> Result<Vec<(String, DownloadSourceType)>, RefreshError> {
+        if !self.is_mirror() {
+            let source_type = match self.from()? {
+                OmaSourceEntryFrom::Http => DownloadSourceType::Http,
+                OmaSourceEntryFrom::Local => DownloadSourceType::Local(local_as_symlink),
+            };
+            return Ok(vec![(original_url.to_string(), source_type)]);
+        }
+
+        let mirrors = self
+            .mirrors()
+            .ok_or_else(|| RefreshError::UnsupportedProtocol(self.url().to_string()))?;
+
+        let base = self.url().trim_end_matches('/');
+        let suffix = original_url
+            .strip_prefix(base)
+            .ok_or_else(|| RefreshError::InvalidUrl(original_url.to_string()))?;
+
+        Ok(mirrors
+            .iter()
+            .map(|m| {
+                let source_type = match m.source_type {
+                    MirrorSourceType::Http => DownloadSourceType::Http,
+                    MirrorSourceType::File => DownloadSourceType::Local(local_as_symlink),
+                };
+                (format!("{}{suffix}", m.url), source_type)
+            })
+            .collect())
     }
 
     pub fn components(&self) -> &[String] {
@@ -170,8 +248,17 @@ impl OmaSourceEntry {
     }
 
     pub fn get_human_download_url(&self, file_name: Option<&str>) -> Result<String, RefreshError> {
-        let url = self.url();
-        let url = Url::parse(url).map_err(|_| RefreshError::InvalidUrl(url.to_string()))?;
+        // For mirror sources display the primary mirror instead of the
+        // `mirror://` URI, which `url::Url` cannot parse.
+        let url = if self.is_mirror() {
+            self.mirrors()
+                .and_then(|m| m.first())
+                .map(|m| Cow::Owned(m.url.clone()))
+                .unwrap_or_else(|| Cow::Borrowed(self.url()))
+        } else {
+            Cow::Borrowed(self.url())
+        };
+        let url = Url::parse(&url).map_err(|_| RefreshError::InvalidUrl(url.to_string()))?;
 
         let host = url.host_str();
 
@@ -258,6 +345,53 @@ impl MirrorSource {
         self.sources.first().unwrap().is_flat()
     }
 
+    pub fn is_mirror(&self) -> bool {
+        self.sources.first().is_some_and(|x| x.is_mirror())
+    }
+
+    /// Candidate URLs for a metadata file — one per resolved mirror, with its
+    /// transport. Non-mirror sources yield a single candidate.
+    pub fn candidate_urls_for(
+        &self,
+        file_name: &str,
+    ) -> Result<Vec<(String, OmaSourceEntryFrom)>, RefreshError> {
+        let original = self.get_download_url(file_name);
+        self.sources
+            .first()
+            .unwrap()
+            .expand_mirror_url(&original, self.is_flat())
+            .map(|v| {
+                v.into_iter()
+                    .map(|(url, source_type)| {
+                        let from = match source_type {
+                            DownloadSourceType::Http => OmaSourceEntryFrom::Http,
+                            DownloadSourceType::Local(_) => OmaSourceEntryFrom::Local,
+                        };
+                        (url, from)
+                    })
+                    .collect()
+            })
+    }
+
+    /// Expand a full original URL into `DownloadSource`s, one per mirror.
+    /// `local_as_symlink` is applied to `file:` mirrors (and to plain local
+    /// sources), matching `collect_download_task`'s existing logic.
+    pub fn download_sources_for(
+        &self,
+        original_url: &str,
+        local_as_symlink: bool,
+    ) -> Result<Vec<DownloadSource>, RefreshError> {
+        self.sources
+            .first()
+            .unwrap()
+            .expand_mirror_url(original_url, local_as_symlink)
+            .map(|v| {
+                v.into_iter()
+                    .map(|(url, source_type)| DownloadSource { url, source_type })
+                    .collect()
+            })
+    }
+
     pub fn trusted(&self) -> bool {
         self.sources.iter().any(|x| x.trusted())
     }
@@ -276,6 +410,12 @@ impl MirrorSource {
         download_dir: &Path,
         tx: Sender<Event>,
     ) -> Result<(), RefreshError> {
+        if self.is_mirror() {
+            return self
+                .fetch_mirror_release(client, index, total, tmp_dir, download_dir, tx)
+                .await;
+        }
+
         match self.from()? {
             OmaSourceEntryFrom::Http => {
                 self.fetch_http_release(client, index, total, tmp_dir, download_dir, tx)
@@ -540,6 +680,159 @@ impl MirrorSource {
 
         let name = name.ok_or_else(|| RefreshError::NoInReleaseFile(self.url().to_string()))?;
         self.set_release_file_name(name);
+
+        Ok(())
+    }
+
+    /// Fetch the release files for a `mirror://` source, trying each resolved
+    /// mirror in order until one succeeds (apt's mirror method behavior).
+    /// Supports both http(s) and `file:` mirrors within one list.
+    #[allow(clippy::too_many_arguments)]
+    async fn fetch_mirror_release(
+        &self,
+        client: &ClientWithMiddleware,
+        index: usize,
+        total: usize,
+        tmp_dir: &Path,
+        download_dir: &Path,
+        tx: Sender<Event>,
+    ) -> Result<(), RefreshError> {
+        let msg = self.get_human_download_message(None)?;
+
+        let _ = tx
+            .send_async(Event::DownloadEvent(oma_fetch::Event::NewProgressSpinner {
+                index,
+                total,
+                msg,
+            }))
+            .await;
+
+        // Try `InRelease` first, then `Release`, each against every mirror.
+        let mut obtained = None; // (file_name, is_release)
+
+        for (file, is_release) in [("InRelease", false), ("Release", true)] {
+            let file_name = self.get_download_file_name(Some(file))?;
+            let candidates = self.candidate_urls_for(file)?;
+
+            for (url, from) in &candidates {
+                let got = match from {
+                    OmaSourceEntryFrom::Http => {
+                        match send_request_with_url_and_method(url, client, Method::GET).await {
+                            Ok(resp) => {
+                                self.download_file(
+                                    &file_name,
+                                    resp,
+                                    index,
+                                    total,
+                                    tmp_dir,
+                                    download_dir,
+                                    tx.clone(),
+                                )
+                                .await
+                                .map_err(|e| RefreshError::DownloadFailed(Some(e)))?;
+                                true
+                            }
+                            // Try the next mirror on any failure.
+                            Err(_) => false,
+                        }
+                    }
+                    OmaSourceEntryFrom::Local => {
+                        let path = Path::new(url.strip_prefix("file:").unwrap_or(url));
+                        if path.exists() {
+                            let dst = download_dir.join(&file_name);
+                            if dst.exists() {
+                                fs::remove_file(&dst)
+                                    .await
+                                    .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
+                            }
+                            fs::symlink(path, &dst)
+                                .await
+                                .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                };
+
+                if got {
+                    obtained = Some((file_name, is_release));
+                    break;
+                }
+            }
+
+            if obtained.is_some() {
+                break;
+            }
+        }
+
+        let Some((file_name, is_release)) = obtained else {
+            if self.is_flat() {
+                // Flat repo without a release file.
+                let _ = tx
+                    .send_async(Event::DownloadEvent(oma_fetch::Event::ProgressDone(index)))
+                    .await;
+                return Ok(());
+            }
+            return Err(RefreshError::NoInReleaseFile(self.url().to_string()));
+        };
+
+        self.set_release_file_name(file_name);
+
+        if is_release && !self.trusted() {
+            // Fetch `Release.gpg` from the first mirror that has it.
+            let file_name = self.get_download_file_name(Some("Release.gpg"))?;
+            let candidates = self.candidate_urls_for("Release.gpg")?;
+
+            for (url, from) in &candidates {
+                let got = match from {
+                    OmaSourceEntryFrom::Http => {
+                        match send_request_with_url_and_method(url, client, Method::GET).await {
+                            Ok(resp) => {
+                                self.download_file(
+                                    &file_name,
+                                    resp,
+                                    index,
+                                    total,
+                                    tmp_dir,
+                                    download_dir,
+                                    tx.clone(),
+                                )
+                                .await
+                                .map_err(|e| RefreshError::DownloadFailed(Some(e)))?;
+                                true
+                            }
+                            Err(_) => false,
+                        }
+                    }
+                    OmaSourceEntryFrom::Local => {
+                        let path = Path::new(url.strip_prefix("file:").unwrap_or(url));
+                        if path.exists() {
+                            let dst = download_dir.join(&file_name);
+                            if dst.exists() {
+                                fs::remove_file(&dst)
+                                    .await
+                                    .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
+                            }
+                            fs::symlink(path, &dst)
+                                .await
+                                .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                };
+
+                if got {
+                    break;
+                }
+            }
+        }
+
+        let _ = tx
+            .send_async(Event::DownloadEvent(oma_fetch::Event::ProgressDone(index)))
+            .await;
 
         Ok(())
     }
@@ -1028,4 +1321,102 @@ fn test_flat_repo_file_name_4() {
     let ose = OmaSourceEntry::new(entry, arch);
     let res = ose.get_download_file_name(Some("Packages")).unwrap();
     assert_eq!(res, "_debs___.___Packages");
+}
+
+#[test]
+fn test_mirror_expansion() {
+    // A mirror source keeps its `mirror://` URI for naming, and expands to
+    // one concrete URL per resolved mirror for downloading.
+    let entry: SourceEntry = "deb mirror+file:///etc/apt/mirrors.test bookworm main"
+        .parse()
+        .unwrap();
+    let entry = OmaSourceEntry::new(entry, Arc::from("amd64"));
+    assert!(entry.is_mirror());
+
+    // Simulate the pre-resolution step.
+    entry.set_mirrors(vec![
+        ResolvedMirror {
+            url: "http://m1.example.com/debian".into(),
+            source_type: MirrorSourceType::Http,
+        },
+        ResolvedMirror {
+            url: "http://m2.example.com/debian".into(),
+            source_type: MirrorSourceType::Http,
+        },
+    ]);
+
+    // `from()` follows the primary mirror's transport.
+    assert_eq!(entry.from().unwrap(), &OmaSourceEntryFrom::Http);
+
+    // Naming stays based on the original `mirror://` URI.
+    let original = entry.get_download_url("InRelease");
+    assert!(original.starts_with("mirror+file:"));
+
+    // Expansion replaces the mirror base with each resolved mirror.
+    let expanded = entry.expand_mirror_url(&original, false).unwrap();
+    assert_eq!(expanded.len(), 2);
+    assert_eq!(
+        expanded[0].0,
+        "http://m1.example.com/debian/dists/bookworm/InRelease"
+    );
+    assert_eq!(
+        expanded[1].0,
+        "http://m2.example.com/debian/dists/bookworm/InRelease"
+    );
+    assert_eq!(expanded[0].1, DownloadSourceType::Http);
+
+    // A `file:` mirror maps to a local source.
+    let entry_file = OmaSourceEntry::new(
+        "deb mirror+file:///etc/apt/mirrors.test bookworm main"
+            .parse()
+            .unwrap(),
+        Arc::from("amd64"),
+    );
+    entry_file.set_mirrors(vec![ResolvedMirror {
+        url: "file:///repo".into(),
+        source_type: MirrorSourceType::File,
+    }]);
+    let original = entry_file.get_download_url("InRelease");
+    let expanded = entry_file.expand_mirror_url(&original, true).unwrap();
+    assert_eq!(expanded[0].0, "file:///repo/dists/bookworm/InRelease");
+    assert_eq!(expanded[0].1, DownloadSourceType::Local(true));
+
+    // Non-mirror sources are returned unchanged.
+    let plain = OmaSourceEntry::new(
+        "deb http://example.com/debian bookworm main"
+            .parse()
+            .unwrap(),
+        Arc::from("amd64"),
+    );
+    let original = plain.get_download_url("InRelease");
+    let expanded = plain.expand_mirror_url(&original, false).unwrap();
+    assert_eq!(expanded.len(), 1);
+    assert_eq!(expanded[0].0, original);
+    assert_eq!(expanded[0].1, DownloadSourceType::Http);
+}
+
+#[tokio::test]
+async fn test_resolve_mirrors_local_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let list = dir.path().join("mirrors.list");
+    std::fs::write(
+        &list,
+        "http://m1.example.com/\tpriority:1\trelease:bookworm\nfile:///local/repo\tpriority:2\n",
+    )
+    .unwrap();
+
+    let uri = format!("mirror+file://{}", list.display());
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = reqwest_middleware::ClientBuilder::new(oma_fetch::reqwest::Client::new()).build();
+
+    let mirrors =
+        oma_fetch::mirror::resolve_mirrors(&uri, &client, Some("amd64"), Some("bookworm"), false)
+            .await
+            .unwrap();
+
+    assert_eq!(mirrors.len(), 2);
+    assert_eq!(mirrors[0].url, "http://m1.example.com");
+    assert_eq!(mirrors[0].source_type, MirrorSourceType::Http);
+    assert_eq!(mirrors[1].url, "file:///local/repo");
+    assert_eq!(mirrors[1].source_type, MirrorSourceType::File);
 }

--- a/oma-refresh/src/sourceslist.rs
+++ b/oma-refresh/src/sourceslist.rs
@@ -1531,16 +1531,9 @@ async fn test_fetch_mirror_release_atomic_pair() {
     let client = reqwest_middleware::ClientBuilder::new(oma_fetch::reqwest::Client::new()).build();
     let (tx, _rx) = flume::unbounded();
 
-    ms.fetch_mirror_release(
-        &client,
-        0,
-        1,
-        tmp_dir.path(),
-        download_dir.path(),
-        tx,
-    )
-    .await
-    .unwrap();
+    ms.fetch_mirror_release(&client, 0, 1, tmp_dir.path(), download_dir.path(), tx)
+        .await
+        .unwrap();
 
     // The pair must come from the same (second) mirror: the downloaded
     // `Release` is B's, not A's, alongside B's signature.

--- a/oma-refresh/src/sourceslist.rs
+++ b/oma-refresh/src/sourceslist.rs
@@ -687,6 +687,13 @@ impl MirrorSource {
     /// Fetch the release files for a `mirror://` source, trying each resolved
     /// mirror in order until one succeeds (apt's mirror method behavior).
     /// Supports both http(s) and `file:` mirrors within one list.
+    ///
+    /// `InRelease` embeds its own signature, so the first mirror that has it
+    /// wins. Otherwise `Release` is fetched and — when the repo is untrusted —
+    /// its detached `Release.gpg` is fetched from the *same* mirror: taking
+    /// the signature from any mirror that has one could combine it with a
+    /// `Release` from another, and an out-of-sync cross-mirror pair fails
+    /// verification even though some mirror carries a valid pair.
     #[allow(clippy::too_many_arguments)]
     async fn fetch_mirror_release(
         &self,
@@ -707,134 +714,164 @@ impl MirrorSource {
             }))
             .await;
 
-        // Try `InRelease` first, then `Release`, each against every mirror.
-        let mut obtained = None; // (file_name, is_release)
-
-        for (file, is_release) in [("InRelease", false), ("Release", true)] {
-            let file_name = self.get_download_file_name(Some(file))?;
-            let candidates = self.candidate_urls_for(file)?;
-
-            for (url, from) in &candidates {
-                let got = match from {
-                    OmaSourceEntryFrom::Http => {
-                        match send_request_with_url_and_method(url, client, Method::GET).await {
-                            Ok(resp) => {
-                                self.download_file(
-                                    &file_name,
-                                    resp,
-                                    index,
-                                    total,
-                                    tmp_dir,
-                                    download_dir,
-                                    tx.clone(),
-                                )
-                                .await
-                                .map_err(|e| RefreshError::DownloadFailed(Some(e)))?;
-                                true
-                            }
-                            // Try the next mirror on any failure.
-                            Err(_) => false,
-                        }
-                    }
-                    OmaSourceEntryFrom::Local => {
-                        let path = Path::new(url.strip_prefix("file:").unwrap_or(url));
-                        if path.exists() {
-                            let dst = download_dir.join(&file_name);
-                            if dst.exists() {
-                                fs::remove_file(&dst)
-                                    .await
-                                    .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
-                            }
-                            fs::symlink(path, &dst)
-                                .await
-                                .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
-                            true
-                        } else {
-                            false
-                        }
-                    }
-                };
-
-                if got {
-                    obtained = Some((file_name, is_release));
-                    break;
-                }
-            }
-
-            if obtained.is_some() {
-                break;
-            }
-        }
-
-        let Some((file_name, is_release)) = obtained else {
-            if self.is_flat() {
-                // Flat repo without a release file.
+        // Try `InRelease` first — it carries its own signature, so any
+        // mirror that has it yields a complete, verifiable release file.
+        let inrelease_name = self.get_download_file_name(Some("InRelease"))?;
+        for (url, from) in self.candidate_urls_for("InRelease")? {
+            if self
+                .try_fetch_release_file(
+                    &inrelease_name,
+                    &url,
+                    &from,
+                    client,
+                    index,
+                    total,
+                    tmp_dir,
+                    download_dir,
+                    tx.clone(),
+                )
+                .await?
+            {
+                self.set_release_file_name(inrelease_name);
                 let _ = tx
                     .send_async(Event::DownloadEvent(oma_fetch::Event::ProgressDone(index)))
                     .await;
                 return Ok(());
             }
-            return Err(RefreshError::NoInReleaseFile(self.url().to_string()));
-        };
+        }
 
-        self.set_release_file_name(file_name);
+        // No mirror has `InRelease`. Fall back to `Release`, and when the
+        // repo is untrusted fetch its detached `Release.gpg` from the same
+        // mirror — try the pair mirror-by-mirror instead of taking `Release`
+        // from one mirror and the signature from another.
+        let release_name = self.get_download_file_name(Some("Release"))?;
+        let gpg_name = self.get_download_file_name(Some("Release.gpg"))?;
+        let release_candidates = self.candidate_urls_for("Release")?;
+        // The same mirrors in the same order, so zip pairs each `Release`
+        // candidate with the `Release.gpg` candidate of the same mirror.
+        let gpg_candidates = self.candidate_urls_for("Release.gpg")?;
+        let trusted = self.trusted();
 
-        if is_release && !self.trusted() {
-            // Fetch `Release.gpg` from the first mirror that has it.
-            let file_name = self.get_download_file_name(Some("Release.gpg"))?;
-            let candidates = self.candidate_urls_for("Release.gpg")?;
+        for ((release_url, release_from), (gpg_url, gpg_from)) in
+            release_candidates.iter().zip(gpg_candidates.iter())
+        {
+            if !self
+                .try_fetch_release_file(
+                    &release_name,
+                    release_url,
+                    release_from,
+                    client,
+                    index,
+                    total,
+                    tmp_dir,
+                    download_dir,
+                    tx.clone(),
+                )
+                .await?
+            {
+                continue;
+            }
 
-            for (url, from) in &candidates {
-                let got = match from {
-                    OmaSourceEntryFrom::Http => {
-                        match send_request_with_url_and_method(url, client, Method::GET).await {
-                            Ok(resp) => {
-                                self.download_file(
-                                    &file_name,
-                                    resp,
-                                    index,
-                                    total,
-                                    tmp_dir,
-                                    download_dir,
-                                    tx.clone(),
-                                )
-                                .await
-                                .map_err(|e| RefreshError::DownloadFailed(Some(e)))?;
-                                true
-                            }
-                            Err(_) => false,
-                        }
-                    }
-                    OmaSourceEntryFrom::Local => {
-                        let path = Path::new(url.strip_prefix("file:").unwrap_or(url));
-                        if path.exists() {
-                            let dst = download_dir.join(&file_name);
-                            if dst.exists() {
-                                fs::remove_file(&dst)
-                                    .await
-                                    .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
-                            }
-                            fs::symlink(path, &dst)
-                                .await
-                                .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
-                            true
-                        } else {
-                            false
-                        }
-                    }
-                };
+            if trusted {
+                self.set_release_file_name(release_name);
+                let _ = tx
+                    .send_async(Event::DownloadEvent(oma_fetch::Event::ProgressDone(index)))
+                    .await;
+                return Ok(());
+            }
 
-                if got {
-                    break;
-                }
+            // Untrusted: the detached signature must come from this mirror
+            // too; otherwise the pair is incomplete, try the next mirror.
+            if self
+                .try_fetch_release_file(
+                    &gpg_name,
+                    gpg_url,
+                    gpg_from,
+                    client,
+                    index,
+                    total,
+                    tmp_dir,
+                    download_dir,
+                    tx.clone(),
+                )
+                .await?
+            {
+                self.set_release_file_name(release_name);
+                let _ = tx
+                    .send_async(Event::DownloadEvent(oma_fetch::Event::ProgressDone(index)))
+                    .await;
+                return Ok(());
             }
         }
 
-        let _ = tx
-            .send_async(Event::DownloadEvent(oma_fetch::Event::ProgressDone(index)))
-            .await;
+        // Nothing usable: no mirror served `InRelease`, or (untrusted) no
+        // mirror had a consistent `Release` + `Release.gpg` pair.
+        if self.is_flat() {
+            // Flat repo without a release file.
+            let _ = tx
+                .send_async(Event::DownloadEvent(oma_fetch::Event::ProgressDone(index)))
+                .await;
+            return Ok(());
+        }
+        Err(RefreshError::NoInReleaseFile(self.url().to_string()))
+    }
 
-        Ok(())
+    /// Try to obtain `file_name` from one candidate mirror, writing it under
+    /// `download_dir`. Returns whether the file was obtained; failures to
+    /// reach a mirror return `false` so the caller can try the next one.
+    #[allow(clippy::too_many_arguments)]
+    async fn try_fetch_release_file(
+        &self,
+        file_name: &str,
+        url: &str,
+        from: &OmaSourceEntryFrom,
+        client: &ClientWithMiddleware,
+        index: usize,
+        total: usize,
+        tmp_dir: &Path,
+        download_dir: &Path,
+        tx: Sender<Event>,
+    ) -> Result<bool, RefreshError> {
+        let got = match from {
+            OmaSourceEntryFrom::Http => {
+                match send_request_with_url_and_method(url, client, Method::GET).await {
+                    Ok(resp) => {
+                        self.download_file(
+                            file_name,
+                            resp,
+                            index,
+                            total,
+                            tmp_dir,
+                            download_dir,
+                            tx.clone(),
+                        )
+                        .await
+                        .map_err(|e| RefreshError::DownloadFailed(Some(e)))?;
+                        true
+                    }
+                    // Try the next mirror on any failure.
+                    Err(_) => false,
+                }
+            }
+            OmaSourceEntryFrom::Local => {
+                let path = Path::new(url.strip_prefix("file:").unwrap_or(url));
+                if path.exists() {
+                    let dst = download_dir.join(file_name);
+                    if dst.exists() {
+                        fs::remove_file(&dst)
+                            .await
+                            .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
+                    }
+                    fs::symlink(path, &dst)
+                        .await
+                        .map_err(|e| RefreshError::OperateFile(dst.clone(), e))?;
+                    true
+                } else {
+                    false
+                }
+            }
+        };
+        Ok(got)
     }
 }
 
@@ -1419,4 +1456,94 @@ async fn test_resolve_mirrors_local_file() {
     assert_eq!(mirrors[0].source_type, MirrorSourceType::Http);
     assert_eq!(mirrors[1].url, "file:///local/repo");
     assert_eq!(mirrors[1].source_type, MirrorSourceType::File);
+}
+
+#[tokio::test]
+async fn test_fetch_mirror_release_atomic_pair() {
+    // Mirror A has `Release` but no signature; mirror B has a consistent
+    // `Release` + `Release.gpg` pair. The release fetch must fall through to
+    // mirror B's *pair* rather than combining A's `Release` with B's
+    // signature — a cross-mirror pair that would fail verification.
+    let dir = tempfile::tempdir().unwrap();
+    let mirror_a = dir.path().join("a");
+    let mirror_b = dir.path().join("b");
+    let download_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = tempfile::tempdir().unwrap();
+
+    let entry: SourceEntry = "deb mirror+file:///etc/apt/mirrors.test bookworm main"
+        .parse()
+        .unwrap();
+    let ose = OmaSourceEntry::new(entry, Arc::from("amd64"));
+    ose.set_mirrors(vec![
+        ResolvedMirror {
+            url: format!("file://{}", mirror_a.display()),
+            source_type: MirrorSourceType::File,
+        },
+        ResolvedMirror {
+            url: format!("file://{}", mirror_b.display()),
+            source_type: MirrorSourceType::File,
+        },
+    ]);
+
+    let release_name = ose.get_download_file_name(Some("Release")).unwrap();
+    let gpg_name = ose.get_download_file_name(Some("Release.gpg")).unwrap();
+
+    // Expand the concrete paths so the fixtures land exactly where the
+    // fetch will look for them.
+    let release_urls = ose
+        .expand_mirror_url(&ose.get_download_url("Release"), false)
+        .unwrap();
+    let gpg_urls = ose
+        .expand_mirror_url(&ose.get_download_url("Release.gpg"), false)
+        .unwrap();
+    assert_eq!(release_urls.len(), 2);
+    assert_eq!(gpg_urls.len(), 2);
+
+    // Mirror A: only `Release` — out of sync, no signature.
+    let a_release = Path::new(release_urls[0].0.strip_prefix("file:").unwrap());
+    std::fs::create_dir_all(a_release.parent().unwrap()).unwrap();
+    std::fs::write(a_release, b"release-a").unwrap();
+
+    // Mirror B: a complete `Release` + `Release.gpg` pair.
+    let b_release = Path::new(release_urls[1].0.strip_prefix("file:").unwrap());
+    std::fs::create_dir_all(b_release.parent().unwrap()).unwrap();
+    std::fs::write(b_release, b"release-b").unwrap();
+    let b_gpg = Path::new(gpg_urls[1].0.strip_prefix("file:").unwrap());
+    std::fs::create_dir_all(b_gpg.parent().unwrap()).unwrap();
+    std::fs::write(b_gpg, b"gpg-b").unwrap();
+
+    let ms = MirrorSource {
+        sources: vec![ose],
+        release_file_name: OnceCell::new(),
+    };
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = reqwest_middleware::ClientBuilder::new(oma_fetch::reqwest::Client::new()).build();
+    let (tx, _rx) = flume::unbounded();
+
+    ms.fetch_mirror_release(
+        &client,
+        0,
+        1,
+        tmp_dir.path(),
+        download_dir.path(),
+        tx,
+    )
+    .await
+    .unwrap();
+
+    // The pair must come from the same (second) mirror: the downloaded
+    // `Release` is B's, not A's, alongside B's signature.
+    assert_eq!(
+        ms.release_file_name.get().map(String::as_str),
+        Some(release_name.as_str())
+    );
+    assert_eq!(
+        std::fs::read_to_string(download_dir.path().join(&release_name)).unwrap(),
+        "release-b"
+    );
+    assert_eq!(
+        std::fs::read_to_string(download_dir.path().join(&gpg_name)).unwrap(),
+        "gpg-b"
+    );
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -344,6 +344,7 @@ impl From<RefreshError> for OutputError {
             },
             RefreshError::NoMetadataToDownload => fl!("oma-refresh-no-metadata-to-download").into(),
             RefreshError::CreateTokioRuntime(error) => error.to_string().into(),
+            RefreshError::MirrorResolve(e) => e.to_string().into(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -661,6 +661,7 @@ pub fn oma_apt_error_to_output(err: OmaAptError) -> OutputError {
             ),
         },
         OmaAptError::RecvError => anyhow::anyhow!("{err}").into(),
+        OmaAptError::Mirror(e) => anyhow::anyhow!("{e}").into(),
         OmaAptError::Anyhow(error) => error.into(),
     }
 }


### PR DESCRIPTION
## Description

Implement apt's `mirror://` protocol (`mirror://`, `mirror+http(s)://`, `mirror+file://`) end to end: `sources.list` entries can now point at a mirror list instead of a hardcoded mirror, and both metadata refresh (`oma refresh`) and package downloads (`oma install`) resolve the list and try each mirror in priority order, falling back to the next one on failure (apt's `Alternate-URIs` behavior).

- Add a shared mirror resolution module in `oma-fetch`: interprets `mirror://` (list fetched over http) / `mirror+http(s)://` / `mirror+file://` URIs, parses the apt mirror-list format (one `<uri>` per line, optionally with tab-separated `priority:` / `arch:` / `suite:` / `codename:` / `release:` / `type:` tags), filters by arch/release/type, orders by priority, and resolves to concrete mirror base URLs. Lists fetched over the network may not reference local `file:` mirrors, mirroring apt's CVE-2018-0501 mitigation
- `oma-refresh`: resolve each mirror list once (deduplicated by URI) in a new pre-resolution step before any download starts; list-file naming keeps the original `mirror://` URI (matching apt), while InRelease/Release/Release.gpg are fetched by walking the mirrors in order (`fetch_mirror_release`), and Packages/Contents/... get one download source per mirror so the download manager falls back to the next mirror on failure; the progress display shows the primary mirror
- `oma-pm`: expand a mirrored package URL into one download source per resolved mirror (the pool path is appended to each mirror base), mapping `file:` mirrors to local sources like plain file repositories
- Allowlist `MirrorListFileRecieved` in `_typos.toml` — that is apt's actual (misspelled) function name in `methods/mirror.cc`, referenced faithfully in the new module's docs

Mirror selection follows apt's priority ordering; ties keep list order (apt randomizes among equal priorities — deliberately not replicated). Verified with `cargo test --workspace --lib`, `cargo clippy --workspace`, `cargo fmt --check`, and `typos`.

This PR will fix #357 

## About AI

This PR was written in collaboration with Deepseek V4 Flash in a VS Code agent session. I have reviewed and amended the code, tested it thoroughly, and updated the comments.

- Model: Deepseek v4 flash
- Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)
