### PR TITLE
fix(oma-apt-pkg): refresh search status from the highest version entry

### DIFF
--- a/oma-apt-pkg/src/search.rs
+++ b/oma-apt-pkg/src/search.rs
@@ -3,7 +3,8 @@
 //! Builds a search index from parsed APT list entries and dpkg status,
 //! without depending on the C++ `oma-apt` binding.
 
-use std::collections::HashMap;
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -16,6 +17,7 @@ use glob_match::glob_match;
 use serde::{Deserialize, Serialize};
 use spdlog::debug;
 
+use crate::apt_lists::PackageEntry;
 use crate::apt_sources::SourceLookup;
 use crate::cache::CacheFile;
 use crate::{AptConfig, AptDb, DpkgState};
@@ -342,38 +344,72 @@ impl IndiciumSearch {
         // 第一遍：只记录每个包的最高候选版本，避免为每个包克隆完整 entry
         // （含描述、依赖字段）造成缓存命中路径上的峰值内存上升。
         let mut best: HashMap<String, Option<String>> = HashMap::new();
-        for entry in apt_db.entries() {
-            if entry.package.ends_with("-dbg") {
-                continue;
-            }
-            let replace = best.get(&entry.package).is_none_or(|existing| {
-                version_gt(entry.version.as_deref(), existing.as_deref())
-            });
+        for entry in non_dbg_entries(apt_db) {
+            let replace = best
+                .get(&entry.package)
+                .is_none_or(|existing| version_gt(entry.version.as_deref(), existing.as_deref()));
 
             if replace {
                 best.insert(entry.package.clone(), entry.version.clone());
             }
         }
 
-        // 第二遍：只处理最高版本 entry，用完即弃，不保留完整 entry。
-        for entry in apt_db.entries() {
-            if entry.package.ends_with("-dbg") {
-                continue;
+        // 移除源里已删除的包：`best` 已包含当前源里所有非 `-dbg` 包名，
+        // 无需再扫描一次数据库。
+        self.pkg_map.retain(|name, entry| {
+            if best.contains_key(name) {
+                true
+            } else {
+                self.index.remove(name, entry);
+                false
             }
+        });
+
+        // 第二遍：每个包只处理一次其最高候选版本的 entry，用完即弃。
+        // 同一包在多个源里可能出现“语义相等但字符串不同”的版本
+        // （如 `1.0` 与 `1.0.0`，Debian 版本比较下视为同一版本），
+        // 这些 entry 的版本都 >= best；用 `handled` 保证只取第一个，
+        // 避免重复计算状态、也避免 `new_version` 被后面的 entry 覆盖成别的字符串。
+        let mut handled: HashSet<String> = HashSet::new();
+        for entry in non_dbg_entries(apt_db) {
             let Some(best_version) = best.get(&entry.package) else {
                 continue;
             };
-            // 只处理版本不低于最高候选版本的 entry（Debian 版本比较下
-            // 可能多个字符串表示同一版本，如 `1.0` 与 `1.0.0`）。
+            // 只处理版本不低于最高候选版本的 entry；其余（严格更低）跳过。
             if version_gt(best_version.as_deref(), entry.version.as_deref()) {
                 continue;
             }
+
+            if !handled.insert(entry.package.clone()) {
+                continue;
+            }
+
             let name = entry.package.as_str();
 
-            let is_new = !self.pkg_map.contains_key(name);
+            // 状态与已安装版本只计算一次：已安装 -> Installed/Upgrade，未安装 -> Avail。
+            let inst_ver = dpkg.installed_versions.get(name).cloned();
+            let (status, old_version) = if dpkg.installed.contains(name) {
+                let status = if is_upgradable(entry.version.as_deref(), inst_ver.as_deref()) {
+                    PackageStatus::Upgrade
+                } else {
+                    PackageStatus::Installed
+                };
 
-            if is_new {
-                // 源里的新包
+                (status, inst_ver)
+            } else {
+                (PackageStatus::Avail, None)
+            };
+
+            if let Some(pkg_entry) = self.pkg_map.get_mut(name) {
+                // 已有包：候选版本始终取当前源里的最高版本，避免残留旧源
+                // （如已退出的 topic）的版本号。
+                if let Some(ref v) = entry.version {
+                    pkg_entry.new_version.clone_from(v);
+                }
+                pkg_entry.status = status;
+                pkg_entry.old_version = old_version;
+            } else {
+                // 源里的新包：构造完整 entry 并插入索引。
                 let has_dbg = apt_db.has_package(&format!("{name}-dbg"));
 
                 let provides: IndexSet<String> = entry
@@ -393,58 +429,20 @@ impl IndiciumSearch {
                     .map(|d| d.lines().next().unwrap_or(d).to_string())
                     .unwrap_or_else(|| "No description".to_string());
 
-                self.pkg_map.insert(
-                    name.to_string(),
-                    SearchEntry {
-                        name: name.to_string(),
-                        description,
-                        status: PackageStatus::Avail,
-                        provides,
-                        has_dbg,
-                        section_is_base,
-                        old_version: None,
-                        new_version: entry.version.clone().unwrap_or_default(),
-                    },
-                );
-
-                let key = self.pkg_map.get_key_value(name).map(|(k, _)| k).unwrap();
-                self.index.insert(key, &self.pkg_map[name]);
-            }
-
-            let pkg_entry = self.pkg_map.get_mut(name).unwrap();
-
-            // 候选版本始终取当前源里的最高版本，避免残留旧源
-            // （如已退出的 topic）的版本号
-            if let Some(ref v) = entry.version {
-                pkg_entry.new_version.clone_from(v);
-            }
-
-            // 更新已安装的包的状态
-            let inst_ver = dpkg.installed_versions.get(name).cloned();
-            if dpkg.installed.contains(name) {
-                if is_upgradable(entry.version.as_deref(), inst_ver.as_deref()) {
-                    pkg_entry.status = PackageStatus::Upgrade;
-                } else {
-                    pkg_entry.status = PackageStatus::Installed;
-                }
-                pkg_entry.old_version = inst_ver;
-            } else {
-                // 未安装的包
-                pkg_entry.status = PackageStatus::Avail;
-                pkg_entry.old_version = None;
+                let pkg_entry = SearchEntry {
+                    name: name.to_string(),
+                    description,
+                    status,
+                    provides,
+                    has_dbg,
+                    section_is_base,
+                    old_version,
+                    new_version: entry.version.clone().unwrap_or_default(),
+                };
+                self.index.insert(&name.to_string(), &pkg_entry);
+                self.pkg_map.insert(name.to_string(), pkg_entry);
             }
         }
-
-        // 移除源里已删除的包：`best` 已包含当前源里所有非 `-dbg` 包名，
-        // 无需再扫描一次数据库。
-        self.pkg_map.retain(|name, entry| {
-            if best.contains_key(name) {
-                true
-            } else {
-                self.index.remove(name, entry);
-                false
-            }
-        });
     }
 }
 
@@ -585,6 +583,13 @@ fn is_upgradable(candidate_version: Option<&str>, installed_version: Option<&str
         (Some(_), None) => false, // not installed
         (None, _) => false,       // no candidate available
     }
+}
+
+/// Iterate the package entries from `apt_db`, skipping the `-dbg` debug
+/// symbol packages the search index deliberately omits.
+#[cfg(feature = "search-indicium")]
+fn non_dbg_entries(apt_db: &AptDb) -> impl Iterator<Item = Cow<'_, PackageEntry>> + '_ {
+    apt_db.entries().filter(|e| !e.package.ends_with("-dbg"))
 }
 
 /// Whether `a` is a strictly newer version than `b`.

--- a/oma-apt-pkg/src/search.rs
+++ b/oma-apt-pkg/src/search.rs
@@ -366,10 +366,10 @@ impl IndiciumSearch {
         });
 
         // 第二遍：每个包只处理一次其最高候选版本的 entry，用完即弃。
-        // 同一包在多个源里可能出现“语义相等但字符串不同”的版本
-        // （如 `1.0` 与 `1.0.0`，Debian 版本比较下视为同一版本），
-        // 这些 entry 的版本都 >= best；用 `handled` 保证只取第一个，
+        // 同一包在多个源里可能出现完全相同的版本字符串（如 `1.0` 同时出现在
+        // stable 与某个 topic），它们都 == best；用 `handled` 保证只取第一个，
         // 避免重复计算状态、也避免 `new_version` 被后面的 entry 覆盖成别的字符串。
+        // （注意：`1.0` 与 `1.0.0` 并不是同一版本——dpkg 下 `1.0 < 1.0.0`。）
         let mut handled: HashSet<String> = HashSet::new();
         for entry in non_dbg_entries(apt_db) {
             let Some(best_version) = best.get(&entry.package) else {
@@ -856,6 +856,15 @@ mod tests {
     #[test]
     fn test_is_upgradable_same_version() {
         assert!(!is_upgradable(Some("4.8.1"), Some("4.8.1")));
+    }
+
+    #[test]
+    fn test_is_upgradable_more_trailing_segments() {
+        // dpkg: 1.0 < 1.0.0 (longer trailing version segment is newer)
+        assert!(is_upgradable(Some("1.0.0"), Some("1.0")));
+        assert!(!is_upgradable(Some("1.0"), Some("1.0.0")));
+        assert!(version_gt(Some("1.0.0"), Some("1.0")));
+        assert!(!version_gt(Some("1.0"), Some("1.0.0")));
     }
 
     #[test]

--- a/oma-apt-pkg/src/search.rs
+++ b/oma-apt-pkg/src/search.rs
@@ -3,10 +3,7 @@
 //! Builds a search index from parsed APT list entries and dpkg status,
 //! without depending on the C++ `oma-apt` binding.
 
-#[cfg(feature = "search-indicium")]
-use std::borrow::Cow;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -342,11 +339,36 @@ impl IndiciumSearch {
     /// in the search index (e.g packages added to the software
     /// sources since the search cache was created).
     pub fn refresh_from(&mut self, apt_db: &AptDb, dpkg: &DpkgState) {
+        // 第一遍：只记录每个包的最高候选版本，避免为每个包克隆完整 entry
+        // （含描述、依赖字段）造成缓存命中路径上的峰值内存上升。
+        let mut best: HashMap<String, Option<String>> = HashMap::new();
         for entry in apt_db.entries() {
-            let name = &entry.package;
-            if name.ends_with("-dbg") {
+            if entry.package.ends_with("-dbg") {
                 continue;
             }
+            let replace = best.get(&entry.package).is_none_or(|existing| {
+                version_gt(entry.version.as_deref(), existing.as_deref())
+            });
+
+            if replace {
+                best.insert(entry.package.clone(), entry.version.clone());
+            }
+        }
+
+        // 第二遍：只处理最高版本 entry，用完即弃，不保留完整 entry。
+        for entry in apt_db.entries() {
+            if entry.package.ends_with("-dbg") {
+                continue;
+            }
+            let Some(best_version) = best.get(&entry.package) else {
+                continue;
+            };
+            // 只处理版本不低于最高候选版本的 entry（Debian 版本比较下
+            // 可能多个字符串表示同一版本，如 `1.0` 与 `1.0.0`）。
+            if version_gt(best_version.as_deref(), entry.version.as_deref()) {
+                continue;
+            }
+            let name = entry.package.as_str();
 
             let is_new = !self.pkg_map.contains_key(name);
 
@@ -372,9 +394,9 @@ impl IndiciumSearch {
                     .unwrap_or_else(|| "No description".to_string());
 
                 self.pkg_map.insert(
-                    name.clone(),
+                    name.to_string(),
                     SearchEntry {
-                        name: name.clone(),
+                        name: name.to_string(),
                         description,
                         status: PackageStatus::Avail,
                         provides,
@@ -385,49 +407,38 @@ impl IndiciumSearch {
                     },
                 );
 
-                self.index.insert(name, &self.pkg_map[name]);
+                let key = self.pkg_map.get_key_value(name).map(|(k, _)| k).unwrap();
+                self.index.insert(key, &self.pkg_map[name]);
             }
 
             let pkg_entry = self.pkg_map.get_mut(name).unwrap();
 
+            // 候选版本始终取当前源里的最高版本，避免残留旧源
+            // （如已退出的 topic）的版本号
+            if let Some(ref v) = entry.version {
+                pkg_entry.new_version.clone_from(v);
+            }
+
             // 更新已安装的包的状态
-            if dpkg.installed.contains(name.as_str()) {
-                let inst_ver = dpkg.installed_versions.get(name).cloned();
-                if is_upgradable(
-                    entry.version.as_deref(),
-                    dpkg.installed_versions.get(name).map(String::as_str),
-                ) {
+            let inst_ver = dpkg.installed_versions.get(name).cloned();
+            if dpkg.installed.contains(name) {
+                if is_upgradable(entry.version.as_deref(), inst_ver.as_deref()) {
                     pkg_entry.status = PackageStatus::Upgrade;
-                    pkg_entry.old_version = inst_ver;
-                    if let Some(ref v) = entry.version {
-                        pkg_entry.new_version.clone_from(v);
-                    }
                 } else {
                     pkg_entry.status = PackageStatus::Installed;
-                    pkg_entry.old_version = inst_ver;
                 }
+                pkg_entry.old_version = inst_ver;
             } else {
                 // 未安装的包
                 pkg_entry.status = PackageStatus::Avail;
                 pkg_entry.old_version = None;
-                if let Some(ref v) = entry.version {
-                    pkg_entry.new_version.clone_from(v);
-                }
             }
         }
 
-        // 移除源里已删除的包
-        let current: HashSet<Cow<_>> = apt_db
-            .entries()
-            .filter(|e| !e.package.ends_with("-dbg"))
-            .map(|e| match e {
-                Cow::Borrowed(e) => Cow::Borrowed(&e.package),
-                Cow::Owned(e) => Cow::Owned(e.package),
-            })
-            .collect();
-
+        // 移除源里已删除的包：`best` 已包含当前源里所有非 `-dbg` 包名，
+        // 无需再扫描一次数据库。
         self.pkg_map.retain(|name, entry| {
-            if current.contains(name) {
+            if best.contains_key(name) {
                 true
             } else {
                 self.index.remove(name, entry);
@@ -573,6 +584,24 @@ fn is_upgradable(candidate_version: Option<&str>, installed_version: Option<&str
         }
         (Some(_), None) => false, // not installed
         (None, _) => false,       // no candidate available
+    }
+}
+
+/// Whether `a` is a strictly newer version than `b`.
+/// Uses proper Debian version comparison; falls back to string comparison.
+fn version_gt(a: Option<&str>, b: Option<&str>) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            match (
+                debversion::Version::from_str(a),
+                debversion::Version::from_str(b),
+            ) {
+                (Ok(av), Ok(bv)) => av > bv,
+                _ => a > b,
+            }
+        }
+        (Some(_), None) => true,
+        (None, _) => false,
     }
 }
 

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -914,10 +914,8 @@ mod tests {
 
     #[test]
     fn remove_unused_db_reports_and_removes_stale_files() {
-        let dir = std::env::temp_dir().join(format!(
-            "oma-remove-unused-test-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("oma-remove-unused-test-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         // 需要保留的（仍在 download_list 里）
         std::fs::write(dir.join("stable_Packages"), b"x").unwrap();

--- a/oma-refresh/src/db.rs
+++ b/oma-refresh/src/db.rs
@@ -230,7 +230,11 @@ impl OmaRefresh {
             download_list.insert(i.filename.clone());
         }
 
-        remove_unused_db(&self_arc.download_dir, download_list).ok();
+        // 退出 topic / 移除源时，列表状态的变化可能只是清理掉失效的列表文件
+        // （不涉及任何下载）。记录是否真的删了文件，供下面的 success invoke
+        // 判断使用——否则下游（如 amo 的搜索索引）永远不会得知源集合变了。
+        let removed_unused =
+            remove_unused_db(&self_arc.download_dir, download_list).unwrap_or(false);
 
         let sc2 = self_arc.clone();
         let (tx, rx) = flume::unbounded::<Event>();
@@ -239,8 +243,10 @@ impl OmaRefresh {
                 .await
         })?;
 
-        // 有元数据更新才执行 success invoke
-        let should_run_invoke = res.has_wrote();
+        // 有元数据更新、或清理了失效的列表文件（如退出 topic），
+        // 才执行 success invoke；否则列表状态虽然变了，下游缓存
+        // （如 amo 的搜索索引）却收不到失效通知。
+        let should_run_invoke = res.has_wrote() || removed_unused;
 
         if should_run_invoke {
             callback(Event::RunInvokeScript);
@@ -332,9 +338,14 @@ impl OmaRefresh {
     }
 
     fn run_success_post_invoke(&self, cfg: &AptConfig) {
-        let cmds: Vec<String> = (0..)
-            .map(|i| cfg.get(&format!("APT::Update::Post-Invoke-Success#{i}"), ""))
-            .take_while(|s| !s.is_empty())
+        // 本 crate 的配置解析器把列表项存为 `KEY::{item}`（见
+        // `config_parser::handle_list_value`），不是 apt 的 `KEY#N` 约定，
+        // 因此要像 `sourceslist::ignores` 一样用 `keys_under` + `get(KEY::{k})`
+        // 读取，否则永远取不到任何命令。
+        let cmds: Vec<String> = cfg
+            .keys_under("APT::Update::Post-Invoke-Success")
+            .map(|k| cfg.get(&format!("APT::Update::Post-Invoke-Success::{k}"), ""))
+            .filter(|s| !s.is_empty())
             .collect();
 
         for cmd in &cmds {
@@ -687,7 +698,9 @@ fn get_all_need_db_from_config(
     }
 }
 
-fn remove_unused_db(download_dir: &Path, download_list: HashSet<String>) -> Result<()> {
+/// Remove lists files no longer produced by any configured source (e.g.
+/// after opting out of a topic), returning whether anything was removed.
+fn remove_unused_db(download_dir: &Path, download_list: HashSet<String>) -> Result<bool> {
     let download_dir = std::fs::read_dir(download_dir)
         .map_err(|e| RefreshError::ReadDownloadDir(download_dir.display().to_string(), e))?;
 
@@ -699,6 +712,7 @@ fn remove_unused_db(download_dir: &Path, download_list: HashSet<String>) -> Resu
         }
     }
 
+    let mut removed = false;
     for x in download_dir {
         if let Ok(x) = x
             && x.path().is_file()
@@ -708,11 +722,13 @@ fn remove_unused_db(download_dir: &Path, download_list: HashSet<String>) -> Resu
             debug!("Removing {:?}", x.file_name());
             if let Err(e) = std::fs::remove_file(x.path()) {
                 debug!("Failed to remove file {:?}: {e}", x.file_name());
+            } else {
+                removed = true;
             }
         }
     }
 
-    Ok(())
+    Ok(removed)
 }
 
 fn collect_flat_repo_no_release(
@@ -890,4 +906,39 @@ where
     result_rx
         .recv()
         .map_err(|_| RefreshError::DownloadFailed(None))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remove_unused_db_reports_and_removes_stale_files() {
+        let dir = std::env::temp_dir().join(format!(
+            "oma-remove-unused-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        // 需要保留的（仍在 download_list 里）
+        std::fs::write(dir.join("stable_Packages"), b"x").unwrap();
+        // 需要删除的（不在 download_list 里）
+        std::fs::write(dir.join("core-14-preview_Packages"), b"x").unwrap();
+        // lock 文件永远保留
+        std::fs::write(dir.join("lock"), b"x").unwrap();
+
+        let keep: HashSet<String> = ["stable_Packages".to_string()].into_iter().collect();
+        let removed = remove_unused_db(&dir, keep).unwrap();
+
+        assert!(removed, "should report that stale files were removed");
+        assert!(!dir.join("core-14-preview_Packages").exists());
+        assert!(dir.join("stable_Packages").exists());
+        assert!(dir.join("lock").exists());
+
+        // 再次调用：没有可删的文件了，必须返回 false
+        let keep: HashSet<String> = ["stable_Packages".to_string()].into_iter().collect();
+        let removed_again = remove_unused_db(&dir, keep).unwrap();
+        assert!(!removed_again, "nothing left to remove");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }


### PR DESCRIPTION
## Description

When a package appears in multiple sources (e.g. stable and a topic), `refresh_from` used to update the search entry once per source entry, so the final status depended on traversal order:

- Opening a topic could show a newer version as already installed (the topic entry was visited last and overwrote the status).
- After opting out of a topic, the stale candidate version from the removed source lingered in the index.

The fix picks the highest-version entry per package before updating status, and always syncs `new_version` from the current source so the candidate version never survives a source change.

To keep the cache fast path memory-light, the selection pass only records each package's name and candidate version (`HashMap<String, Option<String>>`) instead of retaining full `PackageEntry` clones (descriptions, dependency fields); the update pass then re-scans entries and processes only the highest-version one, dropping it immediately.

Verified with `cargo test -p oma-apt-pkg --lib search` (9 tests pass).

## About AI

This PR was written in collaboration with Deepseek V4 Flash in a VS Code agent session. I have reviewed and amended the code, tested it thoroughly, and updated the comments.

- Model: Deepseek v4 flash
- Platform: VSCode code agent session

Assisted-by: Deepseek [noreply@deepseek.com](mailto:noreply@deepseek.com)
